### PR TITLE
Add message board preview and API

### DIFF
--- a/src/app/api/message-board/route.ts
+++ b/src/app/api/message-board/route.ts
@@ -1,0 +1,24 @@
+import { NextRequest, NextResponse } from 'next/server';
+import admin from 'firebase-admin';
+import serviceAccount from '../../../../serviceAccountKey.json';
+
+if (!admin.apps.length) {
+  admin.initializeApp({
+    credential: admin.credential.cert(serviceAccount as admin.ServiceAccount),
+  });
+}
+
+const db = admin.firestore();
+
+export async function GET(req: NextRequest) {
+  const limitParam = parseInt(req.nextUrl.searchParams.get('limit') || '10', 10);
+
+  const snapshot = await db
+    .collection('posts')
+    .orderBy('createdAt', 'desc')
+    .limit(limitParam)
+    .get();
+
+  const posts = snapshot.docs.map((doc) => ({ id: doc.id, ...doc.data() }));
+  return NextResponse.json({ posts });
+}

--- a/src/app/message-board/layout.tsx
+++ b/src/app/message-board/layout.tsx
@@ -1,0 +1,3 @@
+export default function MessageBoardLayout({ children }: { children: React.ReactNode }) {
+  return <main className="py-8">{children}</main>;
+}

--- a/src/app/message-board/page.tsx
+++ b/src/app/message-board/page.tsx
@@ -1,0 +1,66 @@
+'use client';
+
+import { useEffect, useState } from 'react';
+import Link from 'next/link';
+import { db } from '@/lib/firebase';
+import { collection, getDocs, query, orderBy, limit } from 'firebase/firestore';
+
+interface Post {
+  id: string;
+  title: string;
+  author: string;
+  excerpt?: string;
+}
+
+export default function MessageBoardPage() {
+  const [posts, setPosts] = useState<Post[] | null>(null);
+
+  useEffect(() => {
+    const load = async () => {
+      try {
+        const q = query(collection(db, 'posts'), orderBy('createdAt', 'desc'), limit(10));
+        const snapshot = await getDocs(q);
+        const items: Post[] = [];
+        snapshot.forEach((doc) => {
+          const data = doc.data() as any;
+          items.push({
+            id: doc.id,
+            title: data.title || '',
+            author: data.author || '',
+            excerpt: data.excerpt || (data.content ? data.content.slice(0, 100) : ''),
+          });
+        });
+        setPosts(items);
+      } catch (err) {
+        console.error('Failed to fetch posts', err);
+        setPosts([]);
+      }
+    };
+    load();
+  }, []);
+
+  if (posts === null) {
+    return <p>Loading posts...</p>;
+  }
+
+  return (
+    <>
+      <h1 className="text-3xl font-bold mb-6">Message Board</h1>
+      {posts.length === 0 ? (
+        <p>No posts yet.</p>
+      ) : (
+        <ul className="space-y-6">
+          {posts.map((post) => (
+            <li key={post.id} className="border-b pb-4">
+              <Link href={`/message-board/${post.id}`} className="text-xl font-semibold text-blue-600 hover:underline">
+                {post.title}
+              </Link>
+              <div className="text-sm text-gray-500">by {post.author}</div>
+              <p className="mt-1 text-gray-700">{post.excerpt}</p>
+            </li>
+          ))}
+        </ul>
+      )}
+    </>
+  );
+}

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -2,6 +2,7 @@
 
 import Image from 'next/image';
 import Link from 'next/link';
+import MessageBoardHighlights from '@/components/MessageBoard/MessageBoardHighlights';
 
 export default function Home() {
   return (
@@ -51,6 +52,15 @@ export default function Home() {
 
       {/* Responsive Image Grid */}
       <div className="max-w-5xl mx-auto grid grid-cols-1 md:grid-cols-2 gap-8 mt-12">
+        <aside className="bg-white dark:bg-neutral-900 rounded-lg shadow p-4 space-y-2">
+          <h2 className="text-xl font-semibold">Message Board</h2>
+          <MessageBoardHighlights limit={3} />
+          <div className="text-right">
+            <Link href="/message-board" className="underline text-sm">
+              View all posts→
+            </Link>
+          </div>
+        </aside>
         {/* Front Image */}
         <div className="overflow-hidden rounded-lg shadow-lg transition-transform duration-300 hover:scale-105">
           <Image

--- a/src/components/MessageBoard/MessageBoardHighlights.tsx
+++ b/src/components/MessageBoard/MessageBoardHighlights.tsx
@@ -1,0 +1,54 @@
+'use client';
+
+import { useEffect, useState } from 'react';
+import Link from 'next/link';
+
+interface Post { id: string; title: string; }
+
+export default function MessageBoardHighlights({ limit = 3 }: { limit?: number }) {
+  const [posts, setPosts] = useState<Post[] | null>(null);
+
+  useEffect(() => {
+    const load = async () => {
+      try {
+        const res = await fetch(`/api/message-board?limit=${limit}`);
+        if (res.ok) {
+          const data = await res.json();
+          setPosts(data.posts || []);
+        } else {
+          setPosts([]);
+        }
+      } catch (err) {
+        console.error('Failed to load posts', err);
+        setPosts([]);
+      }
+    };
+    load();
+  }, [limit]);
+
+  if (posts === null) {
+    return <p>Loading…</p>;
+  }
+
+  if (posts.length === 0) {
+    return (
+      <p>
+        <Link href="/message-board" className="underline">
+          Be the first to post
+        </Link>
+      </p>
+    );
+  }
+
+  return (
+    <ul className="space-y-1 list-disc ml-5">
+      {posts.map((p) => (
+        <li key={p.id}>
+          <Link href={`/message-board/${p.id}`} className="text-blue-600 hover:underline">
+            {p.title}
+          </Link>
+        </li>
+      ))}
+    </ul>
+  );
+}


### PR DESCRIPTION
## Summary
- create `/message-board` route listing the latest posts
- expose `/api/message-board` to serve recent posts
- add `MessageBoardHighlights` component to display a small list
- include a preview box on the home page

## Testing
- `npm run lint` *(fails: `next` not found)*
- `npm run build` *(fails: `next` not found)*

------
https://chatgpt.com/codex/tasks/task_e_686ebc58783c83249c3ee99384726313