### PR TITLE
Update message board page to use PostCard

### DIFF
--- a/src/components/MessageBoard/MessageBoardHighlights.tsx
+++ b/src/components/MessageBoard/MessageBoardHighlights.tsx
@@ -2,8 +2,7 @@
 
 import { useEffect, useState } from 'react';
 import Link from 'next/link';
-
-interface Post { id: string; title: string; }
+import { Post } from './types';
 
 export default function MessageBoardHighlights({ limit = 3 }: { limit?: number }) {
   const [posts, setPosts] = useState<Post[] | null>(null);
@@ -13,7 +12,7 @@ export default function MessageBoardHighlights({ limit = 3 }: { limit?: number }
       try {
         const res = await fetch(`/api/message-board?limit=${limit}`);
         if (res.ok) {
-          const data = await res.json();
+          const data: { posts: Post[] } = await res.json();
           setPosts(data.posts || []);
         } else {
           setPosts([]);

--- a/src/components/MessageBoard/PostCard.tsx
+++ b/src/components/MessageBoard/PostCard.tsx
@@ -1,0 +1,18 @@
+'use client';
+
+import Link from 'next/link';
+import { Post } from './types';
+
+export default function PostCard({ post }: { post: Post }) {
+  return (
+    <article className="border-b pb-4">
+      <h2 className="text-xl font-semibold">
+        <Link href={`/message-board/${post.id}`} className="text-blue-600 hover:underline">
+          {post.title}
+        </Link>
+      </h2>
+      <div className="text-sm text-gray-500">by {post.author}</div>
+      {post.excerpt && <p className="mt-1 text-gray-700">{post.excerpt}</p>}
+    </article>
+  );
+}

--- a/src/components/MessageBoard/types.ts
+++ b/src/components/MessageBoard/types.ts
@@ -1,0 +1,6 @@
+export interface Post {
+  id: string;
+  title: string;
+  author: string;
+  excerpt?: string;
+}


### PR DESCRIPTION
## Summary
- switch message board page to use `/api/message-board`
- add shared `Post` interface
- create a new `PostCard` component for rendering
- update highlights component to use shared types

## Testing
- `npm run lint` *(fails: `next` not found)*
- `npm run build` *(fails: `next` not found)*

------
https://chatgpt.com/codex/tasks/task_e_686ec18ca8fc8324b2fea3072cfde96c