### PR TITLE
Mobile facility selector — horizontal layout (Pool, Gym, Sauna)

### DIFF
--- a/src/app/book/page.tsx
+++ b/src/app/book/page.tsx
@@ -1,17 +1,18 @@
 'use client';
 
-import React from 'react';
+import React, { useEffect, useState } from 'react';
 import Image from 'next/image';
 import { ChevronDown } from 'lucide-react';
+import { useRouter, useSearchParams } from 'next/navigation';
 
 import { FacilityCard } from '@/components/FacilityCard';
 import Button from '@/components/ui/Button';
 import GlassCard from '@/components/ui/GlassCard';
 
 const FACILITIES = [
-  { title: 'Pool', href: '/book/schedule?facility=pool', imageSrc: '/images/icons/simple-pool-icon.png' },
-  { title: 'Gym', href: '/book/schedule?facility=gym', imageSrc: '/images/icons/simple-gym-icon.png' },
-  { title: 'Sauna', href: '/book/schedule?facility=sauna', imageSrc: '/images/icons/simple-sauna-icon.png' },
+  { title: 'Pool', slug: 'pool', href: '/book/schedule?facility=pool', imageSrc: '/images/icons/simple-pool-icon.png' },
+  { title: 'Gym', slug: 'gym', href: '/book/schedule?facility=gym', imageSrc: '/images/icons/simple-gym-icon.png' },
+  { title: 'Sauna', slug: 'sauna', href: '/book/schedule?facility=sauna', imageSrc: '/images/icons/simple-sauna-icon.png' },
 ];
 
 const OPENING_TIMES = [
@@ -23,6 +24,22 @@ const OPENING_TIMES = [
 ];
 
 export default function HomePage() {
+  const router = useRouter();
+  const searchParams = useSearchParams();
+  const facilityParam = searchParams?.get('facility')?.toLowerCase() ?? '';
+  const [selectedFacility, setSelectedFacility] = useState(() => {
+    if (facilityParam && FACILITIES.some((facility) => facility.slug === facilityParam)) {
+      return facilityParam;
+    }
+    return FACILITIES[0]?.slug ?? '';
+  });
+
+  useEffect(() => {
+    if (facilityParam && FACILITIES.some((facility) => facility.slug === facilityParam)) {
+      setSelectedFacility(facilityParam);
+    }
+  }, [facilityParam]);
+
   return (
     <main className="max-w-4xl mx-auto py-16 px-6 font-sans bg-white dark:bg-gray-900">
       <div className="flex flex-col items-center text-center gap-3">
@@ -38,7 +55,41 @@ export default function HomePage() {
         </div>
       </div>
 
-      <div className="mt-10 grid grid-cols-1 gap-5 sm:gap-6 md:grid-cols-2 xl:grid-cols-3">
+      <div className="mt-8 flex w-full flex-nowrap gap-3 md:hidden">
+        {FACILITIES.map((facility) => {
+          const isSelected = selectedFacility === facility.slug;
+
+          return (
+            <button
+              key={facility.title}
+              type="button"
+              aria-pressed={isSelected}
+              className={`min-h-[44px] flex-1 whitespace-nowrap rounded-full border-2 px-3 py-2 text-sm font-semibold transition focus:outline-none focus-visible:ring-2 focus-visible:ring-blue-500 focus-visible:ring-offset-2 focus-visible:ring-offset-white dark:focus-visible:ring-offset-gray-900 ${
+                isSelected
+                  ? 'border-slate-300 bg-slate-100 text-slate-900 shadow-sm dark:border-white/40 dark:bg-slate-800 dark:text-white dark:shadow-[0_0_0_1px_rgba(255,255,255,0.2)]'
+                  : 'border-slate-200 bg-transparent text-slate-700 dark:border-white/15 dark:text-white/80'
+              }`}
+              onClick={() => {
+                setSelectedFacility(facility.slug);
+                router.push(facility.href);
+              }}
+            >
+              <span className="flex items-center justify-center gap-2">
+                <Image
+                  src={facility.imageSrc}
+                  alt=""
+                  width={16}
+                  height={16}
+                  className="h-4 w-4 shrink-0 object-contain dark:invert"
+                />
+                {facility.title}
+              </span>
+            </button>
+          );
+        })}
+      </div>
+
+      <div className="mt-10 hidden grid-cols-1 gap-5 sm:gap-6 md:grid md:grid-cols-2 xl:grid-cols-3">
         {FACILITIES.map((facility) => (
           <FacilityCard key={facility.title} {...facility} />
         ))}


### PR DESCRIPTION
### Motivation

- Replace stacked facility cards on narrow screens with a single-row, tappable selector for Pool, Gym and Sauna to improve mobile UX.
- Remove redundant helper text from the mobile selector so facility name alone is shown.
- Ensure the selected facility is clearly indicated in both light and dark themes without changing booking logic or desktop layout.
- Keep desktop/card layout and existing booking/navigation behaviour intact for md+ breakpoints.
- Preserve facility icons in the mobile selector.

### Description

- Updated `src/app/book/page.tsx` to add a mobile-only horizontal selector (three equal buttons in a `flex` row) and preserve the existing card grid for `md+` screens using Tailwind breakpoint utilities (`md:hidden` / `md:grid`).
- Added `slug` to the `FACILITIES` array and introduced `selectedFacility` state with `useRouter` and `useSearchParams` to sync selection with the `facility` query param and navigate using `router.push`.
- Each button is fully tappable with `min-h-[44px]`, `aria-pressed` for accessibility, distinct selected/unselected styles for light/dark (borders + background + optional shadow), and not reliant on color alone.
- Restored facility icons in the mobile selector with compact inline images next to the label.
- No changes were made to booking logic, routing, Firestore queries, or the desktop `FacilityCard` output.

### Testing

- Started the development server with `npm run dev` which reported Next.js ready (server start succeeded).
- Attempted automated visual checks with a Playwright script to capture mobile light/dark screenshots, but the Playwright run could not reach the dev server (connection refused) and therefore failed.
- No unit or integration test suites were executed as part of this change.


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_694ab20d0ae48324b9cfed3e2eca0762)