### PR TITLE
Add advanced insights panels to results cards

### DIFF
--- a/src/app/owners/voting/page.tsx
+++ b/src/app/owners/voting/page.tsx
@@ -12,7 +12,6 @@ import {
   PenSquare,
   Vote as VoteIcon,
 } from "lucide-react";
-import { Bar, BarChart, LabelList, ResponsiveContainer, Tooltip, XAxis } from "recharts";
 
 import { Button } from "@/app/voting/components/ui/Button";
 import { Input } from "@/app/voting/components/ui/Input";
@@ -61,9 +60,7 @@ export default function OwnersVotingPage() {
   const [savingVoteId, setSavingVoteId] = useState<string | null>(null);
   const [voteErrors, setVoteErrors] = useState<Record<string, string | null>>({});
   const [selectedOptions, setSelectedOptions] = useState<Record<string, string>>({});
-  const [expandedInsights, setExpandedInsights] = useState<Record<string, boolean>>({});
-  const [expandedBreakdown, setExpandedBreakdown] = useState<Record<string, boolean>>({});
-  const [prefersReducedMotion, setPrefersReducedMotion] = useState(false);
+  const [expandedMoreInfo, setExpandedMoreInfo] = useState<Record<string, boolean>>({});
   const [authModalOpen, setAuthModalOpen] = useState(false);
 
   // Ask tab state
@@ -219,37 +216,12 @@ export default function OwnersVotingPage() {
     setOptions((prev) => prev.filter((_, i) => i !== index));
   };
 
-  const toggleInsights = (questionId: string) => {
-    setExpandedInsights((prev) => ({ ...prev, [questionId]: !prev[questionId] }));
+  const toggleMoreInfo = (questionId: string) => {
+    setExpandedMoreInfo((prev) => ({
+      ...prev,
+      [questionId]: !prev[questionId],
+    }));
   };
-
-  const toggleBreakdown = (questionId: string) => {
-    setExpandedBreakdown((prev) => ({ ...prev, [questionId]: !(prev[questionId] ?? false) }));
-  };
-
-  useEffect(() => {
-    setExpandedBreakdown((prev) => {
-      let changed = false;
-      const next = { ...prev };
-      questions.forEach((q) => {
-        const hasVotes = (questionVotes[q.id]?.length ?? 0) > 0;
-        if (prev[q.id] === undefined && hasVotes) {
-          next[q.id] = true;
-          changed = true;
-        }
-      });
-      return changed ? next : prev;
-    });
-  }, [questions, questionVotes]);
-
-  useEffect(() => {
-    if (typeof window === "undefined") return;
-    const mediaQuery = window.matchMedia("(prefers-reduced-motion: reduce)");
-    const handleChange = () => setPrefersReducedMotion(mediaQuery.matches);
-    handleChange();
-    mediaQuery.addEventListener("change", handleChange);
-    return () => mediaQuery.removeEventListener("change", handleChange);
-  }, []);
 
   const handleCreateQuestion = async (event: React.FormEvent) => {
     event.preventDefault();
@@ -661,7 +633,6 @@ export default function OwnersVotingPage() {
                   <p className="text-slate-600 dark:text-slate-300">No questions yet.</p>
                 ) : (
                   questionResults.map(({ question, results, totalVotes }) => {
-                    const isExpanded = expandedInsights[question.id] ?? false;
                     return (
                       <div
                         key={question.id}
@@ -676,14 +647,6 @@ export default function OwnersVotingPage() {
                                 <p className="text-slate-700 text-sm dark:text-slate-300">{question.description}</p>
                               )}
                             </div>
-                            <button
-                              type="button"
-                              onClick={() => toggleInsights(question.id)}
-                              aria-expanded={isExpanded}
-                              className="inline-flex items-center gap-2 rounded-full px-4 py-2 text-sm font-semibold text-cyan-800 shadow-[0_10px_30px_rgba(14,165,233,0.25)] bg-gradient-to-r from-white/80 via-white/60 to-white/40 border border-cyan-500/30 hover:from-cyan-50/80 hover:to-indigo-50/60 transition-all backdrop-blur"
-                            >
-                              {isExpanded ? "Hide insights" : "Advanced insights"}
-                            </button>
                           </div>
                           <div className="flex items-center gap-3">
                             <div className="text-right text-sm text-slate-600 dark:text-slate-400">
@@ -707,23 +670,25 @@ export default function OwnersVotingPage() {
                             <ResultRow key={option.id} option={option} count={count} percentage={percentage} />
                           ))}
                         </div>
+                        <button
+                          type="button"
+                          onClick={() => toggleMoreInfo(question.id)}
+                          aria-expanded={expandedMoreInfo[question.id] ?? false}
+                          className="mt-4 text-sm font-medium text-slate-600 hover:text-slate-900 underline-offset-4 hover:underline dark:text-slate-300 dark:hover:text-white"
+                        >
+                          {expandedMoreInfo[question.id] ? "Hide details" : "More info"}
+                        </button>
 
-                        {isExpanded && (
-                          <AdvancedInsightsPanel
-                            questionId={question.id}
-                            results={results}
-                            totalVotes={totalVotes}
-                            prefersReducedMotion={prefersReducedMotion}
-                          />
+                        {expandedMoreInfo[question.id] && (
+                          <>
+                            <div className="mt-4 h-px bg-slate-200 dark:bg-white/10" />
+                            <MoreInfoPanel
+                              question={question}
+                              results={results}
+                              votes={questionVotes[question.id] ?? []}
+                            />
+                          </>
                         )}
-
-                        <MoreInfoBreakdown
-                          questionId={question.id}
-                          votes={questionVotes[question.id] ?? []}
-                          results={results}
-                          expanded={expandedBreakdown[question.id] ?? false}
-                          onToggle={() => toggleBreakdown(question.id)}
-                        />
                       </div>
                     );
                   })
@@ -819,144 +784,6 @@ function TabButton({
   );
 }
 
-function AdvancedInsightsPanel({
-  questionId,
-  results,
-  totalVotes,
-  prefersReducedMotion,
-}: {
-  questionId: string;
-  results: { option: Option; count: number; percentage: number }[];
-  totalVotes: number;
-  prefersReducedMotion: boolean;
-}) {
-  const gradientId = `insight-gradient-${questionId}`;
-    const barData = results.map(({ option, count, percentage }) => ({
-      id: option.id,
-      name: option.label,
-      count,
-      percentage,
-  }));
-
-  return (
-    <div className="relative overflow-hidden rounded-2xl border border-white/20 bg-white/70 p-5 shadow-[0_18px_60px_rgba(7,89,133,0.18)] backdrop-blur-xl dark:bg-white/10 dark:border-white/10">
-      <div className="pointer-events-none absolute inset-0 bg-gradient-to-br from-cyan-500/10 via-indigo-500/5 to-violet-500/10" />
-      <div className="pointer-events-none absolute -top-20 -left-10 h-48 w-48 rounded-full bg-cyan-300/20 blur-3xl" />
-      <div className="pointer-events-none absolute -bottom-24 -right-12 h-56 w-56 rounded-full bg-violet-400/20 blur-3xl" />
-
-      <div className="relative space-y-5">
-        <div className="flex flex-wrap items-center justify-between gap-3">
-          <div>
-            <p className="text-[11px] uppercase tracking-[0.25em] text-cyan-800/80 dark:text-cyan-200/80">Advanced insights</p>
-            <p className="text-base font-semibold text-slate-900 dark:text-white">Deep dive analytics</p>
-          </div>
-          <div className="rounded-full bg-white/70 px-4 py-2 text-xs font-semibold text-slate-700 shadow-sm ring-1 ring-white/60 backdrop-blur-md dark:bg-white/10 dark:text-white/80">
-            Live · {totalVotes} vote{totalVotes === 1 ? "" : "s"}
-          </div>
-        </div>
-
-        <div className="grid gap-5 lg:grid-cols-[minmax(0,1.2fr)_minmax(0,0.8fr)] items-start">
-          <div className="relative overflow-hidden rounded-xl border border-white/40 bg-white/60 p-4 shadow-[0_25px_60px_rgba(8,47,73,0.18)] backdrop-blur-lg transition-transform duration-500 ease-out transform-gpu lg:p-6 dark:bg-white/5 dark:border-white/10">
-            <div className="pointer-events-none absolute inset-0 bg-gradient-to-br from-cyan-200/15 via-transparent to-indigo-300/10" />
-            <div className="relative h-64 sm:h-72 transform-gpu perspective-[1400px]">
-              <ResponsiveContainer width="100%" height="100%">
-                <BarChart data={barData} barSize={32} barGap={8} margin={{ top: 16, right: 12, left: 12, bottom: 10 }}>
-                  <defs>
-                    <linearGradient id={gradientId} x1="0" y1="0" x2="0" y2="1">
-                      <stop offset="5%" stopColor="#67e8f9" stopOpacity={0.95} />
-                      <stop offset="55%" stopColor="#6366f1" stopOpacity={0.9} />
-                      <stop offset="100%" stopColor="#7c3aed" stopOpacity={0.9} />
-                    </linearGradient>
-                  </defs>
-                  <XAxis
-                    dataKey="name"
-                    interval={0}
-                    tickLine={false}
-                    axisLine={false}
-                    height={48}
-                    tickMargin={12}
-                    tick={{ fill: "#0f172a", fontSize: 12 }}
-                    angle={0}
-                  />
-                  <Tooltip
-                    cursor={{ fill: "rgba(59,130,246,0.08)" }}
-                    contentStyle={{
-                      background: "rgba(255,255,255,0.92)",
-                      borderRadius: "14px",
-                      border: "1px solid rgba(255,255,255,0.6)",
-                      boxShadow: "0 20px 60px rgba(15,23,42,0.12)",
-                      backdropFilter: "blur(12px)",
-                    }}
-                    labelStyle={{ color: "#0f172a", fontWeight: 700 }}
-                    itemStyle={{ color: "#312e81", fontWeight: 600 }}
-                  />
-                  <Bar
-                    dataKey="count"
-                    fill={`url(#${gradientId})`}
-                    radius={[12, 12, 18, 18]}
-                    isAnimationActive={!prefersReducedMotion}
-                    animationDuration={900}
-                    animationBegin={120}
-                    className="drop-shadow-[0_25px_40px_rgba(59,130,246,0.35)]"
-                  >
-                    <LabelList
-                      dataKey="count"
-                      content={({ x = 0, y = 0, width = 0, value }) => {
-                        const numericValue = typeof value === "number" ? value : Number(value ?? 0);
-                        const safeX = (typeof x === "number" ? x : Number(x ?? 0)) + (typeof width === "number" ? width : Number(width ?? 0)) / 2;
-                        const safeY = (typeof y === "number" ? y : Number(y ?? 0)) - 10;
-                        return (
-                          <text
-                            x={safeX}
-                            y={safeY}
-                            textAnchor="middle"
-                            className="fill-slate-900 text-[11px] font-semibold dark:fill-white"
-                          >
-                            {numericValue} vote{numericValue === 1 ? "" : "s"}
-                          </text>
-                        );
-                      }}
-                    />
-                  </Bar>
-                </BarChart>
-              </ResponsiveContainer>
-            </div>
-          </div>
-
-          <div className="space-y-3 rounded-xl border border-white/30 bg-white/60 p-4 shadow-inner shadow-cyan-900/5 backdrop-blur-lg dark:bg-white/5 dark:border-white/10">
-            {results.map(({ option, count, percentage }) => (
-              <div
-                key={option.id}
-                className="rounded-lg border border-white/30 bg-white/60 p-3 shadow-[0_10px_25px_rgba(59,130,246,0.12)] transition hover:-translate-y-0.5 hover:shadow-[0_16px_35px_rgba(99,102,241,0.16)] dark:bg-white/5 dark:border-white/10"
-              >
-                <div className="flex items-center justify-between gap-3">
-                  <div className="flex items-center gap-3">
-                    <span className="inline-flex h-2.5 w-2.5 rounded-full bg-gradient-to-br from-cyan-400 to-indigo-500 shadow-[0_0_0_4px_rgba(34,211,238,0.2)]" />
-                    <p className="text-sm font-semibold text-slate-900 dark:text-white">{option.label}</p>
-                  </div>
-                  <div className="text-right text-sm font-semibold text-slate-800 dark:text-white">
-                    {count} vote{count === 1 ? "" : "s"}
-                  </div>
-                </div>
-                <div className="mt-2 flex items-center justify-between text-xs text-slate-600 dark:text-slate-300">
-                  <span className="text-[color:rgba(15,23,42,0.7)] dark:text-white/70">Momentum</span>
-                  <span className="font-semibold text-indigo-600 dark:text-indigo-300">{percentage}%</span>
-                </div>
-                <div className="mt-2 h-1.5 overflow-hidden rounded-full bg-slate-200/70 dark:bg-white/10">
-                  <div
-                    className="h-full w-full rounded-full bg-gradient-to-r from-cyan-400 via-indigo-500 to-violet-500 transition-all duration-700 ease-out"
-                    style={{ width: `${Number.isFinite(percentage) ? percentage : 0}%` }}
-                  />
-                </div>
-              </div>
-            ))}
-          </div>
-        </div>
-      </div>
-    </div>
-  );
-}
-
 function ResultRow({ option, count, percentage }: { option: Option; count: number; percentage: number }) {
   return (
     <div className="space-y-1">
@@ -976,153 +803,65 @@ function ResultRow({ option, count, percentage }: { option: Option; count: numbe
   );
 }
 
-function MoreInfoBreakdown({
-  questionId,
-  votes,
+function MoreInfoPanel({
+  question,
   results,
-  expanded,
-  onToggle,
+  votes,
 }: {
-  questionId: string;
-  votes: VoteDoc[];
+  question: Question;
   results: { option: Option; count: number; percentage: number }[];
-  expanded: boolean;
-  onToggle: () => void;
+  votes: VoteDoc[];
 }) {
-  const flatCounts = votes.reduce<Record<string, number>>((acc, v) => {
-    const label =
-      typeof v.voterFlat === "string" && v.voterFlat.trim().length > 0
-        ? v.voterFlat.trim()
-        : "(flat unspecified)";
-    acc[label] = (acc[label] ?? 0) + 1;
-    return acc;
-  }, {});
+  const uniqueFlats = Array.from(new Set(votes.map((v) => v.voterFlat).filter(Boolean))).sort();
 
-  const flatEntries = Object.entries(flatCounts).sort((a, b) => a[0].localeCompare(b[0]));
-  const turnoutCount = Object.keys(flatCounts).length;
-
-  const perOptionFlats = results.map(({ option }) => {
-    const counts = votes
-      .filter((v) => v.optionId === option.id)
-      .reduce<Record<string, number>>((acc, v) => {
-        const label =
-          typeof v.voterFlat === "string" && v.voterFlat.trim().length > 0
-            ? v.voterFlat.trim()
-            : "(flat unspecified)";
-        acc[label] = (acc[label] ?? 0) + 1;
-        return acc;
-      }, {});
-
-    const entries = Object.entries(counts).sort((a, b) => a[0].localeCompare(b[0]));
-    const flatCount = entries.length;
-
-    return { option, counts: entries, count: flatCount };
-  });
-
-  const lastUpdated = (() => {
-    const timestamps = votes
-      .map((v) => v.createdAt)
-      .filter(Boolean)
-      .map((t) => {
-        if (typeof t === "number") return new Date(t);
-        if (typeof t === "object" && t && typeof (t as { toDate?: () => Date }).toDate === "function") {
-          return (t as { toDate: () => Date }).toDate();
-        }
-        return null;
-      })
-      .filter((d): d is Date => d instanceof Date && !Number.isNaN(d.getTime()))
-      .sort((a, b) => b.getTime() - a.getTime());
-    return timestamps[0] ?? null;
-  })();
+  if (!SHOW_FLATS_IN_BREAKDOWN) {
+    return (
+      <div className="mt-4 space-y-4">
+        <div className="text-sm text-slate-700 dark:text-slate-200">
+          Turnout: <span className="font-semibold">{uniqueFlats.length}</span> flat{uniqueFlats.length === 1 ? "" : "s"}
+        </div>
+        <p className="text-sm text-slate-600 dark:text-slate-300">Flat-level participation is hidden.</p>
+      </div>
+    );
+  }
 
   return (
-    <div className="mt-4">
-      <button
-        type="button"
-        onClick={onToggle}
-        aria-expanded={expanded}
-        className="inline-flex items-center gap-2 rounded-full px-4 py-2 text-sm font-semibold text-slate-800 bg-white/70 border border-black/10 hover:bg-white transition dark:text-white dark:bg-white/10 dark:border-white/15 dark:hover:bg-white/15"
-      >
-        {expanded ? "Hide more info" : "More info"}
-      </button>
+    <div className="mt-4 space-y-4">
+      <div className="text-sm text-slate-700 dark:text-slate-200">
+        Turnout: <span className="font-semibold">{uniqueFlats.length}</span> flat{uniqueFlats.length === 1 ? "" : "s"}
+      </div>
 
-      {expanded && (
-        <div className="mt-4 rounded-2xl border border-black/10 bg-white/70 p-5 space-y-4 backdrop-blur dark:bg-white/10 dark:border-white/10">
-          <div className="flex flex-wrap items-center justify-between gap-3">
-            <div>
-              <p className="text-xs uppercase tracking-[0.2em] text-slate-600 dark:text-slate-300">Detailed breakdown</p>
-              <p className="text-sm text-slate-700 dark:text-slate-200">
-                Turnout: <span className="font-semibold">{turnoutCount}</span> flat{turnoutCount === 1 ? "" : "s"}
-              </p>
+      <div className="space-y-4">
+        {results.map(({ option }) => {
+          const flats = votes
+            .filter((v) => v.optionId === option.id)
+            .map((v) => v.voterFlat)
+            .filter(Boolean)
+            .sort() as string[];
+
+          return (
+            <div key={option.id} className="space-y-2">
+              <div className="flex justify-between text-sm font-medium text-slate-700 dark:text-slate-200">
+                <span>{option.label}</span>
+                <span>{flats.length}</span>
+              </div>
+
+              {flats.length > 0 && (
+                <div className="flex flex-wrap gap-2">
+                  {flats.map((flat) => (
+                    <span
+                      key={`${question.id}-${option.id}-${flat}`}
+                      className="text-xs px-2 py-1 rounded-full bg-slate-100 text-slate-700 dark:bg-white/10 dark:text-white/80"
+                    >
+                      {flat}
+                    </span>
+                  ))}
+                </div>
+              )}
             </div>
-
-            {lastUpdated && (
-              <div className="text-xs text-slate-600 dark:text-slate-300">
-                Last updated:{" "}
-                <span className="font-semibold">
-                  {lastUpdated.toLocaleString(undefined, { day: "2-digit", month: "short", hour: "2-digit", minute: "2-digit" })}
-                </span>
-              </div>
-            )}
-          </div>
-
-          {SHOW_FLATS_IN_BREAKDOWN ? (
-            <>
-              <div className="space-y-2">
-                <p className="text-sm font-semibold text-slate-900 dark:text-white">Flats voted</p>
-                {flatEntries.length === 0 ? (
-                  <p className="text-sm text-slate-600 dark:text-slate-300">No votes recorded yet.</p>
-                ) : (
-                  <div className="flex flex-wrap gap-2">
-                    {flatEntries.map(([flatLabel, count]) => (
-                      <span
-                        key={`${questionId}-flat-${flatLabel}`}
-                        className="rounded-full border border-black/10 bg-white/60 px-3 py-1 text-xs font-semibold text-slate-700 dark:border-white/10 dark:bg-white/5 dark:text-white/80"
-                      >
-                        {flatLabel}
-                        {count > 1 ? ` (${count})` : ""}
-                      </span>
-                    ))}
-                  </div>
-                )}
-              </div>
-
-              <div className="space-y-3">
-                <p className="text-sm font-semibold text-slate-900 dark:text-white">Votes by option</p>
-                {perOptionFlats.map(({ option, counts, count }) => (
-                  <div
-                    key={option.id}
-                    className="rounded-xl border border-black/10 bg-white/60 p-4 space-y-2 dark:border-white/10 dark:bg-white/5"
-                  >
-                    <div className="flex items-center justify-between">
-                      <p className="text-sm font-semibold text-slate-900 dark:text-white">{option.label}</p>
-                      <p className="text-sm font-semibold text-slate-700 dark:text-white/80">{count}</p>
-                    </div>
-
-                    {count === 0 ? (
-                      <p className="text-sm text-slate-600 dark:text-slate-300">No flats selected this option.</p>
-                    ) : (
-                      <div className="flex flex-wrap gap-2">
-                        {counts.map(([flatLabel, flatCount]) => (
-                          <span
-                            key={`${option.id}-${flatLabel}`}
-                            className="rounded-full border border-black/10 bg-white/70 px-3 py-1 text-xs font-semibold text-slate-700 dark:border-white/10 dark:bg-white/10 dark:text-white/80"
-                          >
-                            {flatLabel}
-                            {flatCount > 1 ? ` (${flatCount})` : ""}
-                          </span>
-                        ))}
-                      </div>
-                    )}
-                  </div>
-                ))}
-              </div>
-            </>
-          ) : (
-            <p className="text-sm text-slate-600 dark:text-slate-300">Flat-level participation is hidden.</p>
-          )}
-        </div>
-      )}
+          );
+        })}
+      </div>
     </div>
   );
 }

--- a/src/app/owners/voting/page.tsx
+++ b/src/app/owners/voting/page.tsx
@@ -156,6 +156,7 @@ export default function OwnersVotingPage() {
   useEffect(() => {
     if (questions.length === 0) {
       setVoteCounts({});
+      setQuestionVotes({});
       return;
     }
 
@@ -225,6 +226,21 @@ export default function OwnersVotingPage() {
   const toggleBreakdown = (questionId: string) => {
     setExpandedBreakdown((prev) => ({ ...prev, [questionId]: !(prev[questionId] ?? false) }));
   };
+
+  useEffect(() => {
+    setExpandedBreakdown((prev) => {
+      let changed = false;
+      const next = { ...prev };
+      questions.forEach((q) => {
+        const hasVotes = (questionVotes[q.id]?.length ?? 0) > 0;
+        if (prev[q.id] === undefined && hasVotes) {
+          next[q.id] = true;
+          changed = true;
+        }
+      });
+      return changed ? next : prev;
+    });
+  }, [questions, questionVotes]);
 
   useEffect(() => {
     if (typeof window === "undefined") return;
@@ -815,11 +831,11 @@ function AdvancedInsightsPanel({
   prefersReducedMotion: boolean;
 }) {
   const gradientId = `insight-gradient-${questionId}`;
-  const barData = results.map(({ option, count, percentage }) => ({
-    id: option.id,
-    name: option.label,
-    count,
-    percentage,
+    const barData = results.map(({ option, count, percentage }) => ({
+      id: option.id,
+      name: option.label,
+      count,
+      percentage,
   }));
 
   return (

--- a/src/app/owners/voting/page.tsx
+++ b/src/app/owners/voting/page.tsx
@@ -852,10 +852,12 @@ function AdvancedInsightsPanel({
                       dataKey="count"
                       content={({ x = 0, y = 0, width = 0, value }) => {
                         const numericValue = typeof value === "number" ? value : Number(value ?? 0);
+                        const safeX = (typeof x === "number" ? x : Number(x ?? 0)) + (typeof width === "number" ? width : Number(width ?? 0)) / 2;
+                        const safeY = (typeof y === "number" ? y : Number(y ?? 0)) - 10;
                         return (
                           <text
-                            x={x + width / 2}
-                            y={y - 10}
+                            x={safeX}
+                            y={safeY}
                             textAnchor="middle"
                             className="fill-slate-900 text-[11px] font-semibold dark:fill-white"
                           >

--- a/src/app/owners/voting/page.tsx
+++ b/src/app/owners/voting/page.tsx
@@ -989,8 +989,6 @@ function MoreInfoBreakdown({
   expanded: boolean;
   onToggle: () => void;
 }) {
-  const turnoutCount = votes.length;
-
   const flatCounts = votes.reduce<Record<string, number>>((acc, v) => {
     const label =
       typeof v.voterFlat === "string" && v.voterFlat.trim().length > 0
@@ -1001,6 +999,7 @@ function MoreInfoBreakdown({
   }, {});
 
   const flatEntries = Object.entries(flatCounts).sort((a, b) => a[0].localeCompare(b[0]));
+  const turnoutCount = Object.keys(flatCounts).length;
 
   const perOptionFlats = results.map(({ option }) => {
     const counts = votes
@@ -1015,10 +1014,9 @@ function MoreInfoBreakdown({
       }, {});
 
     const entries = Object.entries(counts).sort((a, b) => a[0].localeCompare(b[0]));
-    const flatLabels = entries.map(([label]) => label);
-    const flatCount = entries.reduce((sum, [, count]) => sum + count, 0);
+    const flatCount = entries.length;
 
-    return { option, flatLabels, counts: entries, count: flatCount };
+    return { option, counts: entries, count: flatCount };
   });
 
   const lastUpdated = (() => {

--- a/src/app/voting/components/Results.tsx
+++ b/src/app/voting/components/Results.tsx
@@ -193,9 +193,9 @@ function MoreInfoPanel({
         enableParallax={false}
       />
 
-      <p className="mt-3 text-xs text-slate-500 dark:text-slate-400">
-        Turnout: {uniqueFlats.length} flat{uniqueFlats.length === 1 ? "" : "s"}
-      </p>
+      <div className="mt-3 text-xs text-slate-500 dark:text-slate-400">
+        Participation: {totalVotes} vote{totalVotes === 1 ? "" : "s"} recorded
+      </div>
     </div>
   );
 }

--- a/src/app/voting/components/Results.tsx
+++ b/src/app/voting/components/Results.tsx
@@ -3,6 +3,7 @@
 import React, { useEffect, useState } from "react";
 import { collection, onSnapshot, query, where } from "firebase/firestore";
 import { PieChart, Pie, Cell, ResponsiveContainer, Tooltip } from "recharts";
+import type { NameType, ValueType, Payload } from "recharts/types/component/DefaultTooltipContent";
 import { db } from "@/lib/firebase";
 import { getQuestions } from "../services/storageService";
 
@@ -114,10 +115,11 @@ export default function Results() {
                       ))}
                     </Pie>
                     <Tooltip
-                      formatter={(v: unknown, n: unknown, p: { payload: { percentage?: number } }) => [
-                        `${v} votes (${p.payload.percentage ?? 0}%)`,
-                        n as string,
-                      ]}
+                      formatter={(v: ValueType, n: NameType, p?: Payload<ValueType, NameType>) => {
+                        const pct = typeof p?.payload?.percentage === "number" ? p.payload.percentage : 0;
+                        const votes = Number(v ?? 0);
+                        return [`${votes} votes (${pct}%)`, String(n ?? "")];
+                      }}
                     />
                   </PieChart>
                 </ResponsiveContainer>

--- a/src/app/voting/components/Results.tsx
+++ b/src/app/voting/components/Results.tsx
@@ -1,413 +1,186 @@
-import React, { useEffect, useState } from 'react';
-import { collection, onSnapshot, query, where } from 'firebase/firestore';
-import { getQuestions } from '../services/storageService';
-import { QuestionStats } from '../types';
-import { PieChart, Pie, Cell, ResponsiveContainer, Tooltip, BarChart, Bar, XAxis, YAxis } from 'recharts';
-import { Loader2 } from 'lucide-react';
-import { db } from '@/lib/firebase';
+"use client";
+
+import React, { useEffect, useState } from "react";
+import { collection, onSnapshot, query, where } from "firebase/firestore";
+import { PieChart, Pie, Cell, ResponsiveContainer, Tooltip } from "recharts";
+import { db } from "@/lib/firebase";
+import { getQuestions } from "../services/storageService";
 
 type VoteDoc = {
   id: string;
   questionId: string;
   optionId: string;
   voterFlat?: string;
-  createdAt?: unknown;
 };
 
-const Results: React.FC = () => {
-  const [stats, setStats] = useState<QuestionStats[]>([]);
-  const [loading, setLoading] = useState(true);
-  const [questionVotes, setQuestionVotes] = useState<Record<string, VoteDoc[]>>({});
+type QuestionOption = {
+  id: string;
+  label: string;
+};
+
+type QuestionRecord = {
+  id: string;
+  title: string;
+  description?: string;
+  createdAt: number;
+  options: QuestionOption[];
+};
+
+type QuestionStat = {
+  question: QuestionRecord;
+  results: { option: QuestionOption; count: number; percentage: number }[];
+  totalVotes: number;
+};
+
+const COLORS = ["#22d3ee", "#6366f1", "#a78bfa", "#06b6d4", "#818cf8"];
+
+export default function Results() {
+  const [stats, setStats] = useState<QuestionStat[]>([]);
+  const [votesByQuestion, setVotesByQuestion] = useState<Record<string, VoteDoc[]>>({});
   const [openQuestionId, setOpenQuestionId] = useState<string | null>(null);
 
-  const toggleMoreInfo = (questionId: string) => {
-    setOpenQuestionId((prev) => (prev === questionId ? null : questionId));
-  };
-
   useEffect(() => {
-    let unsubscribers: Array<() => void> = [];
-    let isMounted = true;
+    let unsubscribers: (() => void)[] = [];
 
-    const fetchData = async () => {
-      setLoading(true);
-      try {
-        const questions = await getQuestions();
-        if (!isMounted) return;
+    const load = async () => {
+      const questions = (await getQuestions()) as QuestionRecord[];
 
-        if (questions.length === 0) {
-          setStats([]);
-          setLoading(false);
-          return;
-        }
+      unsubscribers = questions.map((question) => {
+        const q = query(collection(db, "voting_votes"), where("questionId", "==", question.id));
 
-        unsubscribers = questions.map((question) => {
-          const votesQuery = query(
-            collection(db, 'voting_votes'),
-            where('questionId', '==', question.id),
-          );
+        return onSnapshot(q, (snap) => {
+          const votes: VoteDoc[] = snap.docs.map((d) => {
+            const data = d.data() as Record<string, unknown>;
+            return {
+              id: d.id,
+              questionId: typeof data.questionId === "string" ? data.questionId : question.id,
+              optionId: typeof data.optionId === "string" ? data.optionId : "",
+              voterFlat: typeof data.voterFlat === "string" ? data.voterFlat : undefined,
+            };
+          });
 
-          return onSnapshot(
-            votesQuery,
-            (snapshot) => {
-              console.log('Votes returned:', snapshot.docs.map((d) => d.data()));
+          setVotesByQuestion((prev) => ({
+            ...prev,
+            [question.id]: votes,
+          }));
 
-              const votes: VoteDoc[] = snapshot.docs.map((d) => {
-                const data = d.data() as Record<string, unknown>;
-                return {
-                  id: d.id,
-                  questionId: typeof data.questionId === 'string' ? data.questionId : question.id,
-                  optionId: typeof data.optionId === 'string' ? data.optionId : '',
-                  voterFlat: typeof data.voterFlat === 'string' ? data.voterFlat : undefined,
-                  createdAt: data.createdAt,
-                };
-              });
+          const optionCounts: Record<string, number> = {};
+          votes.forEach((v) => {
+            optionCounts[v.optionId] = (optionCounts[v.optionId] || 0) + 1;
+          });
 
-              setQuestionVotes((prev) => ({ ...prev, [question.id]: votes }));
+          const totalVotes = votes.length;
 
-              const counts = snapshot.docs.reduce<Record<string, number>>((acc, doc) => {
-                const data = doc.data() as Record<string, unknown>;
-                const optionId = typeof data.optionId === 'string' ? data.optionId : null;
-                if (!optionId) return acc;
-                acc[optionId] = (acc[optionId] ?? 0) + 1;
-                return acc;
-              }, {});
+          const results = question.options.map((opt) => {
+            const count = optionCounts[opt.id] || 0;
+            const percentage = totalVotes === 0 ? 0 : Math.round((count / totalVotes) * 100);
+            return { option: opt, count, percentage };
+          });
 
-              const total = Object.values(counts).reduce((sum, count) => sum + count, 0);
-
-              const results = question.options
-                .map((opt) => {
-                  const count = counts[opt.id] ?? 0;
-                  return {
-                    option: opt,
-                    count,
-                    percentage: total === 0 ? 0 : Math.round((count / Math.max(total, 1)) * 100),
-                  };
-                })
-                .sort((a, b) => b.count - a.count);
-
-              setStats((prev) => {
-                const filtered = prev.filter((item) => item.question.id !== question.id);
-                const next = [...filtered, { question, totalVotes: total, results }];
-                next.sort((a, b) => b.question.createdAt - a.question.createdAt);
-                return next;
-              });
-              setLoading(false);
-            },
-            (error) => {
-              console.error(error);
-              setLoading(false);
-            },
-          );
+          setStats((prev) => {
+            const filtered = prev.filter((p) => p.question.id !== question.id);
+            return [...filtered, { question, results, totalVotes }];
+          });
         });
-      } catch (err) {
-        console.error(err);
-        if (isMounted) setLoading(false);
-      }
+      });
     };
 
-    fetchData();
-
-    return () => {
-      isMounted = false;
-      unsubscribers.forEach((unsub) => unsub());
-    };
+    void load();
+    return () => unsubscribers.forEach((u) => u());
   }, []);
 
-  if (loading) {
-    return (
-      <div className="flex justify-center items-center h-full min-h-[400px]">
-        <Loader2 className="w-8 h-8 text-cyan-500 animate-spin" />
-      </div>
-    );
-  }
-
-  const summaryData = stats.map(s => ({
-    name: s.question.title.length > 15 ? s.question.title.substring(0, 15) + '...' : s.question.title,
-    fullTitle: s.question.title,
-    votes: s.totalVotes
-  }));
-
   return (
-    <div className="max-w-2xl mx-auto py-8 px-6 space-y-8">
+    <div className="space-y-6">
+      {stats.map(({ question, results, totalVotes }) => {
+        const chartData = results.map((r) => ({
+          name: r.option.label,
+          value: r.count,
+          percentage: r.percentage,
+        }));
 
-      <div className="text-center mb-6">
-        <h1 className="text-2xl font-bold text-slate-900">Results & Insights</h1>
-        <p className="text-slate-600">Real-time voting analytics.</p>
-      </div>
+        return (
+          <div key={question.id} className="rounded-2xl bg-white border border-slate-200 p-6 space-y-4">
+            <h2 className="text-lg font-semibold">{question.title}</h2>
 
-      {/* Overview Chart */}
-      {stats.length > 0 && stats.some(s => s.totalVotes > 0) && (
-        <div className="
-          p-6 rounded-3xl
-          bg-white
-          border border-slate-200
-          shadow-[0_24px_70px_rgba(15,23,42,0.14)]
-        ">
-           <h3 className="text-xs font-bold text-slate-500 uppercase tracking-widest mb-6">Participation Overview</h3>
-           <div className="h-48 w-full">
-             <ResponsiveContainer width="100%" height="100%">
-               <BarChart data={summaryData}>
-                 <XAxis 
-                   dataKey="name" 
-                   fontSize={11} 
-                   tickLine={false} 
-                   axisLine={false} 
-                   stroke="#94a3b8"
-                   interval={0}
-                 />
-                 <YAxis 
-                   fontSize={11} 
-                   tickLine={false} 
-                   axisLine={false} 
-                   allowDecimals={false} 
-                   stroke="#64748b" 
-                 />
-                 <Tooltip
-                   cursor={{fill: 'rgba(148,163,184,0.15)'}}
-                   contentStyle={{
-                     backgroundColor: '#ffffff',
-                     borderRadius: '12px',
-                     border: '1px solid #e2e8f0',
-                     color: '#0f172a',
-                     boxShadow: '0 18px 40px rgba(15,23,42,0.12)'
-                   }}
-                   itemStyle={{ color: '#0891b2' }}
-                />
-                 <Bar dataKey="votes" radius={[4, 4, 0, 0]}>
-                    {summaryData.map((entry, index) => (
-                      <Cell key={`cell-${index}`} fill="url(#barGradient)" />
-                    ))}
-                 </Bar>
-                 <defs>
-                   <linearGradient id="barGradient" x1="0" y1="0" x2="0" y2="1">
-                     <stop offset="0%" stopColor="#22d3ee" stopOpacity={1}/>
-                     <stop offset="100%" stopColor="#6366f1" stopOpacity={0.8}/>
-                   </linearGradient>
-                 </defs>
-               </BarChart>
-             </ResponsiveContainer>
-           </div>
-        </div>
-      )}
-
-      {/* Individual Question Cards */}
-      <div className="space-y-6">
-        {stats.map((stat) => (
-          <div key={stat.question.id} className="
-            rounded-[28px]
-            bg-white
-            border border-slate-200
-            overflow-hidden
-            shadow-[0_20px_60px_rgba(15,23,42,0.12)] transition-transform hover:-translate-y-1
-          ">
-            <div className="p-6 border-b border-slate-200 bg-slate-50">
-              <h2 className="text-lg font-bold text-slate-900 leading-snug">{stat.question.title}</h2>
-              {stat.question.description && (
-                 <p className="text-slate-600 text-sm mt-2 leading-relaxed">{stat.question.description}</p>
-              )}
-              <div className="mt-4 flex items-center text-xs text-slate-600 font-medium">
-                 <span className="text-cyan-700">{stat.totalVotes}</span> <span className="ml-1 mr-1">votes</span>
-                 <span className="mx-2 text-slate-300">•</span>
-                 <span>{new Date(stat.question.createdAt).toLocaleDateString(undefined, { month: 'short', day: 'numeric' })}</span>
-              </div>
-            </div>
-
-            <div className="p-6 space-y-5">
-                  {stat.totalVotes === 0 ? (
-                    <div className="text-center py-6 text-slate-500 text-sm italic">
-                      No votes recorded yet.
-                    </div>
-                  ) : (
-                <>
-                 {stat.totalVotes === 0 ? (
-                   <div className="text-center py-6 text-slate-500 text-sm italic">
-                     No votes recorded yet.
-                   </div>
-                 ) : (
-                   <DonutResultsChart
-                     data={stat.results.map((res) => ({
-                       name: res.option.label,
-                       value: res.count,
-                       percentage: res.percentage,
-                      }))}
+            {totalVotes === 0 ? (
+              <p className="text-sm text-slate-500">No votes yet</p>
+            ) : (
+              <div className="h-56">
+                <ResponsiveContainer width="100%" height="100%">
+                  <PieChart>
+                    <Pie data={chartData} dataKey="value" innerRadius={50} outerRadius={80} paddingAngle={2}>
+                      {chartData.map((_, i: number) => (
+                        <Cell key={i} fill={COLORS[i % COLORS.length]} />
+                      ))}
+                    </Pie>
+                    <Tooltip
+                      formatter={(v: unknown, n: unknown, p: { payload: { percentage?: number } }) => [
+                        `${v} votes (${p.payload.percentage ?? 0}%)`,
+                        n as string,
+                      ]}
                     />
-                  )}
-
-                  <div className="mt-4">
-                    <button
-                      type="button"
-                      onClick={() => toggleMoreInfo(stat.question.id)}
-                      aria-expanded={openQuestionId === stat.question.id}
-                      className="
-                        text-sm font-medium
-                        text-slate-600
-                        hover:text-slate-900
-                        underline-offset-4 hover:underline
-                        dark:text-slate-300
-                        dark:hover:text-white
-                      "
-                    >
-                      {openQuestionId === stat.question.id ? 'Hide details' : 'More info'}
-                    </button>
-                  </div>
-
-                  {openQuestionId === stat.question.id && (
-                    <div className="mt-4">
-                      <div className="h-px bg-slate-200 dark:bg-white/10 mb-4" />
-
-                      <MoreInfoPanel
-                        question={stat.question}
-                        results={stat.results}
-                        votes={questionVotes[stat.question.id] ?? []}
-                      />
-                    </div>
-                  )}
-                </>
-              )}
-            </div>
-          </div>
-        ))}
-      </div>
-    </div>
-  );
-};
-
-export default Results;
-
-function DonutResultsChart({
-  data,
-}: {
-  data: { name: string; value: number; percentage: number }[];
-}) {
-  const COLORS = ["#22d3ee", "#6366f1", "#a78bfa", "#06b6d4", "#818cf8", "#94a3b8"];
-
-  if (data.length === 0) return null;
-
-  return (
-    <div className="w-full">
-      <div className="h-56">
-        <ResponsiveContainer width="100%" height="100%">
-          <PieChart>
-            <Pie
-              data={data}
-              dataKey="value"
-              cx="50%"
-              cy="52%"
-              innerRadius={52}
-              outerRadius={78}
-              startAngle={90}
-              endAngle={-270}
-              isAnimationActive={false}
-            >
-              {data.map((_, i) => (
-                <Cell key={i} fill="rgba(15,23,42,0.18)" />
-              ))}
-            </Pie>
-
-            <Pie
-              data={data}
-              dataKey="value"
-              cx="50%"
-              cy="48%"
-              innerRadius={52}
-              outerRadius={78}
-              paddingAngle={2}
-              startAngle={90}
-              endAngle={-270}
-              animationDuration={900}
-              animationEasing="ease-out"
-            >
-              {data.map((_, i) => (
-                <Cell key={i} fill={COLORS[i % COLORS.length]} />
-              ))}
-            </Pie>
-
-            <Tooltip
-              cursor={false}
-              contentStyle={{
-                background: "rgba(255,255,255,0.95)",
-                borderRadius: "14px",
-                border: "1px solid rgba(15,23,42,0.1)",
-                boxShadow: "0 20px 60px rgba(15,23,42,0.15)",
-              }}
-              formatter={(value: unknown, name: unknown, props: { payload?: { percentage?: number } }) => {
-                const v = Number(value ?? 0);
-                const pct = props?.payload?.percentage ?? 0;
-                return [`${v} vote${v === 1 ? "" : "s"} • ${pct}%`, name as string];
-              }}
-            />
-          </PieChart>
-        </ResponsiveContainer>
-      </div>
-
-      <div className="mt-4 space-y-2">
-        {data
-          .slice()
-          .sort((a, b) => b.value - a.value)
-          .map((item, i) => (
-            <div key={item.name} className="flex items-center justify-between text-sm">
-              <div className="flex items-center gap-2">
-                <span className="h-2.5 w-2.5 rounded-full" style={{ background: COLORS[i % COLORS.length] }} />
-                <span className="text-slate-700 dark:text-slate-200">{item.name}</span>
+                  </PieChart>
+                </ResponsiveContainer>
               </div>
-              <span className="text-slate-500 dark:text-slate-300">
-                {item.value} • {item.percentage}%
-              </span>
-            </div>
-          ))}
-      </div>
+            )}
+
+            <button
+              type="button"
+              onClick={() => setOpenQuestionId((prev) => (prev === question.id ? null : question.id))}
+              aria-expanded={openQuestionId === question.id}
+              className="text-sm text-blue-600 underline"
+            >
+              {openQuestionId === question.id ? "Hide details" : "More info"}
+            </button>
+
+            {openQuestionId === question.id && (
+              <MoreInfoPanel votes={votesByQuestion[question.id] ?? []} results={results} />
+            )}
+          </div>
+        );
+      })}
     </div>
   );
 }
 
 function MoreInfoPanel({
-  question,
-  results,
   votes,
+  results,
 }: {
-  question: QuestionStats['question'];
-  results: QuestionStats['results'];
   votes: VoteDoc[];
+  results: QuestionStat["results"];
 }) {
-  const uniqueFlats = Array.from(new Set(votes.map((v) => v.voterFlat).filter(Boolean))).sort();
+  const uniqueFlats = Array.from(new Set(votes.map((v) => v.voterFlat).filter(Boolean)));
 
   return (
     <div className="mt-4 space-y-4">
-      <div className="text-sm text-slate-700 dark:text-slate-200">
-        Turnout: <span className="font-semibold">{uniqueFlats.length}</span> flat{uniqueFlats.length === 1 ? "" : "s"}
+      <div className="text-sm">
+        Turnout: <strong>{uniqueFlats.length}</strong> flats
       </div>
 
-      <div className="space-y-4">
-        {results.map(({ option }) => {
-          const flats = votes
-            .filter((v) => v.optionId === option.id)
-            .map((v) => v.voterFlat)
-            .filter(Boolean)
-            .sort() as string[];
+      {results.map(({ option }) => {
+        const flats = votes
+          .filter((v) => v.optionId === option.id)
+          .map((v) => v.voterFlat)
+          .filter(Boolean);
 
-          return (
-            <div key={option.id} className="space-y-2">
-              <div className="flex justify-between text-sm font-medium text-slate-700 dark:text-slate-200">
-                <span>{option.label}</span>
-                <span>{flats.length}</span>
-              </div>
-
-              {flats.length > 0 && (
-                <div className="flex flex-wrap gap-2">
-                  {flats.map((flat) => (
-                    <span
-                      key={`${question.id}-${option.id}-${flat}`}
-                      className="text-xs px-2 py-1 rounded-full bg-slate-100 text-slate-700 dark:bg-white/10 dark:text-white/80"
-                    >
-                      {flat}
-                    </span>
-                  ))}
-                </div>
-              )}
+        return (
+          <div key={option.id} className="space-y-1">
+            <div className="flex justify-between text-sm">
+              <span>{option.label}</span>
+              <span>{flats.length}</span>
             </div>
-          );
-        })}
-      </div>
+
+            <div className="flex flex-wrap gap-2">
+              {flats.map((f) => (
+                <span key={f} className="text-xs px-2 py-1 rounded-full bg-slate-100">
+                  {f}
+                </span>
+              ))}
+            </div>
+          </div>
+        );
+      })}
     </div>
   );
 }

--- a/src/app/voting/components/Results.tsx
+++ b/src/app/voting/components/Results.tsx
@@ -133,7 +133,7 @@ export default function Results() {
               type="button"
               onClick={() => setOpenQuestionId((prev) => (prev === question.id ? null : question.id))}
               aria-expanded={isOpen}
-              className="inline-flex items-center gap-2 rounded-full px-4 py-1.5 text-sm font-medium backdrop-blur-md border transition-all shadow-sm hover:shadow-md active:scale-[0.98] bg-white/60 border-slate-200 text-slate-700 hover:bg-white/80 dark:bg-white/10 dark:border-white/20 dark:text-white dark:hover:bg-white/15"
+              className="inline-flex items-center gap-2 rounded-full px-4 py-2 text-sm font-medium backdrop-blur-md border transition-all shadow-sm hover:shadow-md active:scale-[0.98] bg-white/80 border-slate-200 text-slate-700 hover:bg-white dark:bg-slate-800/70 dark:border-white/15 dark:text-white dark:hover:bg-slate-800"
             >
               <span>{isOpen ? "Hide details" : "More info"}</span>
               <svg
@@ -181,7 +181,7 @@ function MoreInfoPanel({
   const totalVotes = results.reduce((sum, r) => sum + r.count, 0);
 
   return (
-    <div className="mt-4 space-y-3">
+    <div className="mt-4 space-y-3 rounded-2xl border border-slate-200 bg-slate-50 p-4 shadow-sm dark:border-white/10 dark:bg-white/5">
       <h4 className="text-sm font-semibold text-slate-700 dark:text-slate-200">Visual summary</h4>
 
       <Results3DPie

--- a/src/app/voting/components/Results.tsx
+++ b/src/app/voting/components/Results.tsx
@@ -175,6 +175,7 @@ function MoreInfoPanel({
     value: r.count,
     percentage: r.percentage,
   }));
+  const totalVotes = results.reduce((sum, r) => sum + r.count, 0);
 
   return (
     <div className="mt-4 space-y-4">
@@ -184,6 +185,23 @@ function MoreInfoPanel({
 
       <div className="mt-6">
         <Results3DPie data={pieData} theme={theme} />
+      </div>
+
+      <div className="space-y-2">
+        {results.map(({ option, count, percentage }) => (
+          <div
+            key={option.id}
+            className="flex items-center justify-between rounded-xl border border-slate-200 bg-slate-50 px-3 py-2 text-sm dark:border-white/10 dark:bg-white/5"
+          >
+            <div className="flex items-center gap-2">
+              <span className="font-medium text-slate-900 dark:text-white">{option.label}</span>
+              <span className="text-xs text-slate-500 dark:text-slate-300">{percentage}%</span>
+            </div>
+            <div className="text-xs text-slate-600 dark:text-slate-200">
+              {count} / {totalVotes || 0} votes
+            </div>
+          </div>
+        ))}
       </div>
 
       {results.map(({ option }) => {

--- a/src/app/voting/components/Results.tsx
+++ b/src/app/voting/components/Results.tsx
@@ -2,7 +2,7 @@ import React, { useEffect, useState } from 'react';
 import { collection, onSnapshot, query, where } from 'firebase/firestore';
 import { getQuestions } from '../services/storageService';
 import { QuestionStats } from '../types';
-import { BarChart, Bar, XAxis, YAxis, Tooltip, ResponsiveContainer, Cell, LabelList } from 'recharts';
+import { PieChart, Pie, Cell, ResponsiveContainer, Tooltip, BarChart, Bar, XAxis, YAxis } from 'recharts';
 import { Loader2 } from 'lucide-react';
 import { db } from '@/lib/firebase';
 
@@ -17,20 +17,8 @@ type VoteDoc = {
 const Results: React.FC = () => {
   const [stats, setStats] = useState<QuestionStats[]>([]);
   const [loading, setLoading] = useState(true);
-  const [expanded, setExpanded] = useState<Record<string, boolean>>({});
-  const [animateKey, setAnimateKey] = useState<Record<string, number>>({});
   const [questionVotes, setQuestionVotes] = useState<Record<string, VoteDoc[]>>({});
   const [expandedBreakdown, setExpandedBreakdown] = useState<Record<string, boolean>>({});
-
-  const toggleExpanded = (questionId: string) => {
-    setExpanded((prev) => {
-      const nextOpen = !prev[questionId];
-      if (nextOpen) {
-        setAnimateKey((k) => ({ ...k, [questionId]: (k[questionId] ?? 0) + 1 }));
-      }
-      return { ...prev, [questionId]: nextOpen };
-    });
-  };
 
   useEffect(() => {
     let unsubscribers: Array<() => void> = [];
@@ -218,26 +206,6 @@ const Results: React.FC = () => {
                  <span className="mx-2 text-slate-300">•</span>
                  <span>{new Date(stat.question.createdAt).toLocaleDateString(undefined, { month: 'short', day: 'numeric' })}</span>
               </div>
-              <div className="mt-4">
-                <button
-                  type="button"
-                  onClick={() => toggleExpanded(stat.question.id)}
-                  className="
-                    inline-flex items-center gap-2
-                    rounded-full px-4 py-2
-                    text-sm font-semibold
-                    bg-slate-900 text-white
-                    shadow-[0_16px_40px_rgba(2,6,23,0.35)]
-                    hover:shadow-[0_20px_55px_rgba(34,211,238,0.35)]
-                    transition-all
-                    active:scale-[0.99]
-                  "
-                  aria-expanded={!!expanded[stat.question.id]}
-                >
-                  <span className="h-2 w-2 rounded-full bg-cyan-300 shadow-[0_0_18px_rgba(34,211,238,0.9)]" />
-                  {expanded[stat.question.id] ? 'Hide insights' : 'Advanced insights'}
-                </button>
-              </div>
             </div>
 
             <div className="p-6 space-y-5">
@@ -247,30 +215,19 @@ const Results: React.FC = () => {
                 </div>
               ) : (
                 <>
-                  {stat.results.map((res) => (
-                    <div key={res.option.id} className="space-y-2">
-                      {/* Header: Label + Percentage */}
-                      <div className="flex justify-between items-end">
-                        <span className="text-sm font-medium text-slate-700">{res.option.label}</span>
-                        <span className="text-sm font-bold text-slate-900">{res.percentage}%</span>
-                      </div>
-
-                      {/* Visual Bar Background */}
-                      <div className="w-full bg-slate-100 rounded-full h-2.5 overflow-hidden ring-1 ring-slate-200">
-                        {/* Visual Bar Fill */}
-                        <div
-                          className="h-full rounded-full transition-all duration-1000 ease-out relative shadow-[0_10px_25px_rgba(8,145,178,0.25)]"
-                          style={{
-                            width: `${res.percentage}%`,
-                            background: 'linear-gradient(90deg, #6366f1 0%, #06b6d4 100%)'
-                          }}
-                        />
-                      </div>
-                      <div className="text-xs text-slate-500 text-right">
-                        {res.count} vote{res.count !== 1 ? 's' : ''}
-                      </div>
-                    </div>
-                  ))}
+                 {stat.totalVotes === 0 ? (
+                   <div className="text-center py-6 text-slate-500 text-sm italic">
+                     No votes recorded yet.
+                   </div>
+                 ) : (
+                   <DonutResultsChart
+                     data={stat.results.map((res) => ({
+                       name: res.option.label,
+                       value: res.count,
+                       percentage: res.percentage,
+                     }))}
+                   />
+                 )}
 
                   <button
                     onClick={() =>
@@ -279,235 +236,59 @@ const Results: React.FC = () => {
                         [stat.question.id]: !p[stat.question.id],
                       }))
                     }
-                    className="mt-2 inline-flex rounded-full px-4 py-2 text-sm font-semibold bg-slate-900 text-white hover:opacity-90"
+                    className="mt-4 text-sm font-medium text-slate-600 hover:text-slate-900 underline-offset-4 hover:underline dark:text-slate-300 dark:hover:text-white"
                   >
-                    {expandedBreakdown[stat.question.id] ? 'Hide more info' : 'More info'}
+                    {expandedBreakdown[stat.question.id] ? 'Hide details' : 'More info'}
                   </button>
 
                   {expandedBreakdown[stat.question.id] && (
-                    <div className="mt-4 rounded-xl bg-slate-50 p-4 space-y-3">
-                      <p className="text-sm font-semibold">
-                        Turnout:{' '}
-                        {
-                          new Set(
-                            (questionVotes[stat.question.id] ?? [])
-                              .map((v) => v.voterFlat)
-                              .filter(Boolean),
-                          ).size
-                        }{' '}
-                        flats
-                      </p>
+                    <>
+                      <div className="mt-4 h-px bg-slate-200 dark:bg-white/10" />
+                      <div className="mt-4 space-y-4 pl-1">
+                        <p className="text-sm text-slate-700 dark:text-slate-200">
+                          Turnout:{' '}
+                          <span className="font-semibold">
+                            {
+                              new Set(
+                                (questionVotes[stat.question.id] ?? [])
+                                  .map((v) => v.voterFlat)
+                                  .filter(Boolean),
+                              ).size
+                            }
+                          </span>{" "}
+                          flats
+                        </p>
 
-                      {stat.results.map((res) => {
-                        const flats = (questionVotes[stat.question.id] ?? [])
-                          .filter((v) => v.optionId === res.option.id)
-                          .map((v) => v.voterFlat)
-                          .filter(Boolean)
-                          .sort();
+                        {stat.results.map((res) => {
+                          const flats = (questionVotes[stat.question.id] ?? [])
+                            .filter((v) => v.optionId === res.option.id)
+                            .map((v) => v.voterFlat)
+                            .filter(Boolean)
+                            .sort();
 
-                        return (
-                          <div key={res.option.id}>
-                            <div className="font-medium">
-                              {res.option.label} ({flats.length})
-                            </div>
-                            {flats.length > 0 && (
-                              <div className="flex flex-wrap gap-2 mt-1">
-                                {flats.map((f) => (
-                                  <span key={f} className="text-xs px-2 py-1 rounded bg-white border">
-                                    {f}
-                                  </span>
-                                ))}
+                          return (
+                            <div key={res.option.id} className="space-y-2">
+                              <div className="flex justify-between text-sm font-medium text-slate-700 dark:text-slate-200">
+                                <span>{res.option.label}</span>
+                                <span>{flats.length}</span>
                               </div>
-                            )}
-                          </div>
-                        );
-                      })}
-                    </div>
-                  )}
-
-                  {expanded[stat.question.id] && stat.totalVotes > 0 && (
-                    <div className="px-6 pb-6">
-                      <div
-                        className="
-                          relative overflow-hidden rounded-[26px]
-                          border border-slate-200
-                          bg-[radial-gradient(circle_at_20%_0%,rgba(34,211,238,0.18),transparent_45%),radial-gradient(circle_at_90%_30%,rgba(99,102,241,0.18),transparent_45%),linear-gradient(180deg,#0b1220, #070b13)]
-                          shadow-[0_28px_90px_rgba(15,23,42,0.45)]
-                        "
-                      >
-                        {/* Ambient glow lines */}
-                        <div className="pointer-events-none absolute inset-0 opacity-70">
-                          <div className="absolute -top-24 left-10 h-60 w-60 rounded-full bg-cyan-400/20 blur-3xl" />
-                          <div className="absolute -bottom-24 right-6 h-72 w-72 rounded-full bg-indigo-500/20 blur-3xl" />
-                          <div className="absolute inset-0 bg-[linear-gradient(90deg,rgba(148,163,184,0.05)_1px,transparent_1px),linear-gradient(180deg,rgba(148,163,184,0.05)_1px,transparent_1px)] bg-[size:28px_28px]" />
-                        </div>
-
-                        <div className="relative p-6">
-                          <div className="flex items-start justify-between gap-4">
-                            <div>
-                              <h3 className="text-sm font-bold tracking-wide text-white">
-                                Advanced Insights
-                              </h3>
-                              <p className="mt-1 text-xs text-slate-300">
-                                3D breakdown of votes by option
-                              </p>
-                            </div>
-
-                            <div className="rounded-full border border-white/10 bg-white/5 px-3 py-1 text-xs font-semibold text-slate-200 shadow-[inset_0_1px_0_rgba(255,255,255,0.08)]">
-                              Total votes: <span className="text-cyan-200">{stat.totalVotes}</span>
-                            </div>
-                          </div>
-
-                          {/* 3D chart stage */}
-                          <div className="mt-6">
-                            <div
-                              className="
-                                rounded-2xl border border-white/10
-                                bg-white/5
-                                shadow-[inset_0_1px_0_rgba(255,255,255,0.08),0_22px_60px_rgba(0,0,0,0.35)]
-                                p-4
-                                [perspective:1200px]
-                              "
-                            >
-                              <div
-                                className="
-                                  h-64 w-full
-                                  transform-gpu
-                                  [transform:rotateX(10deg)]
-                                "
-                              >
-                                <ResponsiveContainer width="100%" height="100%">
-                                  <BarChart
-                                    key={`${stat.question.id}-${animateKey[stat.question.id] ?? 0}`}
-                                    data={stat.results.map(r => ({
-                                      name: r.option.label,
-                                      votes: r.count,
-                                    }))}
-                                    margin={{ top: 12, right: 12, left: 0, bottom: 12 }}
-                                  >
-                                    <defs>
-                                      <linearGradient id={`front-${stat.question.id}`} x1="0" y1="0" x2="0" y2="1">
-                                        <stop offset="0%" stopColor="#22d3ee" stopOpacity={1} />
-                                        <stop offset="55%" stopColor="#6366f1" stopOpacity={0.95} />
-                                        <stop offset="100%" stopColor="#0ea5e9" stopOpacity={0.75} />
-                                      </linearGradient>
-
-                                      {/* “side face” gradient for faux depth */}
-                                      <linearGradient id={`side-${stat.question.id}`} x1="0" y1="0" x2="1" y2="1">
-                                        <stop offset="0%" stopColor="#0ea5e9" stopOpacity={0.45} />
-                                        <stop offset="100%" stopColor="#312e81" stopOpacity={0.35} />
-                                      </linearGradient>
-                                    </defs>
-
-                                    <XAxis
-                                      dataKey="name"
-                                      tickLine={false}
-                                      axisLine={false}
-                                      stroke="rgba(226,232,240,0.55)"
-                                      fontSize={11}
-                                      interval={0}
-                                      height={42}
-                                      tick={{ fill: 'rgba(226,232,240,0.75)' }}
-                                    />
-                                    <YAxis
-                                      allowDecimals={false}
-                                      tickLine={false}
-                                      axisLine={false}
-                                      stroke="rgba(226,232,240,0.55)"
-                                      fontSize={11}
-                                      tick={{ fill: 'rgba(226,232,240,0.65)' }}
-                                    />
-                                    <Tooltip
-                                      cursor={{ fill: 'rgba(148,163,184,0.10)' }}
-                                      contentStyle={{
-                                        background: 'rgba(2, 6, 23, 0.92)',
-                                        border: '1px solid rgba(148,163,184,0.25)',
-                                        borderRadius: '14px',
-                                        boxShadow: '0 28px 70px rgba(0,0,0,0.45)',
-                                        color: '#fff',
-                                        backdropFilter: 'blur(10px)',
-                                      }}
-                                      itemStyle={{ color: '#67e8f9' }}
-                                      labelStyle={{ color: 'rgba(226,232,240,0.8)' }}
-                                    />
-
-                                    {/* Base bars (front face) */}
-                                    <Bar
-                                      dataKey="votes"
-                                      radius={[10, 10, 6, 6]}
-                                      animationDuration={900}
-                                      animationEasing="ease-out"
+                              {flats.length > 0 && (
+                                <div className="flex flex-wrap gap-2">
+                                  {flats.map((f) => (
+                                    <span
+                                      key={f}
+                                      className="text-xs px-2 py-1 rounded-full bg-slate-100 text-slate-700 dark:bg-white/10 dark:text-white/80"
                                     >
-                                      {stat.results.map((_, i) => (
-                                        <Cell
-                                          key={i}
-                                          fill={`url(#front-${stat.question.id})`}
-                                          style={{
-                                            filter: 'drop-shadow(0 18px 26px rgba(34,211,238,0.25))',
-                                          }}
-                                        />
-                                      ))}
-                                      <LabelList
-                                        dataKey="votes"
-                                        position="top"
-                                        style={{
-                                          fill: 'rgba(255,255,255,0.90)',
-                                          fontSize: 12,
-                                          fontWeight: 700,
-                                          textShadow: '0 10px 18px rgba(0,0,0,0.55)',
-                                        }}
-                                      />
-                                    </Bar>
-
-                                    {/* Faux “depth overlay”: second bar set slightly offset */}
-                                    <Bar
-                                      dataKey="votes"
-                                      radius={[10, 10, 6, 6]}
-                                      animationDuration={900}
-                                      animationEasing="ease-out"
-                                      barSize={18}
-                                    >
-                                      {stat.results.map((_, i) => (
-                                        <Cell
-                                          key={i}
-                                          fill={`url(#side-${stat.question.id})`}
-                                          style={{
-                                            transform: 'translate(6px, -6px)',
-                                            opacity: 0.8,
-                                          }}
-                                        />
-                                      ))}
-                                    </Bar>
-                                  </BarChart>
-                                </ResponsiveContainer>
-                              </div>
-                            </div>
-
-                            {/* Option summary chips */}
-                            <div className="mt-4 flex flex-wrap gap-2">
-                              {stat.results.map(r => (
-                                <div
-                                  key={r.option.id}
-                                  className="
-                                    rounded-full
-                                    border border-white/10
-                                    bg-white/5
-                                    px-3 py-1
-                                    text-xs font-semibold
-                                    text-slate-200
-                                    shadow-[inset_0_1px_0_rgba(255,255,255,0.08)]
-                                  "
-                                >
-                                  <span className="text-cyan-200">{r.count}</span>
-                                  <span className="mx-1 text-slate-400">•</span>
-                                  {r.option.label}
+                                      {f}
+                                    </span>
+                                  ))}
                                 </div>
-                              ))}
+                              )}
                             </div>
-                          </div>
-                        </div>
+                          );
+                        })}
                       </div>
-                    </div>
+                    </>
                   )}
                 </>
               )}
@@ -520,3 +301,89 @@ const Results: React.FC = () => {
 };
 
 export default Results;
+
+function DonutResultsChart({
+  data,
+}: {
+  data: { name: string; value: number; percentage: number }[];
+}) {
+  const COLORS = ["#22d3ee", "#6366f1", "#a78bfa", "#06b6d4", "#818cf8", "#94a3b8"];
+
+  if (data.length === 0) return null;
+
+  return (
+    <div className="w-full">
+      <div className="h-56">
+        <ResponsiveContainer width="100%" height="100%">
+          <PieChart>
+            <Pie
+              data={data}
+              dataKey="value"
+              cx="50%"
+              cy="52%"
+              innerRadius={52}
+              outerRadius={78}
+              startAngle={90}
+              endAngle={-270}
+              isAnimationActive={false}
+            >
+              {data.map((_, i) => (
+                <Cell key={i} fill="rgba(15,23,42,0.18)" />
+              ))}
+            </Pie>
+
+            <Pie
+              data={data}
+              dataKey="value"
+              cx="50%"
+              cy="48%"
+              innerRadius={52}
+              outerRadius={78}
+              paddingAngle={2}
+              startAngle={90}
+              endAngle={-270}
+              animationDuration={900}
+              animationEasing="ease-out"
+            >
+              {data.map((_, i) => (
+                <Cell key={i} fill={COLORS[i % COLORS.length]} />
+              ))}
+            </Pie>
+
+            <Tooltip
+              cursor={false}
+              contentStyle={{
+                background: "rgba(255,255,255,0.95)",
+                borderRadius: "14px",
+                border: "1px solid rgba(15,23,42,0.1)",
+                boxShadow: "0 20px 60px rgba(15,23,42,0.15)",
+              }}
+              formatter={(value: unknown, name: unknown, props: { payload?: { percentage?: number } }) => {
+                const v = Number(value ?? 0);
+                const pct = props?.payload?.percentage ?? 0;
+                return [`${v} vote${v === 1 ? "" : "s"} • ${pct}%`, name as string];
+              }}
+            />
+          </PieChart>
+        </ResponsiveContainer>
+      </div>
+
+      <div className="mt-4 space-y-2">
+        {data
+          .slice()
+          .sort((a, b) => b.value - a.value)
+          .map((item, i) => (
+            <div key={item.name} className="flex items-center justify-between text-sm">
+              <div className="flex items-center gap-2">
+                <span className="h-2.5 w-2.5 rounded-full" style={{ background: COLORS[i % COLORS.length] }} />
+                <span className="text-slate-700 dark:text-slate-200">{item.name}</span>
+              </div>
+              <span className="text-slate-500 dark:text-slate-300">
+                {item.value} • {item.percentage}%
+              </span>
+            </div>
+          ))}
+      </div>
+    </div>
+  );
+}

--- a/src/app/voting/components/Results.tsx
+++ b/src/app/voting/components/Results.tsx
@@ -37,6 +37,7 @@ export default function Results() {
   const [votesByQuestion, setVotesByQuestion] = useState<Record<string, VoteDoc[]>>({});
   const [openQuestionId, setOpenQuestionId] = useState<string | null>(null);
   const [isDarkMode, setIsDarkMode] = useState(false);
+  const [animateIn, setAnimateIn] = useState(false);
 
   useEffect(() => {
     let unsubscribers: (() => void)[] = [];
@@ -97,8 +98,13 @@ export default function Results() {
     return () => observer.disconnect();
   }, []);
 
+  useEffect(() => {
+    const t = setTimeout(() => setAnimateIn(true), 100);
+    return () => clearTimeout(t);
+  }, []);
+
   return (
-    <div className="space-y-6">
+    <div className="space-y-6" style={{ willChange: "transform, opacity" }}>
       {stats.map(({ question, results, totalVotes }) => {
         const isOpen = openQuestionId === question.id;
         return (
@@ -108,7 +114,7 @@ export default function Results() {
           >
             <h2 className="text-xl font-semibold text-slate-900 dark:text-white">{question.title}</h2>
             <div className="space-y-3">
-              {results.map(({ option, count, percentage }) => {
+              {results.map(({ option, count, percentage }, index) => {
                 const pct = Number.isFinite(percentage) ? percentage : 0;
                 const pctLabel = `${pct}%`;
                 return (
@@ -121,8 +127,8 @@ export default function Results() {
                     </div>
                     <div className="h-2 rounded-full bg-slate-200/80 overflow-hidden dark:bg-white/10">
                       <div
-                        className="h-full rounded-full bg-gradient-to-r from-cyan-400 to-indigo-500 transition-all dark:shadow-[0_10px_30px_rgba(34,211,238,0.22)]"
-                        style={{ width: `${pct}%` }}
+                        className="h-full rounded-full bg-gradient-to-r from-cyan-400 to-indigo-500 transition-[width] duration-700 ease-out dark:shadow-[0_10px_30px_rgba(34,211,238,0.22)]"
+                        style={{ width: animateIn ? `${pct}%` : "0%", transitionDelay: `${index * 120}ms` }}
                       />
                     </div>
                   </div>
@@ -152,13 +158,16 @@ export default function Results() {
               </svg>
             </button>
 
-            {isOpen && (
+            <div
+              className={`overflow-hidden transition-all duration-500 ease-out ${isOpen ? "opacity-100 translate-y-0" : "opacity-0 -translate-y-2 pointer-events-none"}`}
+              style={{ maxHeight: isOpen ? "1200px" : "0px" }}
+            >
               <MoreInfoPanel
                 votes={votesByQuestion[question.id] ?? []}
                 results={results}
                 theme={isDarkMode ? "dark" : "light"}
               />
-            )}
+            </div>
           </div>
         );
       })}

--- a/src/app/voting/components/Results.tsx
+++ b/src/app/voting/components/Results.tsx
@@ -102,8 +102,11 @@ export default function Results() {
       {stats.map(({ question, results, totalVotes }) => {
         const isOpen = openQuestionId === question.id;
         return (
-          <div key={question.id} className="rounded-2xl bg-white border border-slate-200 p-6 space-y-4">
-            <h2 className="text-lg font-semibold">{question.title}</h2>
+          <div
+            key={question.id}
+            className="rounded-2xl border p-6 space-y-4 bg-white border-slate-200 shadow-[0_12px_30px_rgba(0,0,0,0.08)] dark:bg-slate-900/60 dark:border-white/10 dark:shadow-[0_18px_60px_rgba(0,0,0,0.55)] backdrop-blur-xl"
+          >
+            <h2 className="text-xl font-semibold text-slate-900 dark:text-white">{question.title}</h2>
             <div className="space-y-3">
               {results.map(({ option, count, percentage }) => {
                 const pct = Number.isFinite(percentage) ? percentage : 0;
@@ -116,9 +119,9 @@ export default function Results() {
                         {count} vote{count === 1 ? "" : "s"} • {pctLabel}
                       </span>
                     </div>
-                    <div className="h-2 rounded-full bg-slate-200 overflow-hidden dark:bg-white/10">
+                    <div className="h-2 rounded-full bg-slate-200/80 overflow-hidden dark:bg-white/10">
                       <div
-                        className="h-full rounded-full bg-gradient-to-r from-cyan-400 to-indigo-500 transition-all"
+                        className="h-full rounded-full bg-gradient-to-r from-cyan-400 to-indigo-500 transition-all dark:shadow-[0_10px_30px_rgba(34,211,238,0.22)]"
                         style={{ width: `${pct}%` }}
                       />
                     </div>
@@ -127,7 +130,7 @@ export default function Results() {
               })}
             </div>
 
-            <div className="text-xs text-slate-500 dark:text-slate-300">Total votes: {totalVotes}</div>
+            <div className="text-sm text-slate-600 dark:text-slate-300">Total votes: {totalVotes}</div>
 
             <button
               type="button"
@@ -181,8 +184,8 @@ function MoreInfoPanel({
   const totalVotes = results.reduce((sum, r) => sum + r.count, 0);
 
   return (
-    <div className="mt-4 space-y-3 rounded-2xl border border-slate-200 bg-slate-50 p-4 shadow-sm dark:border-white/10 dark:bg-white/5">
-      <h4 className="text-sm font-semibold text-slate-700 dark:text-slate-200">Visual summary</h4>
+    <div className="mt-4 space-y-3 rounded-2xl border p-4 sm:p-6 bg-white border-slate-200 shadow-[0_12px_30px_rgba(15,23,42,0.10)] dark:bg-slate-950/40 dark:border-white/10 dark:shadow-[0_18px_70px_rgba(0,0,0,0.55)] backdrop-blur-xl">
+      <h4 className="text-sm font-semibold text-slate-800 dark:text-slate-200">Visual summary</h4>
 
       <Results3DPie
         data={pieData}

--- a/src/app/voting/components/Results.tsx
+++ b/src/app/voting/components/Results.tsx
@@ -2,13 +2,25 @@ import React, { useEffect, useState } from 'react';
 import { collection, onSnapshot, query, where } from 'firebase/firestore';
 import { getQuestions } from '../services/storageService';
 import { QuestionStats } from '../types';
-import { BarChart, Bar, XAxis, YAxis, Tooltip, ResponsiveContainer, Cell } from 'recharts';
+import { BarChart, Bar, XAxis, YAxis, Tooltip, ResponsiveContainer, Cell, LabelList } from 'recharts';
 import { Loader2 } from 'lucide-react';
 import { db } from '@/lib/firebase';
 
 const Results: React.FC = () => {
   const [stats, setStats] = useState<QuestionStats[]>([]);
   const [loading, setLoading] = useState(true);
+  const [expanded, setExpanded] = useState<Record<string, boolean>>({});
+  const [animateKey, setAnimateKey] = useState<Record<string, number>>({});
+
+  const toggleExpanded = (questionId: string) => {
+    setExpanded((prev) => {
+      const nextOpen = !prev[questionId];
+      if (nextOpen) {
+        setAnimateKey((k) => ({ ...k, [questionId]: (k[questionId] ?? 0) + 1 }));
+      }
+      return { ...prev, [questionId]: nextOpen };
+    });
+  };
 
   useEffect(() => {
     let unsubscribers: Array<() => void> = [];
@@ -183,6 +195,26 @@ const Results: React.FC = () => {
                  <span className="mx-2 text-slate-300">•</span>
                  <span>{new Date(stat.question.createdAt).toLocaleDateString(undefined, { month: 'short', day: 'numeric' })}</span>
               </div>
+              <div className="mt-4">
+                <button
+                  type="button"
+                  onClick={() => toggleExpanded(stat.question.id)}
+                  className="
+                    inline-flex items-center gap-2
+                    rounded-full px-4 py-2
+                    text-sm font-semibold
+                    bg-slate-900 text-white
+                    shadow-[0_16px_40px_rgba(2,6,23,0.35)]
+                    hover:shadow-[0_20px_55px_rgba(34,211,238,0.35)]
+                    transition-all
+                    active:scale-[0.99]
+                  "
+                  aria-expanded={!!expanded[stat.question.id]}
+                >
+                  <span className="h-2 w-2 rounded-full bg-cyan-300 shadow-[0_0_18px_rgba(34,211,238,0.9)]" />
+                  {expanded[stat.question.id] ? 'Hide insights' : 'Advanced insights'}
+                </button>
+              </div>
             </div>
 
             <div className="p-6 space-y-5">
@@ -191,30 +223,217 @@ const Results: React.FC = () => {
                   No votes recorded yet.
                 </div>
               ) : (
-                stat.results.map((res) => (
-                  <div key={res.option.id} className="space-y-2">
-                    {/* Header: Label + Percentage */}
-                    <div className="flex justify-between items-end">
-                      <span className="text-sm font-medium text-slate-700">{res.option.label}</span>
-                      <span className="text-sm font-bold text-slate-900">{res.percentage}%</span>
-                    </div>
+                <>
+                  {stat.results.map((res) => (
+                    <div key={res.option.id} className="space-y-2">
+                      {/* Header: Label + Percentage */}
+                      <div className="flex justify-between items-end">
+                        <span className="text-sm font-medium text-slate-700">{res.option.label}</span>
+                        <span className="text-sm font-bold text-slate-900">{res.percentage}%</span>
+                      </div>
 
-                    {/* Visual Bar Background */}
-                    <div className="w-full bg-slate-100 rounded-full h-2.5 overflow-hidden ring-1 ring-slate-200">
-                      {/* Visual Bar Fill */}
+                      {/* Visual Bar Background */}
+                      <div className="w-full bg-slate-100 rounded-full h-2.5 overflow-hidden ring-1 ring-slate-200">
+                        {/* Visual Bar Fill */}
+                        <div
+                          className="h-full rounded-full transition-all duration-1000 ease-out relative shadow-[0_10px_25px_rgba(8,145,178,0.25)]"
+                          style={{
+                            width: `${res.percentage}%`,
+                            background: 'linear-gradient(90deg, #6366f1 0%, #06b6d4 100%)'
+                          }}
+                        />
+                      </div>
+                      <div className="text-xs text-slate-500 text-right">
+                        {res.count} vote{res.count !== 1 ? 's' : ''}
+                      </div>
+                    </div>
+                  ))}
+
+                  {expanded[stat.question.id] && stat.totalVotes > 0 && (
+                    <div className="px-6 pb-6">
                       <div
-                        className="h-full rounded-full transition-all duration-1000 ease-out relative shadow-[0_10px_25px_rgba(8,145,178,0.25)]"
-                        style={{
-                          width: `${res.percentage}%`,
-                          background: 'linear-gradient(90deg, #6366f1 0%, #06b6d4 100%)'
-                        }}
-                      />
+                        className="
+                          relative overflow-hidden rounded-[26px]
+                          border border-slate-200
+                          bg-[radial-gradient(circle_at_20%_0%,rgba(34,211,238,0.18),transparent_45%),radial-gradient(circle_at_90%_30%,rgba(99,102,241,0.18),transparent_45%),linear-gradient(180deg,#0b1220, #070b13)]
+                          shadow-[0_28px_90px_rgba(15,23,42,0.45)]
+                        "
+                      >
+                        {/* Ambient glow lines */}
+                        <div className="pointer-events-none absolute inset-0 opacity-70">
+                          <div className="absolute -top-24 left-10 h-60 w-60 rounded-full bg-cyan-400/20 blur-3xl" />
+                          <div className="absolute -bottom-24 right-6 h-72 w-72 rounded-full bg-indigo-500/20 blur-3xl" />
+                          <div className="absolute inset-0 bg-[linear-gradient(90deg,rgba(148,163,184,0.05)_1px,transparent_1px),linear-gradient(180deg,rgba(148,163,184,0.05)_1px,transparent_1px)] bg-[size:28px_28px]" />
+                        </div>
+
+                        <div className="relative p-6">
+                          <div className="flex items-start justify-between gap-4">
+                            <div>
+                              <h3 className="text-sm font-bold tracking-wide text-white">
+                                Advanced Insights
+                              </h3>
+                              <p className="mt-1 text-xs text-slate-300">
+                                3D breakdown of votes by option
+                              </p>
+                            </div>
+
+                            <div className="rounded-full border border-white/10 bg-white/5 px-3 py-1 text-xs font-semibold text-slate-200 shadow-[inset_0_1px_0_rgba(255,255,255,0.08)]">
+                              Total votes: <span className="text-cyan-200">{stat.totalVotes}</span>
+                            </div>
+                          </div>
+
+                          {/* 3D chart stage */}
+                          <div className="mt-6">
+                            <div
+                              className="
+                                rounded-2xl border border-white/10
+                                bg-white/5
+                                shadow-[inset_0_1px_0_rgba(255,255,255,0.08),0_22px_60px_rgba(0,0,0,0.35)]
+                                p-4
+                                [perspective:1200px]
+                              "
+                            >
+                              <div
+                                className="
+                                  h-64 w-full
+                                  transform-gpu
+                                  [transform:rotateX(10deg)]
+                                "
+                              >
+                                <ResponsiveContainer width="100%" height="100%">
+                                  <BarChart
+                                    key={`${stat.question.id}-${animateKey[stat.question.id] ?? 0}`}
+                                    data={stat.results.map(r => ({
+                                      name: r.option.label,
+                                      votes: r.count,
+                                    }))}
+                                    margin={{ top: 12, right: 12, left: 0, bottom: 12 }}
+                                  >
+                                    <defs>
+                                      <linearGradient id={`front-${stat.question.id}`} x1="0" y1="0" x2="0" y2="1">
+                                        <stop offset="0%" stopColor="#22d3ee" stopOpacity={1} />
+                                        <stop offset="55%" stopColor="#6366f1" stopOpacity={0.95} />
+                                        <stop offset="100%" stopColor="#0ea5e9" stopOpacity={0.75} />
+                                      </linearGradient>
+
+                                      {/* “side face” gradient for faux depth */}
+                                      <linearGradient id={`side-${stat.question.id}`} x1="0" y1="0" x2="1" y2="1">
+                                        <stop offset="0%" stopColor="#0ea5e9" stopOpacity={0.45} />
+                                        <stop offset="100%" stopColor="#312e81" stopOpacity={0.35} />
+                                      </linearGradient>
+                                    </defs>
+
+                                    <XAxis
+                                      dataKey="name"
+                                      tickLine={false}
+                                      axisLine={false}
+                                      stroke="rgba(226,232,240,0.55)"
+                                      fontSize={11}
+                                      interval={0}
+                                      height={42}
+                                      tick={{ fill: 'rgba(226,232,240,0.75)' }}
+                                    />
+                                    <YAxis
+                                      allowDecimals={false}
+                                      tickLine={false}
+                                      axisLine={false}
+                                      stroke="rgba(226,232,240,0.55)"
+                                      fontSize={11}
+                                      tick={{ fill: 'rgba(226,232,240,0.65)' }}
+                                    />
+                                    <Tooltip
+                                      cursor={{ fill: 'rgba(148,163,184,0.10)' }}
+                                      contentStyle={{
+                                        background: 'rgba(2, 6, 23, 0.92)',
+                                        border: '1px solid rgba(148,163,184,0.25)',
+                                        borderRadius: '14px',
+                                        boxShadow: '0 28px 70px rgba(0,0,0,0.45)',
+                                        color: '#fff',
+                                        backdropFilter: 'blur(10px)',
+                                      }}
+                                      itemStyle={{ color: '#67e8f9' }}
+                                      labelStyle={{ color: 'rgba(226,232,240,0.8)' }}
+                                    />
+
+                                    {/* Base bars (front face) */}
+                                    <Bar
+                                      dataKey="votes"
+                                      radius={[10, 10, 6, 6]}
+                                      animationDuration={900}
+                                      animationEasing="ease-out"
+                                    >
+                                      {stat.results.map((_, i) => (
+                                        <Cell
+                                          key={i}
+                                          fill={`url(#front-${stat.question.id})`}
+                                          style={{
+                                            filter: 'drop-shadow(0 18px 26px rgba(34,211,238,0.25))',
+                                          }}
+                                        />
+                                      ))}
+                                      <LabelList
+                                        dataKey="votes"
+                                        position="top"
+                                        style={{
+                                          fill: 'rgba(255,255,255,0.90)',
+                                          fontSize: 12,
+                                          fontWeight: 700,
+                                          textShadow: '0 10px 18px rgba(0,0,0,0.55)',
+                                        }}
+                                      />
+                                    </Bar>
+
+                                    {/* Faux “depth overlay”: second bar set slightly offset */}
+                                    <Bar
+                                      dataKey="votes"
+                                      radius={[10, 10, 6, 6]}
+                                      animationDuration={900}
+                                      animationEasing="ease-out"
+                                      barSize={18}
+                                    >
+                                      {stat.results.map((_, i) => (
+                                        <Cell
+                                          key={i}
+                                          fill={`url(#side-${stat.question.id})`}
+                                          style={{
+                                            transform: 'translate(6px, -6px)',
+                                            opacity: 0.8,
+                                          }}
+                                        />
+                                      ))}
+                                    </Bar>
+                                  </BarChart>
+                                </ResponsiveContainer>
+                              </div>
+                            </div>
+
+                            {/* Option summary chips */}
+                            <div className="mt-4 flex flex-wrap gap-2">
+                              {stat.results.map(r => (
+                                <div
+                                  key={r.option.id}
+                                  className="
+                                    rounded-full
+                                    border border-white/10
+                                    bg-white/5
+                                    px-3 py-1
+                                    text-xs font-semibold
+                                    text-slate-200
+                                    shadow-[inset_0_1px_0_rgba(255,255,255,0.08)]
+                                  "
+                                >
+                                  <span className="text-cyan-200">{r.count}</span>
+                                  <span className="mx-1 text-slate-400">•</span>
+                                  {r.option.label}
+                                </div>
+                              ))}
+                            </div>
+                          </div>
+                        </div>
+                      </div>
                     </div>
-                    <div className="text-xs text-slate-500 text-right">
-                      {res.count} vote{res.count !== 1 ? 's' : ''}
-                    </div>
-                  </div>
-                ))
+                  )}
+                </>
               )}
             </div>
           </div>

--- a/src/app/voting/components/Results.tsx
+++ b/src/app/voting/components/Results.tsx
@@ -18,7 +18,11 @@ const Results: React.FC = () => {
   const [stats, setStats] = useState<QuestionStats[]>([]);
   const [loading, setLoading] = useState(true);
   const [questionVotes, setQuestionVotes] = useState<Record<string, VoteDoc[]>>({});
-  const [expandedMoreInfo, setExpandedMoreInfo] = useState<Record<string, boolean>>({});
+  const [openQuestionId, setOpenQuestionId] = useState<string | null>(null);
+
+  const toggleMoreInfo = (questionId: string) => {
+    setOpenQuestionId((prev) => (prev === questionId ? null : questionId));
+  };
 
   useEffect(() => {
     let unsubscribers: Array<() => void> = [];
@@ -209,11 +213,11 @@ const Results: React.FC = () => {
             </div>
 
             <div className="p-6 space-y-5">
-              {stat.totalVotes === 0 ? (
-                <div className="text-center py-6 text-slate-500 text-sm italic">
-                  No votes recorded yet.
-                </div>
-              ) : (
+                  {stat.totalVotes === 0 ? (
+                    <div className="text-center py-6 text-slate-500 text-sm italic">
+                      No votes recorded yet.
+                    </div>
+                  ) : (
                 <>
                  {stat.totalVotes === 0 ? (
                    <div className="text-center py-6 text-slate-500 text-sm italic">
@@ -225,35 +229,32 @@ const Results: React.FC = () => {
                        name: res.option.label,
                        value: res.count,
                        percentage: res.percentage,
-                     }))}
-                   />
-                 )}
+                      }))}
+                    />
+                  )}
 
-                  <button
-                    type="button"
-                    onClick={() =>
-                      setExpandedMoreInfo((prev) => ({
-                        ...prev,
-                        [stat.question.id]: !prev[stat.question.id],
-                      }))
-                    }
-                    aria-expanded={!!expandedMoreInfo[stat.question.id]}
-                    className="
-                      mt-4
-                      text-sm font-medium
-                      text-slate-600
-                      hover:text-slate-900
-                      underline-offset-4 hover:underline
-                      dark:text-slate-300
-                      dark:hover:text-white
-                    "
-                  >
-                    {expandedMoreInfo[stat.question.id] ? 'Hide details' : 'More info'}
-                  </button>
+                  <div className="mt-4">
+                    <button
+                      type="button"
+                      onClick={() => toggleMoreInfo(stat.question.id)}
+                      aria-expanded={openQuestionId === stat.question.id}
+                      className="
+                        text-sm font-medium
+                        text-slate-600
+                        hover:text-slate-900
+                        underline-offset-4 hover:underline
+                        dark:text-slate-300
+                        dark:hover:text-white
+                      "
+                    >
+                      {openQuestionId === stat.question.id ? 'Hide details' : 'More info'}
+                    </button>
+                  </div>
 
-                  {expandedMoreInfo[stat.question.id] && (
+                  {openQuestionId === stat.question.id && (
                     <div className="mt-4">
                       <div className="h-px bg-slate-200 dark:bg-white/10 mb-4" />
+
                       <MoreInfoPanel
                         question={stat.question}
                         results={stat.results}

--- a/src/app/voting/components/Results.tsx
+++ b/src/app/voting/components/Results.tsx
@@ -181,45 +181,21 @@ function MoreInfoPanel({
   const totalVotes = results.reduce((sum, r) => sum + r.count, 0);
 
   return (
-    <div className="mt-4 rounded-xl border border-slate-200 bg-slate-50 p-4 space-y-4 dark:border-white/10 dark:bg-white/5">
-      <div>
-        <h4 className="text-sm font-semibold text-slate-900 dark:text-white">Result breakdown</h4>
-        <p className="text-xs text-slate-600 dark:text-slate-300">
-          Visual summary of how votes are distributed.
-        </p>
-      </div>
+    <div className="mt-4 space-y-3">
+      <h4 className="text-sm font-semibold text-slate-700 dark:text-slate-200">Visual summary</h4>
 
-      <Results3DPie data={pieData} theme={theme} emphasis="secondary" totalVotes={totalVotes} turnoutFlats={uniqueFlats.length} enableParallax={false} />
+      <Results3DPie
+        data={pieData}
+        theme={theme}
+        emphasis="secondary"
+        totalVotes={totalVotes}
+        turnoutFlats={uniqueFlats.length}
+        enableParallax={false}
+      />
 
-      <div className="text-xs text-slate-600 dark:text-slate-300">
-        Turnout: <strong>{uniqueFlats.length}</strong> flat{uniqueFlats.length === 1 ? "" : "s"}
-      </div>
-
-      {results.map(({ option }) => {
-        const flats = votes
-          .filter((v) => v.optionId === option.id)
-          .map((v) => v.voterFlat)
-          .filter(Boolean);
-
-        if (flats.length === 0) return null;
-
-        return (
-          <div key={option.id} className="space-y-1">
-            <div className="flex justify-between text-sm">
-              <span>{option.label}</span>
-              <span className="text-xs text-slate-500 dark:text-slate-300">{flats.length} flat{flats.length === 1 ? "" : "s"}</span>
-            </div>
-
-            <div className="flex flex-wrap gap-2">
-              {flats.map((f) => (
-                <span key={f} className="text-xs px-2 py-1 rounded-full bg-slate-100 dark:bg-white/10 dark:text-white">
-                  {f}
-                </span>
-              ))}
-            </div>
-          </div>
-        );
-      })}
+      <p className="mt-3 text-xs text-slate-500 dark:text-slate-400">
+        Turnout: {uniqueFlats.length} flat{uniqueFlats.length === 1 ? "" : "s"}
+      </p>
     </div>
   );
 }

--- a/src/app/voting/components/Results.tsx
+++ b/src/app/voting/components/Results.tsx
@@ -100,6 +100,7 @@ export default function Results() {
   return (
     <div className="space-y-6">
       {stats.map(({ question, results, totalVotes }) => {
+        const isOpen = openQuestionId === question.id;
         return (
           <div key={question.id} className="rounded-2xl bg-white border border-slate-200 p-6 space-y-4">
             <h2 className="text-lg font-semibold">{question.title}</h2>
@@ -131,13 +132,24 @@ export default function Results() {
             <button
               type="button"
               onClick={() => setOpenQuestionId((prev) => (prev === question.id ? null : question.id))}
-              aria-expanded={openQuestionId === question.id}
-              className="mt-3 text-sm font-medium text-slate-500 hover:text-slate-900 underline-offset-4 hover:underline dark:text-slate-400 dark:hover:text-white"
+              aria-expanded={isOpen}
+              className="inline-flex items-center gap-2 rounded-full px-4 py-1.5 text-sm font-medium backdrop-blur-md border transition-all shadow-sm hover:shadow-md active:scale-[0.98] bg-white/60 border-slate-200 text-slate-700 hover:bg-white/80 dark:bg-white/10 dark:border-white/20 dark:text-white dark:hover:bg-white/15"
             >
-              {openQuestionId === question.id ? "Hide details" : "More info"}
+              <span>{isOpen ? "Hide details" : "More info"}</span>
+              <svg
+                className={`h-3.5 w-3.5 transition-transform ${isOpen ? "rotate-180" : ""}`}
+                viewBox="0 0 20 20"
+                fill="currentColor"
+              >
+                <path
+                  fillRule="evenodd"
+                  d="M5.23 7.21a.75.75 0 011.06.02L10 11.06l3.71-3.83a.75.75 0 111.08 1.04l-4.25 4.38a.75.75 0 01-1.08 0L5.21 8.27a.75.75 0 01.02-1.06z"
+                  clipRule="evenodd"
+                />
+              </svg>
             </button>
 
-            {openQuestionId === question.id && (
+            {isOpen && (
               <MoreInfoPanel
                 votes={votesByQuestion[question.id] ?? []}
                 results={results}

--- a/src/app/voting/components/Results3DPie.tsx
+++ b/src/app/voting/components/Results3DPie.tsx
@@ -1,6 +1,8 @@
 "use client";
 
-import { PieChart, Pie, Cell, ResponsiveContainer, Tooltip } from "recharts";
+import { PieChart, Pie, Cell, ResponsiveContainer, Tooltip, Sector } from "recharts";
+import type { SectorProps } from "recharts";
+import { useEffect, useState } from "react";
 
 type PieDatum = {
   name: string;
@@ -30,11 +32,22 @@ export default function Results3DPie({
   const isDark = theme === "dark";
   const colors = isDark ? DARK_COLORS : LIGHT_COLORS;
   const isSecondary = emphasis === "secondary";
+  const [activeIndex, setActiveIndex] = useState(-1);
+  const [animateIn, setAnimateIn] = useState(false);
   const resolvedTotal =
     typeof totalVotes === "number" ? totalVotes : data.reduce((sum, item) => sum + item.value, 0);
   const resolvedTurnout = turnoutFlats ?? undefined;
   const centerNumberFill = isDark ? "#67e8f9" : "#0ea5e9";
   const centerLabelFill = isDark ? "rgba(226,232,240,0.75)" : "rgba(100,116,139,0.9)";
+
+  useEffect(() => {
+    const t = setTimeout(() => setAnimateIn(true), 150);
+    return () => clearTimeout(t);
+  }, []);
+
+  const ActiveSlice = (props: SectorProps) => (
+    <Sector {...props} outerRadius={(Number(props.outerRadius) || 0) + 6} />
+  );
 
   return (
     <div
@@ -48,19 +61,24 @@ export default function Results3DPie({
               data={data}
               dataKey="value"
               nameKey="name"
-              innerRadius="68%"
-              outerRadius="88%"
+              innerRadius="66%"
+              outerRadius="86%"
               startAngle={90}
               endAngle={-270}
-              paddingAngle={2}
+              paddingAngle={3}
               cornerRadius={10}
               stroke={isDark ? "rgba(0,0,0,0.4)" : "rgba(255,255,255,0.8)"}
               strokeWidth={2}
               isAnimationActive
               animationDuration={1400}
-              animationBegin={150}
+              animationBegin={300}
+              animationEasing="ease-out"
               label={false}
               labelLine={false}
+              activeShape={ActiveSlice}
+              onMouseEnter={(_, i) => setActiveIndex(i)}
+              onMouseLeave={() => setActiveIndex(-1)}
+              activeIndex={activeIndex}
             >
               {data.map((_, index) => (
                 <Cell
@@ -77,18 +95,24 @@ export default function Results3DPie({
               data={data}
               dataKey="value"
               nameKey="name"
-              innerRadius="64%"
-              outerRadius="84%"
+              innerRadius="62%"
+              outerRadius="80%"
               startAngle={90}
               endAngle={-270}
-              paddingAngle={2}
+              paddingAngle={3}
               cornerRadius={10}
               stroke={isDark ? "rgba(0,0,0,0.4)" : "rgba(255,255,255,0.8)"}
               strokeWidth={2}
               isAnimationActive
               animationDuration={1400}
+              animationBegin={300}
+              animationEasing="ease-out"
               label={false}
               labelLine={false}
+              activeShape={ActiveSlice}
+              onMouseEnter={(_, i) => setActiveIndex(i)}
+              onMouseLeave={() => setActiveIndex(-1)}
+              activeIndex={activeIndex}
             >
               {data.map((_, index) => (
                 <Cell
@@ -122,26 +146,34 @@ export default function Results3DPie({
               }}
             />
 
-            <text
-              x="50%"
-              y="46%"
-              textAnchor="middle"
-              className="font-extrabold"
-              style={{ fontSize: "48px" }}
-              fill={centerNumberFill}
+            <g
+              style={{
+                opacity: animateIn ? 1 : 0,
+                transform: animateIn ? "translateY(0)" : "translateY(6px)",
+                transition: "opacity 600ms ease-out 900ms, transform 600ms ease-out 900ms",
+              }}
             >
-              {resolvedTotal.toLocaleString()}
-            </text>
-            <text
-              x="50%"
-              y="60%"
-              textAnchor="middle"
-              className="font-medium"
-              style={{ fontSize: "14px" }}
-              fill={centerLabelFill}
-            >
-              Total votes
-            </text>
+              <text
+                x="50%"
+                y="46%"
+                textAnchor="middle"
+                className="font-extrabold"
+                style={{ fontSize: "48px" }}
+                fill={centerNumberFill}
+              >
+                {resolvedTotal.toLocaleString()}
+              </text>
+              <text
+                x="50%"
+                y="60%"
+                textAnchor="middle"
+                className="font-medium"
+                style={{ fontSize: "14px" }}
+                fill={centerLabelFill}
+              >
+                Total votes
+              </text>
+            </g>
           </PieChart>
         </ResponsiveContainer>
       </div>

--- a/src/app/voting/components/Results3DPie.tsx
+++ b/src/app/voting/components/Results3DPie.tsx
@@ -25,6 +25,8 @@ export default function Results3DPie({
   data,
   theme = "light",
   emphasis = "secondary",
+  totalVotes,
+  turnoutFlats,
 }: Results3DPieProps) {
   const colors = theme === "dark" ? DARK_COLORS : LIGHT_COLORS;
   const isSecondary = emphasis === "secondary";

--- a/src/app/voting/components/Results3DPie.tsx
+++ b/src/app/voting/components/Results3DPie.tsx
@@ -1,7 +1,7 @@
 "use client";
 
 import { PieChart, Pie, Cell, ResponsiveContainer, Tooltip } from "recharts";
-import type { ValueType, Payload } from "recharts/types/component/DefaultTooltipContent";
+import type { NameType, ValueType, Payload } from "recharts/types/component/DefaultTooltipContent";
 
 type PieDatum = {
   name: string;

--- a/src/app/voting/components/Results3DPie.tsx
+++ b/src/app/voting/components/Results3DPie.tsx
@@ -1,7 +1,6 @@
 "use client";
 
 import { PieChart, Pie, Cell, ResponsiveContainer, Tooltip } from "recharts";
-import type { NameType, ValueType, Payload } from "recharts/types/component/DefaultTooltipContent";
 
 type PieDatum = {
   name: string;
@@ -46,12 +45,12 @@ export default function Results3DPie({
               data={data}
               dataKey="value"
               nameKey="name"
-              innerRadius={isSecondary ? 46 : 52}
-              outerRadius={isSecondary ? 72 : 82}
+              innerRadius="68%"
+              outerRadius="88%"
               startAngle={90}
               endAngle={-270}
-              paddingAngle={3}
-              cornerRadius={8}
+              paddingAngle={2}
+              cornerRadius={10}
               isAnimationActive
               animationDuration={1400}
               animationBegin={150}
@@ -73,12 +72,12 @@ export default function Results3DPie({
               data={data}
               dataKey="value"
               nameKey="name"
-              innerRadius={isSecondary ? 42 : 48}
-              outerRadius={isSecondary ? 68 : 78}
+              innerRadius="64%"
+              outerRadius="84%"
               startAngle={90}
               endAngle={-270}
-              paddingAngle={3}
-              cornerRadius={8}
+              paddingAngle={2}
+              cornerRadius={10}
               isAnimationActive
               animationDuration={1400}
               label={false}
@@ -86,60 +85,51 @@ export default function Results3DPie({
             >
               {data.map((_, index) => (
                 <Cell
-                  key={`slice-${index}`}
-                  fill={colors[index % colors.length]}
-                  style={{
-                    filter: isSecondary
-                      ? "drop-shadow(0 6px 10px rgba(0,0,0,0.18))"
-                      : theme === "dark"
-                        ? "drop-shadow(0 12px 22px rgba(0,0,0,0.35))"
-                        : "drop-shadow(0 12px 22px rgba(0,0,0,0.25))",
-                  }}
-                />
-              ))}
-            </Pie>
+                key={`slice-${index}`}
+                fill={colors[index % colors.length]}
+                style={{
+                  filter: isSecondary
+                    ? "drop-shadow(0 6px 10px rgba(0,0,0,0.15))"
+                    : "drop-shadow(0 6px 10px rgba(0,0,0,0.15))",
+                }}
+              />
+            ))}
+          </Pie>
 
             <Tooltip
-              formatter={(value: ValueType, name: NameType, props?: Payload<ValueType, NameType>) => {
-                const votes = Number(value ?? 0);
-                const pct =
-                  typeof props?.payload?.percentage === "number" ? props.payload.percentage : 0;
-                return [`${votes} votes (${pct}%)`, String(name ?? "")];
-              }}
-              contentStyle={{
-                background: theme === "dark" ? "rgba(2,6,23,0.95)" : "rgba(255,255,255,0.95)",
-                borderRadius: "12px",
-                border: "none",
-                boxShadow:
-                  theme === "dark"
-                    ? "0 20px 60px rgba(0,0,0,0.7)"
-                    : "0 20px 60px rgba(15,23,42,0.25)",
-                color: theme === "dark" ? "#e5e7eb" : "#0f172a",
-              }}
-              itemStyle={{
-                color: theme === "dark" ? "#67e8f9" : "#0ea5e9",
-                fontWeight: 600,
-              }}
-              labelStyle={{
-                color: theme === "dark" ? "#cbd5f5" : "#334155",
+              content={({ active, payload }) => {
+                if (!active || !payload?.length) return null;
+                const { name, value, percentage } = payload[0].payload as {
+                  name: string;
+                  value: number;
+                  percentage: number;
+                };
+                return (
+                  <div className="rounded-xl bg-white/90 backdrop-blur-md px-4 py-2 shadow-lg border border-slate-200 text-sm dark:bg-slate-900/90 dark:border-white/10">
+                    <div className="font-semibold text-slate-900 dark:text-white">{name}</div>
+                    <div className="text-slate-600 dark:text-slate-300">
+                      {value} votes • {percentage}%
+                    </div>
+                  </div>
+                );
               }}
             />
 
             <text
               x="50%"
-              y="48%"
+              y="46%"
               textAnchor="middle"
               className="fill-slate-900 dark:fill-white font-extrabold"
-              style={{ fontSize: "3rem" }}
+              style={{ fontSize: "48px" }}
             >
               {resolvedTotal.toLocaleString()}
             </text>
             <text
               x="50%"
-              y="62%"
+              y="60%"
               textAnchor="middle"
-              className="fill-slate-500 dark:fill-slate-300 font-medium"
-              style={{ fontSize: "1rem" }}
+              className="fill-slate-500 dark:fill-slate-400 font-medium"
+              style={{ fontSize: "14px" }}
             >
               Total votes
             </text>
@@ -147,9 +137,9 @@ export default function Results3DPie({
         </ResponsiveContainer>
       </div>
 
-      <div className="my-3 h-px bg-slate-200 dark:bg-white/10" />
+      <div className="my-3 h-px bg-slate-200/60 dark:bg-white/10" />
 
-      <div className="mt-4 space-y-2">
+      <div className="mt-4 space-y-1.5">
         {data.map((item, index) => (
           <div key={item.name} className="flex items-center justify-between gap-3 text-sm">
             <div className="flex items-center gap-2 min-w-0">

--- a/src/app/voting/components/Results3DPie.tsx
+++ b/src/app/voting/components/Results3DPie.tsx
@@ -27,7 +27,8 @@ export default function Results3DPie({
   totalVotes,
   turnoutFlats,
 }: Results3DPieProps) {
-  const colors = theme === "dark" ? DARK_COLORS : LIGHT_COLORS;
+  const isDark = theme === "dark";
+  const colors = isDark ? DARK_COLORS : LIGHT_COLORS;
   const isSecondary = emphasis === "secondary";
   const resolvedTotal =
     typeof totalVotes === "number" ? totalVotes : data.reduce((sum, item) => sum + item.value, 0);
@@ -35,10 +36,10 @@ export default function Results3DPie({
 
   return (
     <div
-      className="rounded-2xl p-5 bg-white/70 backdrop-blur-xl border border-slate-200 shadow-xl dark:bg-slate-900/60 dark:border-white/10 dark:shadow-[0_20px_60px_rgba(0,0,0,0.6)]"
+      className="rounded-2xl p-5 bg-white/70 backdrop-blur-xl border border-slate-200/60 shadow-lg dark:bg-slate-900/70 dark:border-white/10 dark:shadow-2xl"
       aria-label={`Vote distribution donut${resolvedTurnout ? `, ${resolvedTurnout} flats` : ""}`}
     >
-      <div className="relative h-64 w-full">
+      <div className="relative h-64 w-full dark:drop-shadow-[0_10px_30px_rgba(0,0,0,0.6)] dark:filter dark:brightness-110">
         <ResponsiveContainer width="100%" height="100%">
           <PieChart>
             <Pie
@@ -51,6 +52,8 @@ export default function Results3DPie({
               endAngle={-270}
               paddingAngle={2}
               cornerRadius={10}
+              stroke={isDark ? "rgba(0,0,0,0.4)" : "rgba(255,255,255,0.8)"}
+              strokeWidth={2}
               isAnimationActive
               animationDuration={1400}
               animationBegin={150}
@@ -78,6 +81,8 @@ export default function Results3DPie({
               endAngle={-270}
               paddingAngle={2}
               cornerRadius={10}
+              stroke={isDark ? "rgba(0,0,0,0.4)" : "rgba(255,255,255,0.8)"}
+              strokeWidth={2}
               isAnimationActive
               animationDuration={1400}
               label={false}

--- a/src/app/voting/components/Results3DPie.tsx
+++ b/src/app/voting/components/Results3DPie.tsx
@@ -12,13 +12,22 @@ type PieDatum = {
 type Results3DPieProps = {
   data: PieDatum[];
   theme?: "light" | "dark";
+  emphasis?: "primary" | "secondary";
+  totalVotes?: number;
+  turnoutFlats?: number;
+  enableParallax?: boolean;
 };
 
 const LIGHT_COLORS = ["#22d3ee", "#6366f1", "#a78bfa", "#06b6d4", "#818cf8"];
 const DARK_COLORS = ["#67e8f9", "#818cf8", "#c4b5fd", "#22d3ee", "#a5b4fc"];
 
-export default function Results3DPie({ data, theme = "light" }: Results3DPieProps) {
+export default function Results3DPie({
+  data,
+  theme = "light",
+  emphasis = "secondary",
+}: Results3DPieProps) {
   const colors = theme === "dark" ? DARK_COLORS : LIGHT_COLORS;
+  const isSecondary = emphasis === "secondary";
 
   return (
     <div className="relative h-64 w-full">
@@ -27,8 +36,8 @@ export default function Results3DPie({ data, theme = "light" }: Results3DPieProp
           <Pie
             data={data}
             dataKey="value"
-            innerRadius={52}
-            outerRadius={82}
+            innerRadius={isSecondary ? 46 : 52}
+            outerRadius={isSecondary ? 72 : 82}
             startAngle={90}
             endAngle={-270}
             paddingAngle={1}
@@ -50,8 +59,8 @@ export default function Results3DPie({ data, theme = "light" }: Results3DPieProp
           <Pie
             data={data}
             dataKey="value"
-            innerRadius={48}
-            outerRadius={78}
+            innerRadius={isSecondary ? 42 : 48}
+            outerRadius={isSecondary ? 68 : 78}
             startAngle={90}
             endAngle={-270}
             paddingAngle={2}
@@ -63,10 +72,11 @@ export default function Results3DPie({ data, theme = "light" }: Results3DPieProp
                 key={`slice-${index}`}
                 fill={colors[index % colors.length]}
                 style={{
-                  filter:
-                    theme === "dark"
-                      ? "drop-shadow(0 12px 22px rgba(0,0,0,0.55))"
-                      : "drop-shadow(0 10px 18px rgba(0,0,0,0.25))",
+                  filter: isSecondary
+                    ? "drop-shadow(0 6px 10px rgba(0,0,0,0.18))"
+                    : theme === "dark"
+                      ? "drop-shadow(0 12px 22px rgba(0,0,0,0.35))"
+                      : "drop-shadow(0 12px 22px rgba(0,0,0,0.25))",
                 }}
               />
             ))}

--- a/src/app/voting/components/Results3DPie.tsx
+++ b/src/app/voting/components/Results3DPie.tsx
@@ -1,0 +1,104 @@
+"use client";
+
+import { PieChart, Pie, Cell, ResponsiveContainer, Tooltip } from "recharts";
+import type { NameType, ValueType, Payload } from "recharts/types/component/DefaultTooltipContent";
+
+type PieDatum = {
+  name: string;
+  value: number;
+  percentage: number;
+};
+
+type Results3DPieProps = {
+  data: PieDatum[];
+  theme?: "light" | "dark";
+};
+
+const LIGHT_COLORS = ["#22d3ee", "#6366f1", "#a78bfa", "#06b6d4", "#818cf8"];
+const DARK_COLORS = ["#67e8f9", "#818cf8", "#c4b5fd", "#22d3ee", "#a5b4fc"];
+
+export default function Results3DPie({ data, theme = "light" }: Results3DPieProps) {
+  const colors = theme === "dark" ? DARK_COLORS : LIGHT_COLORS;
+
+  return (
+    <div className="relative h-64 w-full">
+      <ResponsiveContainer width="100%" height="100%">
+        <PieChart>
+          <Pie
+            data={data}
+            dataKey="value"
+            innerRadius={52}
+            outerRadius={82}
+            startAngle={90}
+            endAngle={-270}
+            paddingAngle={1}
+            isAnimationActive
+            animationDuration={900}
+            animationBegin={150}
+          >
+            {data.map((_, index) => (
+              <Cell
+                key={`shadow-${index}`}
+                fill={theme === "dark" ? "rgba(0,0,0,0.45)" : "rgba(0,0,0,0.18)"}
+                style={{
+                  transform: "translate(3px, 6px)",
+                }}
+              />
+            ))}
+          </Pie>
+
+          <Pie
+            data={data}
+            dataKey="value"
+            innerRadius={48}
+            outerRadius={78}
+            startAngle={90}
+            endAngle={-270}
+            paddingAngle={2}
+            isAnimationActive
+            animationDuration={900}
+          >
+            {data.map((_, index) => (
+              <Cell
+                key={`slice-${index}`}
+                fill={colors[index % colors.length]}
+                style={{
+                  filter:
+                    theme === "dark"
+                      ? "drop-shadow(0 12px 22px rgba(0,0,0,0.55))"
+                      : "drop-shadow(0 10px 18px rgba(0,0,0,0.25))",
+                }}
+              />
+            ))}
+          </Pie>
+
+          <Tooltip
+            formatter={(value: ValueType, name: NameType, props?: Payload<ValueType, NameType>) => {
+              const votes = Number(value ?? 0);
+              const pct =
+                typeof props?.payload?.percentage === "number" ? props.payload.percentage : 0;
+              return [`${votes} votes (${pct}%)`, String(name ?? "")];
+            }}
+            contentStyle={{
+              background: theme === "dark" ? "rgba(2,6,23,0.95)" : "rgba(255,255,255,0.95)",
+              borderRadius: "12px",
+              border: "none",
+              boxShadow:
+                theme === "dark"
+                  ? "0 20px 60px rgba(0,0,0,0.7)"
+                  : "0 20px 60px rgba(15,23,42,0.25)",
+              color: theme === "dark" ? "#e5e7eb" : "#0f172a",
+            }}
+            itemStyle={{
+              color: theme === "dark" ? "#67e8f9" : "#0ea5e9",
+              fontWeight: 600,
+            }}
+            labelStyle={{
+              color: theme === "dark" ? "#cbd5f5" : "#334155",
+            }}
+          />
+        </PieChart>
+      </ResponsiveContainer>
+    </div>
+  );
+}

--- a/src/app/voting/components/Results3DPie.tsx
+++ b/src/app/voting/components/Results3DPie.tsx
@@ -109,6 +109,25 @@ export default function Results3DPie({
           />
         </PieChart>
       </ResponsiveContainer>
+
+      <div className="my-3 h-px bg-slate-200 dark:bg-white/10" />
+
+      <div className="mt-4 space-y-2">
+        {data.map((item, index) => (
+          <div key={item.name} className="flex items-center justify-between gap-3 text-sm">
+            <div className="flex items-center gap-2 min-w-0">
+              <span
+                className="h-2.5 w-2.5 rounded-full shrink-0"
+                style={{ backgroundColor: colors[index % colors.length] }}
+              />
+              <span className="truncate text-slate-700 dark:text-slate-200">{item.name}</span>
+            </div>
+            <span className="shrink-0 text-slate-500 dark:text-slate-400">
+              {item.value} • {item.percentage}%
+            </span>
+          </div>
+        ))}
+      </div>
     </div>
   );
 }

--- a/src/app/voting/components/Results3DPie.tsx
+++ b/src/app/voting/components/Results3DPie.tsx
@@ -1,7 +1,7 @@
 "use client";
 
 import { PieChart, Pie, Cell, ResponsiveContainer, Tooltip } from "recharts";
-import type { NameType, ValueType, Payload } from "recharts/types/component/DefaultTooltipContent";
+import type { ValueType, Payload } from "recharts/types/component/DefaultTooltipContent";
 
 type PieDatum = {
   name: string;

--- a/src/app/voting/components/Results3DPie.tsx
+++ b/src/app/voting/components/Results3DPie.tsx
@@ -28,87 +28,122 @@ export default function Results3DPie({
 }: Results3DPieProps) {
   const colors = theme === "dark" ? DARK_COLORS : LIGHT_COLORS;
   const isSecondary = emphasis === "secondary";
+  const resolvedTotal =
+    typeof totalVotes === "number" ? totalVotes : data.reduce((sum, item) => sum + item.value, 0);
+  const resolvedTurnout = turnoutFlats ?? undefined;
 
   return (
-    <div className="relative h-64 w-full">
-      <ResponsiveContainer width="100%" height="100%">
-        <PieChart>
-          <Pie
-            data={data}
-            dataKey="value"
-            innerRadius={isSecondary ? 46 : 52}
-            outerRadius={isSecondary ? 72 : 82}
-            startAngle={90}
-            endAngle={-270}
-            paddingAngle={1}
-            isAnimationActive
-            animationDuration={900}
-            animationBegin={150}
-          >
-            {data.map((_, index) => (
-              <Cell
-                key={`shadow-${index}`}
-                fill={theme === "dark" ? "rgba(0,0,0,0.45)" : "rgba(0,0,0,0.18)"}
-                style={{
-                  transform: "translate(3px, 6px)",
-                }}
-              />
-            ))}
-          </Pie>
+    <div
+      className="rounded-2xl p-5 bg-white/70 backdrop-blur-xl border border-slate-200 shadow-xl dark:bg-slate-900/60 dark:border-white/10 dark:shadow-[0_20px_60px_rgba(0,0,0,0.6)]"
+      aria-label={`Vote distribution donut${resolvedTurnout ? `, ${resolvedTurnout} flats` : ""}`}
+    >
+      <div className="relative h-64 w-full">
+        <ResponsiveContainer width="100%" height="100%">
+          <PieChart>
+            <Pie
+              data={data}
+              dataKey="value"
+              nameKey="name"
+              innerRadius={isSecondary ? 46 : 52}
+              outerRadius={isSecondary ? 72 : 82}
+              startAngle={90}
+              endAngle={-270}
+              paddingAngle={3}
+              cornerRadius={8}
+              isAnimationActive
+              animationDuration={1400}
+              animationBegin={150}
+              label={false}
+              labelLine={false}
+            >
+              {data.map((_, index) => (
+                <Cell
+                  key={`shadow-${index}`}
+                  fill={theme === "dark" ? "rgba(0,0,0,0.45)" : "rgba(0,0,0,0.18)"}
+                  style={{
+                    transform: "translate(3px, 6px)",
+                  }}
+                />
+              ))}
+            </Pie>
 
-          <Pie
-            data={data}
-            dataKey="value"
-            innerRadius={isSecondary ? 42 : 48}
-            outerRadius={isSecondary ? 68 : 78}
-            startAngle={90}
-            endAngle={-270}
-            paddingAngle={2}
-            isAnimationActive
-            animationDuration={900}
-          >
-            {data.map((_, index) => (
-              <Cell
-                key={`slice-${index}`}
-                fill={colors[index % colors.length]}
-                style={{
-                  filter: isSecondary
-                    ? "drop-shadow(0 6px 10px rgba(0,0,0,0.18))"
-                    : theme === "dark"
-                      ? "drop-shadow(0 12px 22px rgba(0,0,0,0.35))"
-                      : "drop-shadow(0 12px 22px rgba(0,0,0,0.25))",
-                }}
-              />
-            ))}
-          </Pie>
+            <Pie
+              data={data}
+              dataKey="value"
+              nameKey="name"
+              innerRadius={isSecondary ? 42 : 48}
+              outerRadius={isSecondary ? 68 : 78}
+              startAngle={90}
+              endAngle={-270}
+              paddingAngle={3}
+              cornerRadius={8}
+              isAnimationActive
+              animationDuration={1400}
+              label={false}
+              labelLine={false}
+            >
+              {data.map((_, index) => (
+                <Cell
+                  key={`slice-${index}`}
+                  fill={colors[index % colors.length]}
+                  style={{
+                    filter: isSecondary
+                      ? "drop-shadow(0 6px 10px rgba(0,0,0,0.18))"
+                      : theme === "dark"
+                        ? "drop-shadow(0 12px 22px rgba(0,0,0,0.35))"
+                        : "drop-shadow(0 12px 22px rgba(0,0,0,0.25))",
+                  }}
+                />
+              ))}
+            </Pie>
 
-          <Tooltip
-            formatter={(value: ValueType, name: NameType, props?: Payload<ValueType, NameType>) => {
-              const votes = Number(value ?? 0);
-              const pct =
-                typeof props?.payload?.percentage === "number" ? props.payload.percentage : 0;
-              return [`${votes} votes (${pct}%)`, String(name ?? "")];
-            }}
-            contentStyle={{
-              background: theme === "dark" ? "rgba(2,6,23,0.95)" : "rgba(255,255,255,0.95)",
-              borderRadius: "12px",
-              border: "none",
-              boxShadow:
-                theme === "dark"
-                  ? "0 20px 60px rgba(0,0,0,0.7)"
-                  : "0 20px 60px rgba(15,23,42,0.25)",
-              color: theme === "dark" ? "#e5e7eb" : "#0f172a",
-            }}
-            itemStyle={{
-              color: theme === "dark" ? "#67e8f9" : "#0ea5e9",
-              fontWeight: 600,
-            }}
-            labelStyle={{
-              color: theme === "dark" ? "#cbd5f5" : "#334155",
-            }}
-          />
-        </PieChart>
-      </ResponsiveContainer>
+            <Tooltip
+              formatter={(value: ValueType, name: NameType, props?: Payload<ValueType, NameType>) => {
+                const votes = Number(value ?? 0);
+                const pct =
+                  typeof props?.payload?.percentage === "number" ? props.payload.percentage : 0;
+                return [`${votes} votes (${pct}%)`, String(name ?? "")];
+              }}
+              contentStyle={{
+                background: theme === "dark" ? "rgba(2,6,23,0.95)" : "rgba(255,255,255,0.95)",
+                borderRadius: "12px",
+                border: "none",
+                boxShadow:
+                  theme === "dark"
+                    ? "0 20px 60px rgba(0,0,0,0.7)"
+                    : "0 20px 60px rgba(15,23,42,0.25)",
+                color: theme === "dark" ? "#e5e7eb" : "#0f172a",
+              }}
+              itemStyle={{
+                color: theme === "dark" ? "#67e8f9" : "#0ea5e9",
+                fontWeight: 600,
+              }}
+              labelStyle={{
+                color: theme === "dark" ? "#cbd5f5" : "#334155",
+              }}
+            />
+
+            <text
+              x="50%"
+              y="48%"
+              textAnchor="middle"
+              className="fill-slate-900 dark:fill-white font-extrabold"
+              style={{ fontSize: "3rem" }}
+            >
+              {resolvedTotal.toLocaleString()}
+            </text>
+            <text
+              x="50%"
+              y="62%"
+              textAnchor="middle"
+              className="fill-slate-500 dark:fill-slate-300 font-medium"
+              style={{ fontSize: "1rem" }}
+            >
+              Total votes
+            </text>
+          </PieChart>
+        </ResponsiveContainer>
+      </div>
 
       <div className="my-3 h-px bg-slate-200 dark:bg-white/10" />
 

--- a/src/app/voting/components/Results3DPie.tsx
+++ b/src/app/voting/components/Results3DPie.tsx
@@ -33,6 +33,8 @@ export default function Results3DPie({
   const resolvedTotal =
     typeof totalVotes === "number" ? totalVotes : data.reduce((sum, item) => sum + item.value, 0);
   const resolvedTurnout = turnoutFlats ?? undefined;
+  const centerNumberFill = isDark ? "rgba(255,255,255,0.95)" : "rgba(15,23,42,0.95)";
+  const centerLabelFill = isDark ? "rgba(226,232,240,0.75)" : "rgba(100,116,139,0.9)";
 
   return (
     <div
@@ -124,8 +126,9 @@ export default function Results3DPie({
               x="50%"
               y="46%"
               textAnchor="middle"
-              className="fill-slate-900 dark:fill-white font-extrabold"
+              className="font-extrabold"
               style={{ fontSize: "48px" }}
+              fill={centerNumberFill}
             >
               {resolvedTotal.toLocaleString()}
             </text>
@@ -133,8 +136,9 @@ export default function Results3DPie({
               x="50%"
               y="60%"
               textAnchor="middle"
-              className="fill-slate-500 dark:fill-slate-400 font-medium"
+              className="font-medium"
               style={{ fontSize: "14px" }}
+              fill={centerLabelFill}
             >
               Total votes
             </text>

--- a/src/app/voting/components/Results3DPie.tsx
+++ b/src/app/voting/components/Results3DPie.tsx
@@ -33,7 +33,7 @@ export default function Results3DPie({
   const resolvedTotal =
     typeof totalVotes === "number" ? totalVotes : data.reduce((sum, item) => sum + item.value, 0);
   const resolvedTurnout = turnoutFlats ?? undefined;
-  const centerNumberFill = isDark ? "rgba(255,255,255,0.95)" : "rgba(15,23,42,0.95)";
+  const centerNumberFill = isDark ? "#67e8f9" : "#0ea5e9";
   const centerLabelFill = isDark ? "rgba(226,232,240,0.75)" : "rgba(100,116,139,0.9)";
 
   return (


### PR DESCRIPTION
## Summary
- add per-question advanced insights toggles on the owners results cards with premium styling
- introduce a glassy advanced insights panel with animated 3D-inspired bar chart and numeric breakdowns
- respect reduced-motion preferences while keeping existing results data live

## Testing
- npm run lint

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6957fbd4ad808324be0496d00fb6473e)