### PR TITLE
Add Owners' Voting section to homepage

### DIFF
--- a/public/icons/vote-dark.svg
+++ b/public/icons/vote-dark.svg
@@ -1,0 +1,4 @@
+<svg width="96" height="96" viewBox="0 0 96 96" fill="none" xmlns="http://www.w3.org/2000/svg">
+  <rect x="17.5" y="17.5" width="61" height="61" rx="10" stroke="#E5E7EB" stroke-width="4"/>
+  <path d="M35 49.5L45.5 60L63 38" stroke="#E5E7EB" stroke-width="4" stroke-linecap="round" stroke-linejoin="round"/>
+</svg>

--- a/public/icons/vote-light.svg
+++ b/public/icons/vote-light.svg
@@ -1,0 +1,4 @@
+<svg width="96" height="96" viewBox="0 0 96 96" fill="none" xmlns="http://www.w3.org/2000/svg">
+  <rect x="17.5" y="17.5" width="61" height="61" rx="10" stroke="#5F7285" stroke-width="4"/>
+  <path d="M35 49.5L45.5 60L63 38" stroke="#5F7285" stroke-width="4" stroke-linecap="round" stroke-linejoin="round"/>
+</svg>

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -273,6 +273,14 @@ export default function Home() {
           darkIcon="/images/icons/info-icon-dark.png"
           blurb="Access, bins & recycling, contacts and local picks (food, shops, coffee)."
         />
+
+        <IconCard
+          title="Owners’ Voting"
+          href="/voting"
+          lightIcon="/icons/vote-light.svg"
+          darkIcon="/icons/vote-dark.svg"
+          blurb="Vote on proposed ideas, building improvements and shared decisions."
+        />
       </section>
 
       {/* PHOTO CAROUSEL */}


### PR DESCRIPTION
## Summary
- add an Owners’ Voting card to the landing page after Useful Info
- supply theme-aware voting icon assets for light and dark modes

## Testing
- npm run lint

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_693ecf1d168c83249d8b0943c9edbe3b)