### PR TITLE
Lazy initialize Resend client for admin emails

### DIFF
--- a/functions/lib/index.js
+++ b/functions/lib/index.js
@@ -18,8 +18,13 @@ const metrics_1 = require("./metrics");
 if (!(0, app_1.getApps)().length) {
     (0, app_1.initializeApp)();
 }
-const resendApiKey = process.env.RESEND_API_KEY ?? (0, firebase_functions_1.config)().resend?.api_key;
-const resendClient = resendApiKey ? new resend_1.Resend(resendApiKey) : null;
+function getResendClient() {
+    const apiKey = process.env.RESEND_API_KEY ?? (0, firebase_functions_1.config)().resend?.api_key;
+    if (!apiKey) {
+        return null;
+    }
+    return new resend_1.Resend(apiKey);
+}
 exports.sendBookingReminders = (0, scheduler_1.onSchedule)({
     schedule: '0 7 * * *',
     timeZone: 'Europe/London',
@@ -52,6 +57,7 @@ exports.sendBookingReminders = (0, scheduler_1.onSchedule)({
             time: data.time ?? 'Unknown time',
         });
     });
+    const resendClient = getResendClient();
     if (!resendClient) {
         firebase_functions_1.logger.warn('Resend API key is not configured; skipping reminder emails.');
         return;

--- a/functions/src/index.ts
+++ b/functions/src/index.ts
@@ -18,8 +18,15 @@ if (!getApps().length) {
   initializeApp();
 }
 
-const resendApiKey = process.env.RESEND_API_KEY ?? config().resend?.api_key;
-const resendClient = resendApiKey ? new Resend(resendApiKey) : null;
+function getResendClient() {
+  const apiKey = process.env.RESEND_API_KEY ?? config().resend?.api_key;
+
+  if (!apiKey) {
+    return null;
+  }
+
+  return new Resend(apiKey);
+}
 
 export const sendBookingReminders = onSchedule(
   {
@@ -60,6 +67,8 @@ export const sendBookingReminders = onSchedule(
         time: data.time ?? 'Unknown time',
       });
     });
+
+    const resendClient = getResendClient();
 
     if (!resendClient) {
       logger.warn('Resend API key is not configured; skipping reminder emails.');

--- a/src/app/api/admin/send-email/route.ts
+++ b/src/app/api/admin/send-email/route.ts
@@ -1,12 +1,14 @@
+export const runtime = 'nodejs';
+
 import React from 'react';
 import { NextRequest, NextResponse } from 'next/server';
-import { Resend } from 'resend';
 import type { DecodedIdToken } from 'firebase-admin/auth';
 import { FieldValue } from 'firebase-admin/firestore';
 
 import AdminBroadcastEmail from '@/lib/emails/AdminBroadcastEmail';
 import { sanitizeHtml } from '@/lib/sanitizeHtml';
 import { adminAuth, adminDb } from '@/lib/firebase-admin';
+import { sendAdminEmail } from '@/lib/email/resend';
 
 const FROM = process.env.EMAIL_FROM || 'James Square <no-reply@example.com>';
 
@@ -63,9 +65,7 @@ export async function POST(req: NextRequest) {
 
     const safeHtml = sanitizeHtml(bodyHtml);
 
-    const resend = new Resend(process.env.RESEND_API_KEY);
-
-    const { data, error } = await resend.emails.send({
+    const { data, error } = await sendAdminEmail({
       from: FROM,
       to,
       subject,

--- a/src/lib/email/resend.ts
+++ b/src/lib/email/resend.ts
@@ -1,0 +1,35 @@
+import type { ReactElement } from 'react';
+import { Resend } from 'resend';
+
+function getResendClient() {
+  const apiKey = process.env.RESEND_API_KEY;
+
+  if (!apiKey) {
+    throw new Error('RESEND_API_KEY is not set');
+  }
+
+  return new Resend(apiKey);
+}
+
+type SendAdminEmailPayload = {
+  from?: string;
+  to: string | string[];
+  subject: string;
+  html?: string;
+  react?: ReactElement;
+};
+
+export async function sendAdminEmail({ from, to, subject, html, react }: SendAdminEmailPayload) {
+  if (!html && !react) {
+    throw new Error('`html` or `react` content is required to send an email');
+  }
+
+  const resend = getResendClient();
+
+  return resend.emails.send({
+    from: from ?? 'James Square <no-reply@james-square.com>',
+    to,
+    subject,
+    ...(react ? { react } : { html }),
+  });
+}


### PR DESCRIPTION
## Summary
- add a server-side Resend helper that lazily instantiates the client
- update the admin email API route to use the helper, enforce node runtime, and keep existing logging
- adjust scheduled reminders to create the Resend client at runtime and rebuild compiled output

## Testing
- npm --prefix functions run build
- npm run lint

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_693f11ac3c44832487cef3571ea8e3df)