### PR TITLE
Add Myreside and Newton factor info pages

### DIFF
--- a/src/app/myreside/page.tsx
+++ b/src/app/myreside/page.tsx
@@ -16,33 +16,14 @@ const MyresidePage = () => {
       logoSrc="/images/logo/myreside-logo-removebg-preview.png"
       logoAlt="Myreside Management logo"
       managementTitle="How Myreside would manage James Square"
-      managementPoints={[
-        'Traditional factoring model',
-        'Emphasis on in-house service delivery',
-        'Regular site inspections',
-        'Close working relationship with the owners’ committee',
-        'Flexible, practical approach rather than rigid systems',
-      ]}
-      caretakerTitle="Caretaker arrangements"
-      caretakerIntro="James Square already has a caretaker in post."
-      caretakerPoints={[
-        'The existing caretaker would be expected to transfer across (subject to TUPE)',
-        'Caretaking, cleaning, and minor maintenance duties may overlap where required',
-        'Day-to-day support would be provided by Myreside’s internal team',
-        'Holiday and sickness cover would be arranged internally',
-      ]}
-      communicationPoints={[
-        'Direct contact with a named property manager',
-        'Issues raised by phone or email',
-        'Maintenance progressed via internal teams or approved contractors',
-        'Committee involvement encouraged where appropriate',
-      ]}
+      managementText="Myreside Management operates a traditional factoring model, with an emphasis on in-house service delivery and regular site inspections. Their approach focuses on maintaining a close working relationship with the owners’ committee and dealing with issues in a practical and flexible manner rather than relying on rigid systems or processes."
+      communicationText="Communication would be handled directly through a named property manager, with issues raised by phone or email. Maintenance would be coordinated using Myreside’s internal teams or approved contractors, with committee involvement where appropriate and agreed."
       costs={[
-        'Total annual budget: ~£179,000',
-        'Approximate cost per flat: ~£1,740 per year (~£145 per month)',
-        'Management fee: £150 + VAT per flat per year',
-        'Float required: £450 per flat (refundable)',
-        'No commission taken on buildings insurance',
+        { label: 'Total annual budget:', value: 'approximately £179,000' },
+        { label: 'Approximate cost per flat:', value: 'around £1,740 per year (about £145 per month)' },
+        { label: 'Management fee:', value: '£150 plus VAT per flat per year' },
+        { label: 'Float required:', value: '£450 per flat (refundable)' },
+        { label: 'Insurance commission:', value: 'none taken' },
       ]}
       documentationHref="/images/venues/myreside-tender-doc.pdf"
       documentationLabel="View Myreside tender documentation (PDF)"

--- a/src/app/myreside/page.tsx
+++ b/src/app/myreside/page.tsx
@@ -1,0 +1,53 @@
+import type { Metadata } from 'next';
+
+import FactorInfoPage from '@/components/FactorInfoPage';
+
+export const metadata: Metadata = {
+  title: 'Myreside Management | James Square',
+  description: 'Information for James Square owners about Myreside Management factoring proposal.',
+};
+
+const MyresidePage = () => {
+  return (
+    <FactorInfoPage
+      title="Myreside Management"
+      subtitle="Information for James Square owners"
+      intro="Myreside Management is an Edinburgh-based property factor with over 25 years’ experience managing residential developments across the city and surrounding areas. The company presents itself as a hands-on, relationship-led factor with strong director involvement."
+      logoSrc="/images/logo/myreside-logo-removebg-preview.png"
+      logoAlt="Myreside Management logo"
+      managementTitle="How Myreside would manage James Square"
+      managementPoints={[
+        'Traditional factoring model',
+        'Emphasis on in-house service delivery',
+        'Regular site inspections',
+        'Close working relationship with the owners’ committee',
+        'Flexible, practical approach rather than rigid systems',
+      ]}
+      caretakerTitle="Caretaker arrangements"
+      caretakerIntro="James Square already has a caretaker in post."
+      caretakerPoints={[
+        'The existing caretaker would be expected to transfer across (subject to TUPE)',
+        'Caretaking, cleaning, and minor maintenance duties may overlap where required',
+        'Day-to-day support would be provided by Myreside’s internal team',
+        'Holiday and sickness cover would be arranged internally',
+      ]}
+      communicationPoints={[
+        'Direct contact with a named property manager',
+        'Issues raised by phone or email',
+        'Maintenance progressed via internal teams or approved contractors',
+        'Committee involvement encouraged where appropriate',
+      ]}
+      costs={[
+        'Total annual budget: ~£179,000',
+        'Approximate cost per flat: ~£1,740 per year (~£145 per month)',
+        'Management fee: £150 + VAT per flat per year',
+        'Float required: £450 per flat (refundable)',
+        'No commission taken on buildings insurance',
+      ]}
+      documentationHref="/images/venues/myreside-tender-doc.pdf"
+      documentationLabel="View Myreside tender documentation (PDF)"
+    />
+  );
+};
+
+export default MyresidePage;

--- a/src/app/newton/page.tsx
+++ b/src/app/newton/page.tsx
@@ -1,0 +1,54 @@
+import type { Metadata } from 'next';
+
+import FactorInfoPage from '@/components/FactorInfoPage';
+
+export const metadata: Metadata = {
+  title: 'Newton Property Management | James Square',
+  description: 'Information for James Square owners about Newton Property Management factoring proposal.',
+};
+
+const NewtonPage = () => {
+  return (
+    <FactorInfoPage
+      title="Newton Property Management"
+      subtitle="Information for James Square owners"
+      intro="Newton Property Management is an established Scottish property factor operating across multiple regions, including Edinburgh, Glasgow, Aberdeen, and Inverness. Newton manages a range of residential developments, including large and complex sites with shared facilities."
+      logoSrc="/images/logo/newton-logo-removebg-preview.png"
+      logoAlt="Newton Property Management logo"
+      managementTitle="How Newton would manage James Square"
+      managementPoints={[
+        'Structured, systems-based factoring model',
+        'Named property manager and assistant',
+        'Centralised maintenance tracking',
+        'Formal escalation and reporting processes',
+        'Regular communication with the committee',
+      ]}
+      caretakerTitle="Caretaker arrangements"
+      caretakerIntro="James Square already has a caretaker in post."
+      caretakerPoints={[
+        'The existing caretaker would be expected to transfer across (subject to TUPE)',
+        'Caretaker supported through Newton payroll and HR systems',
+        'Clear line management and escalation routes',
+        'Planned holiday and sickness cover',
+      ]}
+      communicationPoints={[
+        'Maintenance issues logged and tracked',
+        'Responsibility assigned to a named manager',
+        'Progress monitored and escalated where required',
+        'Updates provided to the committee',
+        'Online systems used for reporting and visibility',
+      ]}
+      costs={[
+        'Total annual budget: ~£192,700',
+        'Approximate cost per flat: ~£1,870 per year (~£156 per month)',
+        'Management fee: £180 + VAT per flat per year',
+        'Float required: £300 per flat (refundable)',
+        'Potential insurance savings identified',
+      ]}
+      documentationHref="/images/venues/newton-tender-doc.pdf"
+      documentationLabel="View Newton tender documentation (PDF)"
+    />
+  );
+};
+
+export default NewtonPage;

--- a/src/app/newton/page.tsx
+++ b/src/app/newton/page.tsx
@@ -16,34 +16,14 @@ const NewtonPage = () => {
       logoSrc="/images/logo/newton-logo-removebg-preview.png"
       logoAlt="Newton Property Management logo"
       managementTitle="How Newton would manage James Square"
-      managementPoints={[
-        'Structured, systems-based factoring model',
-        'Named property manager and assistant',
-        'Centralised maintenance tracking',
-        'Formal escalation and reporting processes',
-        'Regular communication with the committee',
-      ]}
-      caretakerTitle="Caretaker arrangements"
-      caretakerIntro="James Square already has a caretaker in post."
-      caretakerPoints={[
-        'The existing caretaker would be expected to transfer across (subject to TUPE)',
-        'Caretaker supported through Newton payroll and HR systems',
-        'Clear line management and escalation routes',
-        'Planned holiday and sickness cover',
-      ]}
-      communicationPoints={[
-        'Maintenance issues logged and tracked',
-        'Responsibility assigned to a named manager',
-        'Progress monitored and escalated where required',
-        'Updates provided to the committee',
-        'Online systems used for reporting and visibility',
-      ]}
+      managementText="Newton Property Management operates a structured, systems-based factoring model with defined processes for reporting, escalation, and oversight. Management would be delivered through a named property manager supported by centralised systems designed to provide consistency and visibility across maintenance and compliance matters."
+      communicationText="Maintenance issues would be logged, tracked, and assigned through Newton’s internal systems, with responsibility held by a named property manager. Progress would be monitored and escalated where required, with updates available to the committee as matters are progressed."
       costs={[
-        'Total annual budget: ~£192,700',
-        'Approximate cost per flat: ~£1,870 per year (~£156 per month)',
-        'Management fee: £180 + VAT per flat per year',
-        'Float required: £300 per flat (refundable)',
-        'Potential insurance savings identified',
+        { label: 'Total annual budget:', value: 'approximately £192,700' },
+        { label: 'Approximate cost per flat:', value: 'around £1,870 per year (about £156 per month)' },
+        { label: 'Management fee:', value: '£180 plus VAT per flat per year' },
+        { label: 'Float required:', value: '£300 per flat (refundable)' },
+        { label: 'Insurance:', value: 'potential savings identified' },
       ]}
       documentationHref="/images/venues/newton-tender-doc.pdf"
       documentationLabel="View Newton tender documentation (PDF)"

--- a/src/app/owners/secure/page.tsx
+++ b/src/app/owners/secure/page.tsx
@@ -114,6 +114,10 @@ const OwnersSecurePage = () => {
 
         <div className="space-y-6">
           <motion.div variants={itemVariants}>
+            <FactorReviewSection />
+          </motion.div>
+
+          <motion.div variants={itemVariants}>
             <SgmSection />
           </motion.div>
 
@@ -249,6 +253,39 @@ function SgmSection() {
         <p className="text-xs text-slate-500 dark:text-slate-300">
           Calendar options and meeting details are also available at james-square.com/egm.
         </p>
+      </div>
+    </GlassCard>
+  );
+}
+
+function FactorReviewSection() {
+  return (
+    <GlassCard
+      title="Factor review information"
+      titleClassName="text-2xl font-semibold text-slate-900 dark:text-slate-100"
+    >
+      <p className="text-sm md:text-base text-slate-700 dark:text-slate-200">
+        Access neutral information and documentation for each proposed factor ahead of the general meeting.
+      </p>
+      <div className="grid gap-4 sm:grid-cols-2">
+        <Link
+          href="/myreside"
+          className="group rounded-2xl border border-slate-200/80 bg-white/80 p-5 text-left text-sm font-semibold text-slate-900 shadow-sm transition hover:-translate-y-0.5 hover:shadow-md focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-cyan-500/60 dark:border-white/10 dark:bg-white/5 dark:text-white"
+        >
+          <p className="text-base font-semibold">View Myreside Management information</p>
+          <p className="mt-2 text-sm font-normal text-slate-600 dark:text-slate-300">
+            Review the Myreside proposal, caretaker approach, costs, and tender documentation.
+          </p>
+        </Link>
+        <Link
+          href="/newton"
+          className="group rounded-2xl border border-slate-200/80 bg-white/80 p-5 text-left text-sm font-semibold text-slate-900 shadow-sm transition hover:-translate-y-0.5 hover:shadow-md focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-cyan-500/60 dark:border-white/10 dark:bg-white/5 dark:text-white"
+        >
+          <p className="text-base font-semibold">View Newton Property Management information</p>
+          <p className="mt-2 text-sm font-normal text-slate-600 dark:text-slate-300">
+            Review the Newton proposal, caretaker approach, costs, and tender documentation.
+          </p>
+        </Link>
       </div>
     </GlassCard>
   );

--- a/src/app/owners/secure/page.tsx
+++ b/src/app/owners/secure/page.tsx
@@ -125,8 +125,22 @@ const OwnersSecurePage = () => {
         </motion.div>
 
         <div className="space-y-6">
-          <motion.div variants={itemVariants}>
+          <motion.div
+            initial={prefersReducedMotion ? { opacity: 1, y: 0 } : { opacity: 0, y: 8 }}
+            whileInView={{ opacity: 1, y: 0 }}
+            transition={{ duration: prefersReducedMotion ? 0 : 0.35, ease: easeOut }}
+            viewport={{ once: true, amount: 0.2 }}
+          >
             <SgmSection />
+          </motion.div>
+
+          <motion.div variants={itemVariants} className="flex justify-center">
+            <motion.div
+              className="h-px w-full max-w-4xl bg-slate-200/70 dark:bg-white/10"
+              initial={prefersReducedMotion ? { opacity: 1, width: '100%' } : { opacity: 0, width: 0 }}
+              animate={{ opacity: 1, width: '100%' }}
+              transition={{ duration: prefersReducedMotion ? 0 : 0.4, ease: 'easeOut' }}
+            />
           </motion.div>
 
           <motion.div variants={itemVariants}>
@@ -147,12 +161,30 @@ export default OwnersSecurePage;
 function SgmSection() {
   const [meetingConcluded, setMeetingConcluded] = useState(false);
   const [votingClosed, setVotingClosed] = useState(false);
+  const prefersReducedMotion = useReducedMotion();
 
   useEffect(() => {
     const now = new Date();
     setMeetingConcluded(now > EGM_END);
     setVotingClosed(now > VOTING_DEADLINE);
   }, []);
+
+  const actionGridVariants = {
+    hidden: { opacity: prefersReducedMotion ? 1 : 0 },
+    show: {
+      opacity: 1,
+      transition: {
+        duration: prefersReducedMotion ? 0 : 0.15,
+        ease: 'easeOut',
+        staggerChildren: prefersReducedMotion ? 0 : 0.05,
+      },
+    },
+  };
+
+  const actionItemVariants = {
+    hidden: { opacity: prefersReducedMotion ? 1 : 0, y: prefersReducedMotion ? 0 : 4 },
+    show: { opacity: 1, y: 0, transition: { duration: prefersReducedMotion ? 0 : 0.2, ease: 'easeOut' } },
+  };
 
   const egmCardClassName = meetingConcluded
     ? votingClosed
@@ -232,49 +264,63 @@ function SgmSection() {
                 href={GOOGLE_CALENDAR_URL}
                 target="_blank"
                 rel="noreferrer noopener"
-                className="inline-flex items-center justify-center rounded-lg border border-black/10 bg-white/85 px-3 py-2 text-xs font-semibold text-slate-900 shadow-sm transition-all duration-200 hover:-translate-y-0.5 hover:shadow-md focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-slate-500 active:translate-y-[1px] dark:border-white/15 dark:bg-white/20 dark:text-white"
+                className="inline-flex items-center justify-center rounded-lg border border-black/10 bg-white/85 px-3 py-2 text-xs font-semibold text-slate-900 shadow-sm transition-all duration-150 ease-out hover:-translate-y-0.5 hover:shadow-md hover:bg-white/95 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-slate-500 active:translate-y-[1px] active:scale-[0.98] dark:border-white/15 dark:bg-white/20 dark:text-white dark:hover:bg-white/25"
               >
                 Add to Google Calendar
               </a>
               <a
                 href={EGM_ICS_PATH}
                 download="james-square-egm-2026.ics"
-                className="inline-flex items-center justify-center rounded-lg border border-black/10 bg-white/85 px-3 py-2 text-xs font-semibold text-slate-900 shadow-sm transition-all duration-200 hover:-translate-y-0.5 hover:shadow-md focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-slate-500 active:translate-y-[1px] dark:border-white/15 dark:bg-white/20 dark:text-white"
+                className="inline-flex items-center justify-center rounded-lg border border-black/10 bg-white/85 px-3 py-2 text-xs font-semibold text-slate-900 shadow-sm transition-all duration-150 ease-out hover:-translate-y-0.5 hover:shadow-md hover:bg-white/95 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-slate-500 active:translate-y-[1px] active:scale-[0.98] dark:border-white/15 dark:bg-white/20 dark:text-white dark:hover:bg-white/25"
               >
                 Add to Apple Calendar
               </a>
             </div>
           </div>
-          <div className="grid gap-3 sm:grid-cols-2">
-            <Link
-              href={EGM_TEAMS_LINK}
-              target="_blank"
-              rel="noreferrer noopener"
-              className="inline-flex items-center justify-center rounded-xl border border-black/10 bg-white/85 px-4 py-3 text-sm font-semibold text-slate-900 shadow-sm transition-all duration-200 hover:-translate-y-0.5 hover:shadow-lg focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-slate-500 active:translate-y-[1px] dark:border-white/15 dark:bg-white/20 dark:text-white"
-            >
-              Join Microsoft Teams meeting
-            </Link>
-            <Link
-              href={EGM_PAGE_URL}
-              target="_blank"
-              rel="noreferrer noopener"
-              className="inline-flex items-center justify-center rounded-xl border border-black/10 bg-white/85 px-4 py-3 text-sm font-semibold text-slate-900 shadow-sm transition-all duration-200 hover:-translate-y-0.5 hover:shadow-lg focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-slate-500 active:translate-y-[1px] dark:border-white/15 dark:bg-white/20 dark:text-white"
-            >
-              View meeting details
-            </Link>
-            <Link
-              href="/myreside"
-              className="inline-flex items-center justify-center rounded-xl border border-black/10 bg-white/85 px-4 py-3 text-sm font-semibold text-slate-900 shadow-sm transition-all duration-200 hover:-translate-y-0.5 hover:shadow-lg focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-slate-500 active:translate-y-[1px] dark:border-white/15 dark:bg-white/20 dark:text-white"
-            >
-              View Myreside Management information
-            </Link>
-            <Link
-              href="/newton"
-              className="inline-flex items-center justify-center rounded-xl border border-black/10 bg-white/85 px-4 py-3 text-sm font-semibold text-slate-900 shadow-sm transition-all duration-200 hover:-translate-y-0.5 hover:shadow-lg focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-slate-500 active:translate-y-[1px] dark:border-white/15 dark:bg-white/20 dark:text-white"
-            >
-              View Newton Property Management information
-            </Link>
-          </div>
+          <motion.div
+            className="grid gap-3 sm:grid-cols-2"
+            variants={actionGridVariants}
+            initial="hidden"
+            whileInView="show"
+            viewport={{ once: true, amount: 0.2 }}
+          >
+            <motion.div variants={actionItemVariants}>
+              <Link
+                href={EGM_TEAMS_LINK}
+                target="_blank"
+                rel="noreferrer noopener"
+                className="inline-flex w-full items-center justify-center rounded-xl border border-black/10 bg-white/85 px-4 py-3 text-sm font-semibold text-slate-900 shadow-sm transition-all duration-150 ease-out hover:-translate-y-0.5 hover:shadow-md hover:bg-white/95 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-slate-500 active:translate-y-[1px] dark:border-white/15 dark:bg-white/20 dark:text-white dark:hover:bg-white/25"
+              >
+                Join Microsoft Teams meeting
+              </Link>
+            </motion.div>
+            <motion.div variants={actionItemVariants}>
+              <Link
+                href={EGM_PAGE_URL}
+                target="_blank"
+                rel="noreferrer noopener"
+                className="inline-flex w-full items-center justify-center rounded-xl border border-black/10 bg-white/85 px-4 py-3 text-sm font-semibold text-slate-900 shadow-sm transition-all duration-150 ease-out hover:-translate-y-0.5 hover:shadow-md hover:bg-white/95 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-slate-500 active:translate-y-[1px] dark:border-white/15 dark:bg-white/20 dark:text-white dark:hover:bg-white/25"
+              >
+                View meeting details
+              </Link>
+            </motion.div>
+            <motion.div variants={actionItemVariants}>
+              <Link
+                href="/myreside"
+                className="inline-flex w-full items-center justify-center rounded-xl border border-black/10 bg-white/85 px-4 py-3 text-sm font-semibold text-slate-900 shadow-sm transition-all duration-150 ease-out hover:-translate-y-0.5 hover:shadow-md hover:bg-white/95 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-slate-500 active:translate-y-[1px] dark:border-white/15 dark:bg-white/20 dark:text-white dark:hover:bg-white/25"
+              >
+                View Myreside Management information
+              </Link>
+            </motion.div>
+            <motion.div variants={actionItemVariants}>
+              <Link
+                href="/newton"
+                className="inline-flex w-full items-center justify-center rounded-xl border border-black/10 bg-white/85 px-4 py-3 text-sm font-semibold text-slate-900 shadow-sm transition-all duration-150 ease-out hover:-translate-y-0.5 hover:shadow-md hover:bg-white/95 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-slate-500 active:translate-y-[1px] dark:border-white/15 dark:bg-white/20 dark:text-white dark:hover:bg-white/25"
+              >
+                View Newton Property Management information
+              </Link>
+            </motion.div>
+          </motion.div>
           <p className="text-xs text-slate-500 dark:text-slate-300 text-center sm:text-left">
             Proposal documents are provided for information only and may be updated ahead of the meeting.
           </p>
@@ -329,50 +375,64 @@ function SgmSection() {
               href={GOOGLE_CALENDAR_URL}
               target="_blank"
               rel="noreferrer noopener"
-              className="inline-flex items-center justify-center rounded-lg border border-black/10 bg-white/85 px-3 py-2 text-xs font-semibold text-slate-900 shadow-sm transition-all duration-200 hover:-translate-y-0.5 hover:shadow-md focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-slate-500 active:translate-y-[1px] dark:border-white/15 dark:bg-white/20 dark:text-white"
+              className="inline-flex items-center justify-center rounded-lg border border-black/10 bg-white/85 px-3 py-2 text-xs font-semibold text-slate-900 shadow-sm transition-all duration-150 ease-out hover:-translate-y-0.5 hover:shadow-md hover:bg-white/95 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-slate-500 active:translate-y-[1px] active:scale-[0.98] dark:border-white/15 dark:bg-white/20 dark:text-white dark:hover:bg-white/25"
             >
               Add to Google Calendar
             </a>
             <a
               href={EGM_ICS_PATH}
               download="james-square-egm-2026.ics"
-              className="inline-flex items-center justify-center rounded-lg border border-black/10 bg-white/85 px-3 py-2 text-xs font-semibold text-slate-900 shadow-sm transition-all duration-200 hover:-translate-y-0.5 hover:shadow-md focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-slate-500 active:translate-y-[1px] dark:border-white/15 dark:bg-white/20 dark:text-white"
+              className="inline-flex items-center justify-center rounded-lg border border-black/10 bg-white/85 px-3 py-2 text-xs font-semibold text-slate-900 shadow-sm transition-all duration-150 ease-out hover:-translate-y-0.5 hover:shadow-md hover:bg-white/95 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-slate-500 active:translate-y-[1px] active:scale-[0.98] dark:border-white/15 dark:bg-white/20 dark:text-white dark:hover:bg-white/25"
             >
               Add to Apple Calendar
             </a>
           </div>
         </div>
 
-          <div className="grid gap-3 sm:grid-cols-2">
+        <motion.div
+          className="grid gap-3 sm:grid-cols-2"
+          variants={actionGridVariants}
+          initial="hidden"
+          whileInView="show"
+          viewport={{ once: true, amount: 0.2 }}
+        >
+          <motion.div variants={actionItemVariants}>
             <Link
               href={EGM_TEAMS_LINK}
-            target="_blank"
-            rel="noreferrer noopener"
-            className="inline-flex items-center justify-center rounded-xl border border-black/10 bg-white/85 px-4 py-3 text-sm font-semibold text-slate-900 shadow-sm transition-all duration-200 hover:-translate-y-0.5 hover:shadow-lg focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-slate-500 active:translate-y-[1px] dark:border-white/15 dark:bg-white/20 dark:text-white"
-          >
-            Join Microsoft Teams meeting
-          </Link>
-          <Link
-            href={EGM_PAGE_URL}
-            target="_blank"
-            rel="noreferrer noopener"
-            className="inline-flex items-center justify-center rounded-xl border border-black/10 bg-white/85 px-4 py-3 text-sm font-semibold text-slate-900 shadow-sm transition-all duration-200 hover:-translate-y-0.5 hover:shadow-lg focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-slate-500 active:translate-y-[1px] dark:border-white/15 dark:bg-white/20 dark:text-white"
+              target="_blank"
+              rel="noreferrer noopener"
+              className="inline-flex w-full items-center justify-center rounded-xl border border-black/10 bg-white/85 px-4 py-3 text-sm font-semibold text-slate-900 shadow-sm transition-all duration-150 ease-out hover:-translate-y-0.5 hover:shadow-md hover:bg-white/95 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-slate-500 active:translate-y-[1px] dark:border-white/15 dark:bg-white/20 dark:text-white dark:hover:bg-white/25"
+            >
+              Join Microsoft Teams meeting
+            </Link>
+          </motion.div>
+          <motion.div variants={actionItemVariants}>
+            <Link
+              href={EGM_PAGE_URL}
+              target="_blank"
+              rel="noreferrer noopener"
+              className="inline-flex w-full items-center justify-center rounded-xl border border-black/10 bg-white/85 px-4 py-3 text-sm font-semibold text-slate-900 shadow-sm transition-all duration-150 ease-out hover:-translate-y-0.5 hover:shadow-md hover:bg-white/95 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-slate-500 active:translate-y-[1px] dark:border-white/15 dark:bg-white/20 dark:text-white dark:hover:bg-white/25"
             >
               View meeting details
             </Link>
+          </motion.div>
+          <motion.div variants={actionItemVariants}>
             <Link
               href="/myreside"
-              className="inline-flex items-center justify-center rounded-xl border border-black/10 bg-white/85 px-4 py-3 text-sm font-semibold text-slate-900 shadow-sm transition-all duration-200 hover:-translate-y-0.5 hover:shadow-lg focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-slate-500 active:translate-y-[1px] dark:border-white/15 dark:bg-white/20 dark:text-white"
+              className="inline-flex w-full items-center justify-center rounded-xl border border-black/10 bg-white/85 px-4 py-3 text-sm font-semibold text-slate-900 shadow-sm transition-all duration-150 ease-out hover:-translate-y-0.5 hover:shadow-md hover:bg-white/95 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-slate-500 active:translate-y-[1px] dark:border-white/15 dark:bg-white/20 dark:text-white dark:hover:bg-white/25"
             >
               View Myreside Management information
             </Link>
+          </motion.div>
+          <motion.div variants={actionItemVariants}>
             <Link
               href="/newton"
-              className="inline-flex items-center justify-center rounded-xl border border-black/10 bg-white/85 px-4 py-3 text-sm font-semibold text-slate-900 shadow-sm transition-all duration-200 hover:-translate-y-0.5 hover:shadow-lg focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-slate-500 active:translate-y-[1px] dark:border-white/15 dark:bg-white/20 dark:text-white"
+              className="inline-flex w-full items-center justify-center rounded-xl border border-black/10 bg-white/85 px-4 py-3 text-sm font-semibold text-slate-900 shadow-sm transition-all duration-150 ease-out hover:-translate-y-0.5 hover:shadow-md hover:bg-white/95 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-slate-500 active:translate-y-[1px] dark:border-white/15 dark:bg-white/20 dark:text-white dark:hover:bg-white/25"
             >
               View Newton Property Management information
             </Link>
-          </div>
+          </motion.div>
+        </motion.div>
         <p className="text-xs text-slate-500 dark:text-slate-300 text-center sm:text-left">
           Proposal documents are provided for information only and may be updated ahead of the meeting.
         </p>

--- a/src/app/owners/secure/page.tsx
+++ b/src/app/owners/secure/page.tsx
@@ -125,22 +125,8 @@ const OwnersSecurePage = () => {
         </motion.div>
 
         <div className="space-y-6">
-          <motion.div
-            initial={prefersReducedMotion ? { opacity: 1, y: 0 } : { opacity: 0, y: 8 }}
-            whileInView={{ opacity: 1, y: 0 }}
-            transition={{ duration: prefersReducedMotion ? 0 : 0.35, ease: easeOut }}
-            viewport={{ once: true, amount: 0.2 }}
-          >
+          <motion.div variants={itemVariants}>
             <SgmSection />
-          </motion.div>
-
-          <motion.div variants={itemVariants} className="flex justify-center">
-            <motion.div
-              className="h-px w-full max-w-4xl bg-slate-200/70 dark:bg-white/10"
-              initial={prefersReducedMotion ? { opacity: 1, width: '100%' } : { opacity: 0, width: 0 }}
-              animate={{ opacity: 1, width: '100%' }}
-              transition={{ duration: prefersReducedMotion ? 0 : 0.4, ease: 'easeOut' }}
-            />
           </motion.div>
 
           <motion.div variants={itemVariants}>
@@ -161,30 +147,12 @@ export default OwnersSecurePage;
 function SgmSection() {
   const [meetingConcluded, setMeetingConcluded] = useState(false);
   const [votingClosed, setVotingClosed] = useState(false);
-  const prefersReducedMotion = useReducedMotion();
 
   useEffect(() => {
     const now = new Date();
     setMeetingConcluded(now > EGM_END);
     setVotingClosed(now > VOTING_DEADLINE);
   }, []);
-
-  const actionGridVariants = {
-    hidden: { opacity: prefersReducedMotion ? 1 : 0 },
-    show: {
-      opacity: 1,
-      transition: {
-        duration: prefersReducedMotion ? 0 : 0.15,
-        ease: 'easeOut',
-        staggerChildren: prefersReducedMotion ? 0 : 0.05,
-      },
-    },
-  };
-
-  const actionItemVariants = {
-    hidden: { opacity: prefersReducedMotion ? 1 : 0, y: prefersReducedMotion ? 0 : 4 },
-    show: { opacity: 1, y: 0, transition: { duration: prefersReducedMotion ? 0 : 0.2, ease: 'easeOut' } },
-  };
 
   const egmCardClassName = meetingConcluded
     ? votingClosed
@@ -200,135 +168,106 @@ function SgmSection() {
         titleClassName="text-2xl font-semibold text-slate-900 dark:text-slate-100"
         className={egmCardClassName}
       >
-        <div className="space-y-6 rounded-2xl border border-slate-200/70 bg-white/70 p-6 shadow-sm dark:border-white/10 dark:bg-white/5">
-          {votingClosed ? (
-            <>
-              <p className="text-xs font-semibold uppercase tracking-[0.2em] text-slate-500 dark:text-slate-300">
-                Voting closed – outcome pending
-              </p>
-              <p className="text-sm md:text-base text-slate-700 dark:text-slate-200">Voting has now closed.</p>
-              <p className="text-sm md:text-base text-slate-700 dark:text-slate-200">
-                The outcome of the vote and any next steps will be shared with owners once confirmed.
-              </p>
-            </>
-          ) : (
-            <>
-              <p className="text-xs font-semibold uppercase tracking-[0.2em] text-slate-500 dark:text-slate-300">
-                Meeting concluded
-              </p>
-              <p className="text-sm md:text-base text-slate-700 dark:text-slate-200">
-                The Extraordinary General Meeting held on Wednesday 21 January 2026 has now taken place.
-              </p>
-              <p className="text-sm md:text-base text-slate-700 dark:text-slate-200">
-                Owners are now invited to vote on which property factor they believe would be best for James Square.
-              </p>
-              <div className="space-y-2">
-                <Link
-                  href="https://www.james-square.com/voting"
-                  target="_blank"
-                  rel="noreferrer noopener"
-                  className="inline-flex items-center justify-center rounded-full px-5 py-2.5 text-sm font-semibold text-white bg-slate-900 shadow-[0_6px_18px_rgba(0,0,0,0.18)] transition-all duration-200 hover:-translate-y-0.5 hover:scale-[1.01] hover:shadow-[0_10px_28px_rgba(0,0,0,0.2)] focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-slate-500 active:translate-y-[1px] dark:bg-white dark:text-slate-900"
-                >
-                  Place your vote
-                </Link>
-                <p className="text-xs text-slate-500 dark:text-slate-300">Voting will close on Friday 23 January 2026.</p>
-              </div>
-            </>
-          )}
-          <div className={glassPanel}>
-            <dl className="grid grid-cols-1 gap-3 text-sm text-slate-800 dark:text-slate-100 sm:grid-cols-2 lg:grid-cols-4">
-              <div>
-                <dt className="font-semibold">Date</dt>
-                <dd>Wednesday 21 January 2026</dd>
-              </div>
-              <div>
-                <dt className="font-semibold">Time</dt>
-                <dd>From 18:00 (UK time)</dd>
-              </div>
-              <div>
-                <dt className="font-semibold">Format</dt>
-                <dd>Online via Microsoft Teams</dd>
-              </div>
-              <div>
-                <dt className="font-semibold">Audience</dt>
-                <dd>James Square owners</dd>
-              </div>
-            </dl>
-          </div>
-          <div className="space-y-3">
-            <p className="text-xs font-semibold uppercase tracking-[0.18em] text-slate-500 dark:text-slate-300">
-              Add meeting to calendar
+        {votingClosed ? (
+          <>
+            <p className="text-xs font-semibold uppercase tracking-[0.2em] text-slate-500 dark:text-slate-300">
+              Voting closed – outcome pending
             </p>
-            <div className="grid gap-3 sm:grid-cols-2">
-              <a
-                href={GOOGLE_CALENDAR_URL}
+            <p className="text-sm md:text-base text-slate-700 dark:text-slate-200">Voting has now closed.</p>
+            <p className="text-sm md:text-base text-slate-700 dark:text-slate-200">
+              The outcome of the vote and any next steps will be shared with owners once confirmed.
+            </p>
+          </>
+        ) : (
+          <>
+            <p className="text-xs font-semibold uppercase tracking-[0.2em] text-slate-500 dark:text-slate-300">
+              Meeting concluded
+            </p>
+            <p className="text-sm md:text-base text-slate-700 dark:text-slate-200">
+              The Extraordinary General Meeting held on Wednesday 21 January 2026 has now taken place.
+            </p>
+            <p className="text-sm md:text-base text-slate-700 dark:text-slate-200">
+              Owners are now invited to vote on which property factor they believe would be best for James Square.
+            </p>
+            <div className="space-y-2">
+              <Link
+                href="https://www.james-square.com/voting"
                 target="_blank"
                 rel="noreferrer noopener"
-                className="inline-flex items-center justify-center rounded-lg border border-black/10 bg-white/85 px-3 py-2 text-xs font-semibold text-slate-900 shadow-sm transition-all duration-150 ease-out hover:-translate-y-0.5 hover:shadow-md hover:bg-white/95 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-slate-500 active:translate-y-[1px] active:scale-[0.98] dark:border-white/15 dark:bg-white/20 dark:text-white dark:hover:bg-white/25"
+                className="inline-flex items-center justify-center rounded-full px-5 py-2.5 text-sm font-semibold text-white bg-slate-900 shadow-[0_6px_18px_rgba(0,0,0,0.18)] transition-all duration-200 hover:-translate-y-0.5 hover:scale-[1.01] hover:shadow-[0_10px_28px_rgba(0,0,0,0.2)] focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-slate-500 active:translate-y-[1px] dark:bg-white dark:text-slate-900"
               >
-                Add to Google Calendar
-              </a>
-              <a
-                href={EGM_ICS_PATH}
-                download="james-square-egm-2026.ics"
-                className="inline-flex items-center justify-center rounded-lg border border-black/10 bg-white/85 px-3 py-2 text-xs font-semibold text-slate-900 shadow-sm transition-all duration-150 ease-out hover:-translate-y-0.5 hover:shadow-md hover:bg-white/95 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-slate-500 active:translate-y-[1px] active:scale-[0.98] dark:border-white/15 dark:bg-white/20 dark:text-white dark:hover:bg-white/25"
-              >
-                Add to Apple Calendar
-              </a>
+                Place your vote
+              </Link>
+              <p className="text-xs text-slate-500 dark:text-slate-300">Voting will close on Friday 23 January 2026.</p>
             </div>
-          </div>
-          <motion.div
-            className="grid gap-3 sm:grid-cols-2"
-            variants={actionGridVariants}
-            initial="hidden"
-            whileInView="show"
-            viewport={{ once: true, amount: 0.2 }}
-          >
-            <motion.div variants={actionItemVariants}>
-              <Link
-                href={EGM_TEAMS_LINK}
-                target="_blank"
-                rel="noreferrer noopener"
-                className="inline-flex w-full items-center justify-center rounded-xl border border-black/10 bg-white/85 px-4 py-3 text-sm font-semibold text-slate-900 shadow-sm transition-all duration-150 ease-out hover:-translate-y-0.5 hover:shadow-md hover:bg-white/95 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-slate-500 active:translate-y-[1px] dark:border-white/15 dark:bg-white/20 dark:text-white dark:hover:bg-white/25"
-              >
-                Join Microsoft Teams meeting
-              </Link>
-            </motion.div>
-            <motion.div variants={actionItemVariants}>
-              <Link
-                href={EGM_PAGE_URL}
-                target="_blank"
-                rel="noreferrer noopener"
-                className="inline-flex w-full items-center justify-center rounded-xl border border-black/10 bg-white/85 px-4 py-3 text-sm font-semibold text-slate-900 shadow-sm transition-all duration-150 ease-out hover:-translate-y-0.5 hover:shadow-md hover:bg-white/95 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-slate-500 active:translate-y-[1px] dark:border-white/15 dark:bg-white/20 dark:text-white dark:hover:bg-white/25"
-              >
-                View meeting details
-              </Link>
-            </motion.div>
-            <motion.div variants={actionItemVariants}>
-              <Link
-                href="/myreside"
-                className="inline-flex w-full items-center justify-center rounded-xl border border-black/10 bg-white/85 px-4 py-3 text-sm font-semibold text-slate-900 shadow-sm transition-all duration-150 ease-out hover:-translate-y-0.5 hover:shadow-md hover:bg-white/95 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-slate-500 active:translate-y-[1px] dark:border-white/15 dark:bg-white/20 dark:text-white dark:hover:bg-white/25"
-              >
-                View Myreside Management information
-              </Link>
-            </motion.div>
-            <motion.div variants={actionItemVariants}>
-              <Link
-                href="/newton"
-                className="inline-flex w-full items-center justify-center rounded-xl border border-black/10 bg-white/85 px-4 py-3 text-sm font-semibold text-slate-900 shadow-sm transition-all duration-150 ease-out hover:-translate-y-0.5 hover:shadow-md hover:bg-white/95 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-slate-500 active:translate-y-[1px] dark:border-white/15 dark:bg-white/20 dark:text-white dark:hover:bg-white/25"
-              >
-                View Newton Property Management information
-              </Link>
-            </motion.div>
-          </motion.div>
-          <p className="text-xs text-slate-500 dark:text-slate-300 text-center sm:text-left">
-            Proposal documents are provided for information only and may be updated ahead of the meeting.
+          </>
+        )}
+        <div className="grid gap-4 text-sm text-slate-700 dark:text-slate-200 md:grid-cols-[140px_1fr]">
+          <div className="font-semibold text-slate-900 dark:text-slate-100">Date</div>
+          <div>Wednesday 21 January 2026</div>
+          <div className="font-semibold text-slate-900 dark:text-slate-100">Time</div>
+          <div>From 18:00 (UK time)</div>
+          <div className="font-semibold text-slate-900 dark:text-slate-100">Format</div>
+          <div>Online via Microsoft Teams</div>
+          <div className="font-semibold text-slate-900 dark:text-slate-100">Audience</div>
+          <div>James Square owners</div>
+        </div>
+        <div className="space-y-3">
+          <p className="text-xs font-semibold uppercase tracking-[0.18em] text-slate-500 dark:text-slate-300">
+            Add meeting to calendar
           </p>
-          <div className="inline-flex flex-col gap-1 rounded-full border border-slate-200/80 bg-white/70 px-4 py-2 text-xs text-slate-600 dark:border-white/10 dark:bg-white/5 dark:text-slate-300">
-            <span>Factor documentation is provided for information only.</span>
-            <span>Proposals are initial and subject to clarification and update ahead of the meeting.</span>
+          <div className="grid gap-3 sm:grid-cols-2">
+            <a
+              href={GOOGLE_CALENDAR_URL}
+              target="_blank"
+              rel="noreferrer noopener"
+              className="inline-flex items-center justify-center rounded-lg border border-slate-200/80 bg-white/80 px-3 py-2 text-xs font-semibold text-slate-700 shadow-sm transition-colors duration-150 ease-out hover:bg-white/95 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-slate-500 dark:border-white/10 dark:bg-white/10 dark:text-slate-200 dark:hover:bg-white/15"
+            >
+              Add to Google Calendar
+            </a>
+            <a
+              href={EGM_ICS_PATH}
+              download="james-square-egm-2026.ics"
+              className="inline-flex items-center justify-center rounded-lg border border-slate-200/80 bg-white/80 px-3 py-2 text-xs font-semibold text-slate-700 shadow-sm transition-colors duration-150 ease-out hover:bg-white/95 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-slate-500 dark:border-white/10 dark:bg-white/10 dark:text-slate-200 dark:hover:bg-white/15"
+            >
+              Add to Apple Calendar
+            </a>
           </div>
         </div>
+        <div className="grid gap-3 sm:grid-cols-2">
+          <Link
+            href={EGM_TEAMS_LINK}
+            target="_blank"
+            rel="noreferrer noopener"
+            className="inline-flex items-center justify-center rounded-xl border border-black/10 bg-white/85 px-4 py-3 text-sm font-semibold text-slate-900 shadow-sm transition-all duration-150 ease-out hover:bg-white/95 hover:shadow-md focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-slate-500 dark:border-white/15 dark:bg-white/20 dark:text-white dark:hover:bg-white/25"
+          >
+            Join Microsoft Teams meeting
+          </Link>
+          <Link
+            href={EGM_PAGE_URL}
+            target="_blank"
+            rel="noreferrer noopener"
+            className="inline-flex items-center justify-center rounded-xl border border-black/10 bg-white/85 px-4 py-3 text-sm font-semibold text-slate-900 shadow-sm transition-all duration-150 ease-out hover:bg-white/95 hover:shadow-md focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-slate-500 dark:border-white/15 dark:bg-white/20 dark:text-white dark:hover:bg-white/25"
+          >
+            View meeting details
+          </Link>
+          <Link
+            href="/myreside"
+            className="inline-flex items-center justify-center rounded-xl border border-black/10 bg-white/85 px-4 py-3 text-sm font-semibold text-slate-900 shadow-sm transition-all duration-150 ease-out hover:bg-white/95 hover:shadow-md focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-slate-500 dark:border-white/15 dark:bg-white/20 dark:text-white dark:hover:bg-white/25"
+          >
+            View Myreside Management information
+          </Link>
+          <Link
+            href="/newton"
+            className="inline-flex items-center justify-center rounded-xl border border-black/10 bg-white/85 px-4 py-3 text-sm font-semibold text-slate-900 shadow-sm transition-all duration-150 ease-out hover:bg-white/95 hover:shadow-md focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-slate-500 dark:border-white/15 dark:bg-white/20 dark:text-white dark:hover:bg-white/25"
+          >
+            View Newton Property Management information
+          </Link>
+        </div>
+        <p className="text-sm text-slate-500 dark:text-slate-300">
+          Factor documentation is provided for information only. Proposals are initial and subject to clarification and
+          update ahead of the meeting.
+        </p>
       </GlassCard>
     );
   }
@@ -340,107 +279,79 @@ function SgmSection() {
       titleClassName="text-2xl font-semibold text-slate-900 dark:text-slate-100"
       className={egmCardClassName}
     >
-      <div className="space-y-6 rounded-2xl border border-slate-200/70 bg-white/70 p-6 shadow-sm dark:border-white/10 dark:bg-white/5">
-        <p className="text-sm md:text-base text-slate-700 dark:text-slate-200">
-          This meeting has been arranged for owners to discuss and vote on a potential change to the property factor for
-          James Square. Owners are encouraged to review the information below in advance of the meeting.
-        </p>
+      <p className="text-sm md:text-base text-slate-700 dark:text-slate-200">
+        This meeting has been arranged for owners to discuss and vote on a potential change to the property factor for
+        James Square. Owners are encouraged to review the information below in advance of the meeting.
+      </p>
 
-        <div className={glassPanel}>
-          <dl className="grid grid-cols-1 gap-3 text-sm text-slate-800 dark:text-slate-100 sm:grid-cols-2 lg:grid-cols-4">
-            <div>
-              <dt className="font-semibold">Date</dt>
-              <dd>Wednesday 21 January 2026</dd>
-            </div>
-            <div>
-              <dt className="font-semibold">Time</dt>
-              <dd>From 18:00 (UK time)</dd>
-            </div>
-            <div>
-              <dt className="font-semibold">Format</dt>
-              <dd>Online via Microsoft Teams</dd>
-            </div>
-            <div>
-              <dt className="font-semibold">Audience</dt>
-              <dd>James Square owners</dd>
-            </div>
-          </dl>
-        </div>
-        <div className="space-y-3">
-          <p className="text-xs font-semibold uppercase tracking-[0.18em] text-slate-500 dark:text-slate-300">
-            Add meeting to calendar
-          </p>
-          <div className="grid gap-3 sm:grid-cols-2">
-            <a
-              href={GOOGLE_CALENDAR_URL}
-              target="_blank"
-              rel="noreferrer noopener"
-              className="inline-flex items-center justify-center rounded-lg border border-black/10 bg-white/85 px-3 py-2 text-xs font-semibold text-slate-900 shadow-sm transition-all duration-150 ease-out hover:-translate-y-0.5 hover:shadow-md hover:bg-white/95 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-slate-500 active:translate-y-[1px] active:scale-[0.98] dark:border-white/15 dark:bg-white/20 dark:text-white dark:hover:bg-white/25"
-            >
-              Add to Google Calendar
-            </a>
-            <a
-              href={EGM_ICS_PATH}
-              download="james-square-egm-2026.ics"
-              className="inline-flex items-center justify-center rounded-lg border border-black/10 bg-white/85 px-3 py-2 text-xs font-semibold text-slate-900 shadow-sm transition-all duration-150 ease-out hover:-translate-y-0.5 hover:shadow-md hover:bg-white/95 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-slate-500 active:translate-y-[1px] active:scale-[0.98] dark:border-white/15 dark:bg-white/20 dark:text-white dark:hover:bg-white/25"
-            >
-              Add to Apple Calendar
-            </a>
-          </div>
-        </div>
+      <div className="grid gap-4 text-sm text-slate-700 dark:text-slate-200 md:grid-cols-[140px_1fr]">
+        <div className="font-semibold text-slate-900 dark:text-slate-100">Date</div>
+        <div>Wednesday 21 January 2026</div>
+        <div className="font-semibold text-slate-900 dark:text-slate-100">Time</div>
+        <div>From 18:00 (UK time)</div>
+        <div className="font-semibold text-slate-900 dark:text-slate-100">Format</div>
+        <div>Online via Microsoft Teams</div>
+        <div className="font-semibold text-slate-900 dark:text-slate-100">Audience</div>
+        <div>James Square owners</div>
+      </div>
 
-        <motion.div
-          className="grid gap-3 sm:grid-cols-2"
-          variants={actionGridVariants}
-          initial="hidden"
-          whileInView="show"
-          viewport={{ once: true, amount: 0.2 }}
-        >
-          <motion.div variants={actionItemVariants}>
-            <Link
-              href={EGM_TEAMS_LINK}
-              target="_blank"
-              rel="noreferrer noopener"
-              className="inline-flex w-full items-center justify-center rounded-xl border border-black/10 bg-white/85 px-4 py-3 text-sm font-semibold text-slate-900 shadow-sm transition-all duration-150 ease-out hover:-translate-y-0.5 hover:shadow-md hover:bg-white/95 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-slate-500 active:translate-y-[1px] dark:border-white/15 dark:bg-white/20 dark:text-white dark:hover:bg-white/25"
-            >
-              Join Microsoft Teams meeting
-            </Link>
-          </motion.div>
-          <motion.div variants={actionItemVariants}>
-            <Link
-              href={EGM_PAGE_URL}
-              target="_blank"
-              rel="noreferrer noopener"
-              className="inline-flex w-full items-center justify-center rounded-xl border border-black/10 bg-white/85 px-4 py-3 text-sm font-semibold text-slate-900 shadow-sm transition-all duration-150 ease-out hover:-translate-y-0.5 hover:shadow-md hover:bg-white/95 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-slate-500 active:translate-y-[1px] dark:border-white/15 dark:bg-white/20 dark:text-white dark:hover:bg-white/25"
-            >
-              View meeting details
-            </Link>
-          </motion.div>
-          <motion.div variants={actionItemVariants}>
-            <Link
-              href="/myreside"
-              className="inline-flex w-full items-center justify-center rounded-xl border border-black/10 bg-white/85 px-4 py-3 text-sm font-semibold text-slate-900 shadow-sm transition-all duration-150 ease-out hover:-translate-y-0.5 hover:shadow-md hover:bg-white/95 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-slate-500 active:translate-y-[1px] dark:border-white/15 dark:bg-white/20 dark:text-white dark:hover:bg-white/25"
-            >
-              View Myreside Management information
-            </Link>
-          </motion.div>
-          <motion.div variants={actionItemVariants}>
-            <Link
-              href="/newton"
-              className="inline-flex w-full items-center justify-center rounded-xl border border-black/10 bg-white/85 px-4 py-3 text-sm font-semibold text-slate-900 shadow-sm transition-all duration-150 ease-out hover:-translate-y-0.5 hover:shadow-md hover:bg-white/95 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-slate-500 active:translate-y-[1px] dark:border-white/15 dark:bg-white/20 dark:text-white dark:hover:bg-white/25"
-            >
-              View Newton Property Management information
-            </Link>
-          </motion.div>
-        </motion.div>
-        <p className="text-xs text-slate-500 dark:text-slate-300 text-center sm:text-left">
-          Proposal documents are provided for information only and may be updated ahead of the meeting.
+      <div className="space-y-3">
+        <p className="text-xs font-semibold uppercase tracking-[0.18em] text-slate-500 dark:text-slate-300">
+          Add meeting to calendar
         </p>
-        <div className="inline-flex flex-col gap-1 rounded-full border border-slate-200/80 bg-white/70 px-4 py-2 text-xs text-slate-600 dark:border-white/10 dark:bg-white/5 dark:text-slate-300">
-          <span>Factor documentation is provided for information only.</span>
-          <span>Proposals are initial and subject to clarification and update ahead of the meeting.</span>
+        <div className="grid gap-3 sm:grid-cols-2">
+          <a
+            href={GOOGLE_CALENDAR_URL}
+            target="_blank"
+            rel="noreferrer noopener"
+            className="inline-flex items-center justify-center rounded-lg border border-slate-200/80 bg-white/80 px-3 py-2 text-xs font-semibold text-slate-700 shadow-sm transition-colors duration-150 ease-out hover:bg-white/95 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-slate-500 dark:border-white/10 dark:bg-white/10 dark:text-slate-200 dark:hover:bg-white/15"
+          >
+            Add to Google Calendar
+          </a>
+          <a
+            href={EGM_ICS_PATH}
+            download="james-square-egm-2026.ics"
+            className="inline-flex items-center justify-center rounded-lg border border-slate-200/80 bg-white/80 px-3 py-2 text-xs font-semibold text-slate-700 shadow-sm transition-colors duration-150 ease-out hover:bg-white/95 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-slate-500 dark:border-white/10 dark:bg-white/10 dark:text-slate-200 dark:hover:bg-white/15"
+          >
+            Add to Apple Calendar
+          </a>
         </div>
       </div>
+
+      <div className="grid gap-3 sm:grid-cols-2">
+        <Link
+          href={EGM_TEAMS_LINK}
+          target="_blank"
+          rel="noreferrer noopener"
+          className="inline-flex items-center justify-center rounded-xl border border-black/10 bg-white/85 px-4 py-3 text-sm font-semibold text-slate-900 shadow-sm transition-all duration-150 ease-out hover:bg-white/95 hover:shadow-md focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-slate-500 dark:border-white/15 dark:bg-white/20 dark:text-white dark:hover:bg-white/25"
+        >
+          Join Microsoft Teams meeting
+        </Link>
+        <Link
+          href={EGM_PAGE_URL}
+          target="_blank"
+          rel="noreferrer noopener"
+          className="inline-flex items-center justify-center rounded-xl border border-black/10 bg-white/85 px-4 py-3 text-sm font-semibold text-slate-900 shadow-sm transition-all duration-150 ease-out hover:bg-white/95 hover:shadow-md focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-slate-500 dark:border-white/15 dark:bg-white/20 dark:text-white dark:hover:bg-white/25"
+        >
+          View meeting details
+        </Link>
+        <Link
+          href="/myreside"
+          className="inline-flex items-center justify-center rounded-xl border border-black/10 bg-white/85 px-4 py-3 text-sm font-semibold text-slate-900 shadow-sm transition-all duration-150 ease-out hover:bg-white/95 hover:shadow-md focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-slate-500 dark:border-white/15 dark:bg-white/20 dark:text-white dark:hover:bg-white/25"
+        >
+          View Myreside Management information
+        </Link>
+        <Link
+          href="/newton"
+          className="inline-flex items-center justify-center rounded-xl border border-black/10 bg-white/85 px-4 py-3 text-sm font-semibold text-slate-900 shadow-sm transition-all duration-150 ease-out hover:bg-white/95 hover:shadow-md focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-slate-500 dark:border-white/15 dark:bg-white/20 dark:text-white dark:hover:bg-white/25"
+        >
+          View Newton Property Management information
+        </Link>
+      </div>
+      <p className="text-sm text-slate-500 dark:text-slate-300">
+        Factor documentation is provided for information only. Proposals are initial and subject to clarification and
+        update ahead of the meeting.
+      </p>
     </GlassCard>
   );
 }

--- a/src/app/owners/secure/page.tsx
+++ b/src/app/owners/secure/page.tsx
@@ -222,21 +222,26 @@ function SgmSection() {
                 <dd>James Square owners</dd>
               </div>
             </dl>
-            <div className="mt-3 flex flex-wrap items-center gap-3 text-xs">
+          </div>
+          <div className="space-y-3">
+            <p className="text-xs font-semibold uppercase tracking-[0.18em] text-slate-500 dark:text-slate-300">
+              Add meeting to calendar
+            </p>
+            <div className="grid gap-3 sm:grid-cols-2">
               <a
                 href={GOOGLE_CALENDAR_URL}
                 target="_blank"
                 rel="noreferrer noopener"
-                className="font-medium text-slate-600 underline underline-offset-4 transition hover:text-slate-500 dark:text-slate-300 dark:hover:text-slate-200"
+                className="inline-flex items-center justify-center rounded-lg border border-black/10 bg-white/85 px-3 py-2 text-xs font-semibold text-slate-900 shadow-sm transition-all duration-200 hover:-translate-y-0.5 hover:shadow-md focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-slate-500 active:translate-y-[1px] dark:border-white/15 dark:bg-white/20 dark:text-white"
               >
-                Add meeting to calendar
+                Add to Google Calendar
               </a>
               <a
                 href={EGM_ICS_PATH}
                 download="james-square-egm-2026.ics"
-                className="text-slate-500 underline underline-offset-4 transition hover:text-slate-400 dark:text-slate-400 dark:hover:text-slate-300"
+                className="inline-flex items-center justify-center rounded-lg border border-black/10 bg-white/85 px-3 py-2 text-xs font-semibold text-slate-900 shadow-sm transition-all duration-200 hover:-translate-y-0.5 hover:shadow-md focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-slate-500 active:translate-y-[1px] dark:border-white/15 dark:bg-white/20 dark:text-white"
               >
-                Apple Calendar file
+                Add to Apple Calendar
               </a>
             </div>
           </div>
@@ -314,21 +319,26 @@ function SgmSection() {
               <dd>James Square owners</dd>
             </div>
           </dl>
-          <div className="mt-3 flex flex-wrap items-center gap-3 text-xs">
+        </div>
+        <div className="space-y-3">
+          <p className="text-xs font-semibold uppercase tracking-[0.18em] text-slate-500 dark:text-slate-300">
+            Add meeting to calendar
+          </p>
+          <div className="grid gap-3 sm:grid-cols-2">
             <a
               href={GOOGLE_CALENDAR_URL}
               target="_blank"
               rel="noreferrer noopener"
-              className="font-medium text-slate-600 underline underline-offset-4 transition hover:text-slate-500 dark:text-slate-300 dark:hover:text-slate-200"
+              className="inline-flex items-center justify-center rounded-lg border border-black/10 bg-white/85 px-3 py-2 text-xs font-semibold text-slate-900 shadow-sm transition-all duration-200 hover:-translate-y-0.5 hover:shadow-md focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-slate-500 active:translate-y-[1px] dark:border-white/15 dark:bg-white/20 dark:text-white"
             >
-              Add meeting to calendar
+              Add to Google Calendar
             </a>
             <a
               href={EGM_ICS_PATH}
               download="james-square-egm-2026.ics"
-              className="text-slate-500 underline underline-offset-4 transition hover:text-slate-400 dark:text-slate-400 dark:hover:text-slate-300"
+              className="inline-flex items-center justify-center rounded-lg border border-black/10 bg-white/85 px-3 py-2 text-xs font-semibold text-slate-900 shadow-sm transition-all duration-200 hover:-translate-y-0.5 hover:shadow-md focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-slate-500 active:translate-y-[1px] dark:border-white/15 dark:bg-white/20 dark:text-white"
             >
-              Apple Calendar file
+              Add to Apple Calendar
             </a>
           </div>
         </div>

--- a/src/app/owners/secure/page.tsx
+++ b/src/app/owners/secure/page.tsx
@@ -1,5 +1,6 @@
 'use client';
 
+import Image from 'next/image';
 import Link from 'next/link';
 import { useRouter } from 'next/navigation';
 import { useEffect, useState, type ReactNode } from 'react';
@@ -12,6 +13,18 @@ import GradientBG from '@/components/GradientBG';
 const OWNERS_ACCESS_KEY = 'owners_secure_access';
 const EGM_END = new Date('2026-01-21T20:30:00Z');
 const VOTING_DEADLINE = new Date('2026-01-23T23:59:00Z');
+const EGM_TITLE = 'James Square – Extraordinary General Meeting';
+const EGM_PAGE_URL = 'https://www.james-square.com/egm';
+const EGM_TEAMS_LINK =
+  'https://teams.microsoft.com/l/meetup-join/19%3ameeting_ZjI4NmMzZjYtYmI3OS00ZDk3LTg1ZDgtNGE5NDI3YmExNzA1%40thread.v2/0?context=%7b%22Tid%22%3a%22f5c44b19-1c42-4ad7-b10e-1d2fcf2b71d3%22%2c%22Oid%22%3a%2290c27962-4d1a-4d45-8e9e-ff0f7b30452b%22%7d';
+const EGM_DESCRIPTION =
+  'This meeting has been arranged for owners to discuss and vote on a potential change to the property factor for James Square. Join via Microsoft Teams.';
+const GOOGLE_CALENDAR_URL = `https://calendar.google.com/calendar/render?action=TEMPLATE&text=${encodeURIComponent(
+  EGM_TITLE,
+)}&dates=20260121T180000Z/20260121T203000Z&details=${encodeURIComponent(
+  `${EGM_DESCRIPTION}\n\nMicrosoft Teams: ${EGM_TEAMS_LINK}\nEGM details: ${EGM_PAGE_URL}`,
+)}&location=${encodeURIComponent('Microsoft Teams')}`;
+const EGM_ICS_PATH = '/calendar/james-square-egm-2026.ics';
 
 const glassPanel =
   'rounded-2xl border border-white/40 bg-white/65 p-4 shadow-sm backdrop-blur dark:border-white/10 dark:bg-white/5';
@@ -156,44 +169,81 @@ function SgmSection() {
         titleClassName="text-2xl font-semibold text-slate-900 dark:text-slate-100"
         className={egmCardClassName}
       >
-        {votingClosed ? (
-          <>
-            <p className="text-xs font-semibold uppercase tracking-[0.2em] text-slate-500 dark:text-slate-300">
-              Voting closed – outcome pending
-            </p>
-            <p className="text-sm md:text-base text-slate-700 dark:text-slate-200">Voting has now closed.</p>
-            <p className="text-sm md:text-base text-slate-700 dark:text-slate-200">
-              The outcome of the vote and any next steps will be shared with owners once confirmed.
-            </p>
-          </>
-        ) : (
-          <>
-            <p className="text-xs font-semibold uppercase tracking-[0.2em] text-slate-500 dark:text-slate-300">
-              Meeting concluded
-            </p>
-            <p className="text-sm md:text-base text-slate-700 dark:text-slate-200">
-              The Extraordinary General Meeting held on Wednesday 21 January 2026 has now taken place.
-            </p>
-            <p className="text-sm md:text-base text-slate-700 dark:text-slate-200">
-              Owners are now invited to vote on which property factor they believe would be best for James Square.
-            </p>
-            <div className="space-y-2">
-              <Link
-                href="https://www.james-square.com/voting"
+        <div className="space-y-6 rounded-2xl border border-slate-200/70 bg-white/70 p-6 shadow-sm dark:border-white/10 dark:bg-white/5">
+          {votingClosed ? (
+            <>
+              <p className="text-xs font-semibold uppercase tracking-[0.2em] text-slate-500 dark:text-slate-300">
+                Voting closed – outcome pending
+              </p>
+              <p className="text-sm md:text-base text-slate-700 dark:text-slate-200">Voting has now closed.</p>
+              <p className="text-sm md:text-base text-slate-700 dark:text-slate-200">
+                The outcome of the vote and any next steps will be shared with owners once confirmed.
+              </p>
+            </>
+          ) : (
+            <>
+              <p className="text-xs font-semibold uppercase tracking-[0.2em] text-slate-500 dark:text-slate-300">
+                Meeting concluded
+              </p>
+              <p className="text-sm md:text-base text-slate-700 dark:text-slate-200">
+                The Extraordinary General Meeting held on Wednesday 21 January 2026 has now taken place.
+              </p>
+              <p className="text-sm md:text-base text-slate-700 dark:text-slate-200">
+                Owners are now invited to vote on which property factor they believe would be best for James Square.
+              </p>
+              <div className="space-y-2">
+                <Link
+                  href="https://www.james-square.com/voting"
+                  target="_blank"
+                  rel="noreferrer noopener"
+                  className="inline-flex items-center justify-center rounded-full px-5 py-2.5 text-sm font-semibold text-white bg-slate-900 shadow-[0_6px_18px_rgba(0,0,0,0.18)] transition-all duration-200 hover:-translate-y-0.5 hover:scale-[1.01] hover:shadow-[0_10px_28px_rgba(0,0,0,0.2)] focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-slate-500 active:translate-y-[1px] dark:bg-white dark:text-slate-900"
+                >
+                  Place your vote
+                </Link>
+                <p className="text-xs text-slate-500 dark:text-slate-300">Voting will close on Friday 23 January 2026.</p>
+              </div>
+            </>
+          )}
+          <div className={glassPanel}>
+            <dl className="grid grid-cols-1 gap-3 text-sm text-slate-800 dark:text-slate-100 sm:grid-cols-2 lg:grid-cols-4">
+              <div>
+                <dt className="font-semibold">Date</dt>
+                <dd>Wednesday 21 January 2026</dd>
+              </div>
+              <div>
+                <dt className="font-semibold">Time</dt>
+                <dd>From 18:00 (UK time)</dd>
+              </div>
+              <div>
+                <dt className="font-semibold">Format</dt>
+                <dd>Online via Microsoft Teams</dd>
+              </div>
+              <div>
+                <dt className="font-semibold">Audience</dt>
+                <dd>James Square owners</dd>
+              </div>
+            </dl>
+            <div className="mt-3 flex flex-wrap items-center gap-3 text-xs">
+              <a
+                href={GOOGLE_CALENDAR_URL}
                 target="_blank"
                 rel="noreferrer noopener"
-                className="inline-flex items-center justify-center rounded-full px-5 py-2.5 text-sm font-semibold text-white bg-slate-900 shadow-[0_6px_18px_rgba(0,0,0,0.18)] transition-all duration-200 hover:-translate-y-0.5 hover:scale-[1.01] hover:shadow-[0_10px_28px_rgba(0,0,0,0.2)] focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-slate-500 active:translate-y-[1px] dark:bg-white dark:text-slate-900"
+                className="font-medium text-slate-600 underline underline-offset-4 transition hover:text-slate-500 dark:text-slate-300 dark:hover:text-slate-200"
               >
-                Place your vote
-              </Link>
-              <p className="text-xs text-slate-500 dark:text-slate-300">Voting will close on Friday 23 January 2026.</p>
+                Add meeting to calendar
+              </a>
+              <a
+                href={EGM_ICS_PATH}
+                download="james-square-egm-2026.ics"
+                className="text-slate-500 underline underline-offset-4 transition hover:text-slate-400 dark:text-slate-400 dark:hover:text-slate-300"
+              >
+                Apple Calendar file
+              </a>
             </div>
-          </>
-        )}
-        <div className="space-y-4">
+          </div>
           <div className="grid gap-3 sm:grid-cols-2">
             <Link
-              href="https://teams.microsoft.com/l/meetup-join/19%3ameeting_ZjI4NmMzZjYtYmI3OS00ZDk3LTg1ZDgtNGE5NDI3YmExNzA1%40thread.v2/0?context=%7b%22Tid%22%3a%22f5c44b19-1c42-4ad7-b10e-1d2fcf2b71d3%22%2c%22Oid%22%3a%2290c27962-4d1a-4d45-8e9e-ff0f7b30452b%22%7d"
+              href={EGM_TEAMS_LINK}
               target="_blank"
               rel="noreferrer noopener"
               className="inline-flex items-center justify-center rounded-xl border border-black/10 bg-white/85 px-4 py-3 text-sm font-semibold text-slate-900 shadow-sm transition-all duration-200 hover:-translate-y-0.5 hover:shadow-lg focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-slate-500 active:translate-y-[1px] dark:border-white/15 dark:bg-white/20 dark:text-white"
@@ -201,26 +251,47 @@ function SgmSection() {
               Join Microsoft Teams meeting
             </Link>
             <Link
-              href="https://www.james-square.com/egm"
+              href={EGM_PAGE_URL}
               target="_blank"
               rel="noreferrer noopener"
               className="inline-flex items-center justify-center rounded-xl border border-black/10 bg-white/85 px-4 py-3 text-sm font-semibold text-slate-900 shadow-sm transition-all duration-200 hover:-translate-y-0.5 hover:shadow-lg focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-slate-500 active:translate-y-[1px] dark:border-white/15 dark:bg-white/20 dark:text-white"
             >
               View meeting details
             </Link>
-            <Link
-              href="/myreside"
-              className="inline-flex items-center justify-center rounded-xl border border-black/10 bg-white/85 px-4 py-3 text-sm font-semibold text-slate-900 shadow-sm transition-all duration-200 hover:-translate-y-0.5 hover:shadow-lg focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-slate-500 active:translate-y-[1px] dark:border-white/15 dark:bg-white/20 dark:text-white"
-            >
-              View Myreside factor info
-            </Link>
-            <Link
-              href="/newton"
-              className="inline-flex items-center justify-center rounded-xl border border-black/10 bg-white/85 px-4 py-3 text-sm font-semibold text-slate-900 shadow-sm transition-all duration-200 hover:-translate-y-0.5 hover:shadow-lg focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-slate-500 active:translate-y-[1px] dark:border-white/15 dark:bg-white/20 dark:text-white"
-            >
-              View Newton factor info
-            </Link>
+            <div className="flex flex-col items-center gap-2">
+              <Link
+                href="/myreside"
+                className="inline-flex w-full items-center justify-center rounded-xl border border-black/10 bg-white/85 px-4 py-3 text-sm font-semibold text-slate-900 shadow-sm transition-all duration-200 hover:-translate-y-0.5 hover:shadow-lg focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-slate-500 active:translate-y-[1px] dark:border-white/15 dark:bg-white/20 dark:text-white"
+              >
+                View Myreside Management information
+              </Link>
+              <Image
+                src="/images/logo/myreside-logo-removebg-preview.png"
+                alt="Myreside Management logo"
+                width={160}
+                height={40}
+                className="h-10 w-auto object-contain opacity-60"
+              />
+            </div>
+            <div className="flex flex-col items-center gap-2">
+              <Link
+                href="/newton"
+                className="inline-flex w-full items-center justify-center rounded-xl border border-black/10 bg-white/85 px-4 py-3 text-sm font-semibold text-slate-900 shadow-sm transition-all duration-200 hover:-translate-y-0.5 hover:shadow-lg focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-slate-500 active:translate-y-[1px] dark:border-white/15 dark:bg-white/20 dark:text-white"
+              >
+                View Newton Property Management information
+              </Link>
+              <Image
+                src="/images/logo/newton-logo-removebg-preview.png"
+                alt="Newton Property Management logo"
+                width={160}
+                height={40}
+                className="h-10 w-auto object-contain opacity-60"
+              />
+            </div>
           </div>
+          <p className="text-xs text-slate-500 dark:text-slate-300 text-center sm:text-left">
+            Proposal documents are provided for information only and may be updated ahead of the meeting.
+          </p>
           <div className="inline-flex flex-col gap-1 rounded-full border border-slate-200/80 bg-white/70 px-4 py-2 text-xs text-slate-600 dark:border-white/10 dark:bg-white/5 dark:text-slate-300">
             <span>Factor documentation is provided for information only.</span>
             <span>Proposals are initial and subject to clarification and update ahead of the meeting.</span>
@@ -237,36 +308,53 @@ function SgmSection() {
       titleClassName="text-2xl font-semibold text-slate-900 dark:text-slate-100"
       className={egmCardClassName}
     >
-      <p className="text-sm md:text-base text-slate-700 dark:text-slate-200">
-        This meeting has been arranged for owners to discuss and vote on a potential change to the property factor for
-        James Square. Owners are encouraged to review the information below in advance of the meeting.
-      </p>
+      <div className="space-y-6 rounded-2xl border border-slate-200/70 bg-white/70 p-6 shadow-sm dark:border-white/10 dark:bg-white/5">
+        <p className="text-sm md:text-base text-slate-700 dark:text-slate-200">
+          This meeting has been arranged for owners to discuss and vote on a potential change to the property factor for
+          James Square. Owners are encouraged to review the information below in advance of the meeting.
+        </p>
 
-      <div className={glassPanel}>
-        <dl className="grid grid-cols-1 gap-3 text-sm text-slate-800 dark:text-slate-100 sm:grid-cols-2 lg:grid-cols-4">
-          <div>
-            <dt className="font-semibold">Date</dt>
-            <dd>Wednesday 21 January 2026</dd>
+        <div className={glassPanel}>
+          <dl className="grid grid-cols-1 gap-3 text-sm text-slate-800 dark:text-slate-100 sm:grid-cols-2 lg:grid-cols-4">
+            <div>
+              <dt className="font-semibold">Date</dt>
+              <dd>Wednesday 21 January 2026</dd>
+            </div>
+            <div>
+              <dt className="font-semibold">Time</dt>
+              <dd>From 18:00 (UK time)</dd>
+            </div>
+            <div>
+              <dt className="font-semibold">Format</dt>
+              <dd>Online via Microsoft Teams</dd>
+            </div>
+            <div>
+              <dt className="font-semibold">Audience</dt>
+              <dd>James Square owners</dd>
+            </div>
+          </dl>
+          <div className="mt-3 flex flex-wrap items-center gap-3 text-xs">
+            <a
+              href={GOOGLE_CALENDAR_URL}
+              target="_blank"
+              rel="noreferrer noopener"
+              className="font-medium text-slate-600 underline underline-offset-4 transition hover:text-slate-500 dark:text-slate-300 dark:hover:text-slate-200"
+            >
+              Add meeting to calendar
+            </a>
+            <a
+              href={EGM_ICS_PATH}
+              download="james-square-egm-2026.ics"
+              className="text-slate-500 underline underline-offset-4 transition hover:text-slate-400 dark:text-slate-400 dark:hover:text-slate-300"
+            >
+              Apple Calendar file
+            </a>
           </div>
-          <div>
-            <dt className="font-semibold">Time</dt>
-            <dd>From 18:00 (UK time)</dd>
-          </div>
-          <div>
-            <dt className="font-semibold">Format</dt>
-            <dd>Online via Microsoft Teams</dd>
-          </div>
-          <div>
-            <dt className="font-semibold">Audience</dt>
-            <dd>James Square owners</dd>
-          </div>
-        </dl>
-      </div>
+        </div>
 
-      <div className="space-y-4">
         <div className="grid gap-3 sm:grid-cols-2">
           <Link
-            href="https://teams.microsoft.com/l/meetup-join/19%3ameeting_ZjI4NmMzZjYtYmI3OS00ZDk3LTg1ZDgtNGE5NDI3YmExNzA1%40thread.v2/0?context=%7b%22Tid%22%3a%22f5c44b19-1c42-4ad7-b10e-1d2fcf2b71d3%22%2c%22Oid%22%3a%2290c27962-4d1a-4d45-8e9e-ff0f7b30452b%22%7d"
+            href={EGM_TEAMS_LINK}
             target="_blank"
             rel="noreferrer noopener"
             className="inline-flex items-center justify-center rounded-xl border border-black/10 bg-white/85 px-4 py-3 text-sm font-semibold text-slate-900 shadow-sm transition-all duration-200 hover:-translate-y-0.5 hover:shadow-lg focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-slate-500 active:translate-y-[1px] dark:border-white/15 dark:bg-white/20 dark:text-white"
@@ -274,26 +362,47 @@ function SgmSection() {
             Join Microsoft Teams meeting
           </Link>
           <Link
-            href="https://www.james-square.com/egm"
+            href={EGM_PAGE_URL}
             target="_blank"
             rel="noreferrer noopener"
             className="inline-flex items-center justify-center rounded-xl border border-black/10 bg-white/85 px-4 py-3 text-sm font-semibold text-slate-900 shadow-sm transition-all duration-200 hover:-translate-y-0.5 hover:shadow-lg focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-slate-500 active:translate-y-[1px] dark:border-white/15 dark:bg-white/20 dark:text-white"
           >
             View meeting details
           </Link>
-          <Link
-            href="/myreside"
-            className="inline-flex items-center justify-center rounded-xl border border-black/10 bg-white/85 px-4 py-3 text-sm font-semibold text-slate-900 shadow-sm transition-all duration-200 hover:-translate-y-0.5 hover:shadow-lg focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-slate-500 active:translate-y-[1px] dark:border-white/15 dark:bg-white/20 dark:text-white"
-          >
-            View Myreside factor info
-          </Link>
-          <Link
-            href="/newton"
-            className="inline-flex items-center justify-center rounded-xl border border-black/10 bg-white/85 px-4 py-3 text-sm font-semibold text-slate-900 shadow-sm transition-all duration-200 hover:-translate-y-0.5 hover:shadow-lg focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-slate-500 active:translate-y-[1px] dark:border-white/15 dark:bg-white/20 dark:text-white"
-          >
-            View Newton factor info
-          </Link>
+          <div className="flex flex-col items-center gap-2">
+            <Link
+              href="/myreside"
+              className="inline-flex w-full items-center justify-center rounded-xl border border-black/10 bg-white/85 px-4 py-3 text-sm font-semibold text-slate-900 shadow-sm transition-all duration-200 hover:-translate-y-0.5 hover:shadow-lg focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-slate-500 active:translate-y-[1px] dark:border-white/15 dark:bg-white/20 dark:text-white"
+            >
+              View Myreside Management information
+            </Link>
+            <Image
+              src="/images/logo/myreside-logo-removebg-preview.png"
+              alt="Myreside Management logo"
+              width={160}
+              height={40}
+              className="h-10 w-auto object-contain opacity-60"
+            />
+          </div>
+          <div className="flex flex-col items-center gap-2">
+            <Link
+              href="/newton"
+              className="inline-flex w-full items-center justify-center rounded-xl border border-black/10 bg-white/85 px-4 py-3 text-sm font-semibold text-slate-900 shadow-sm transition-all duration-200 hover:-translate-y-0.5 hover:shadow-lg focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-slate-500 active:translate-y-[1px] dark:border-white/15 dark:bg-white/20 dark:text-white"
+            >
+              View Newton Property Management information
+            </Link>
+            <Image
+              src="/images/logo/newton-logo-removebg-preview.png"
+              alt="Newton Property Management logo"
+              width={160}
+              height={40}
+              className="h-10 w-auto object-contain opacity-60"
+            />
+          </div>
         </div>
+        <p className="text-xs text-slate-500 dark:text-slate-300 text-center sm:text-left">
+          Proposal documents are provided for information only and may be updated ahead of the meeting.
+        </p>
         <div className="inline-flex flex-col gap-1 rounded-full border border-slate-200/80 bg-white/70 px-4 py-2 text-xs text-slate-600 dark:border-white/10 dark:bg-white/5 dark:text-slate-300">
           <span>Factor documentation is provided for information only.</span>
           <span>Proposals are initial and subject to clarification and update ahead of the meeting.</span>

--- a/src/app/owners/secure/page.tsx
+++ b/src/app/owners/secure/page.tsx
@@ -114,10 +114,6 @@ const OwnersSecurePage = () => {
 
         <div className="space-y-6">
           <motion.div variants={itemVariants}>
-            <FactorReviewSection />
-          </motion.div>
-
-          <motion.div variants={itemVariants}>
             <SgmSection />
           </motion.div>
 
@@ -156,6 +152,7 @@ function SgmSection() {
     return (
       <GlassCard
         title="Extraordinary General Meeting (EGM)"
+        subtitle="Factor review and decision"
         titleClassName="text-2xl font-semibold text-slate-900 dark:text-slate-100"
         className={egmCardClassName}
       >
@@ -193,6 +190,42 @@ function SgmSection() {
             </div>
           </>
         )}
+        <div className="space-y-4">
+          <div className="grid gap-3 sm:grid-cols-2">
+            <Link
+              href="https://teams.microsoft.com/l/meetup-join/19%3ameeting_ZjI4NmMzZjYtYmI3OS00ZDk3LTg1ZDgtNGE5NDI3YmExNzA1%40thread.v2/0?context=%7b%22Tid%22%3a%22f5c44b19-1c42-4ad7-b10e-1d2fcf2b71d3%22%2c%22Oid%22%3a%2290c27962-4d1a-4d45-8e9e-ff0f7b30452b%22%7d"
+              target="_blank"
+              rel="noreferrer noopener"
+              className="inline-flex items-center justify-center rounded-xl border border-black/10 bg-white/85 px-4 py-3 text-sm font-semibold text-slate-900 shadow-sm transition-all duration-200 hover:-translate-y-0.5 hover:shadow-lg focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-slate-500 active:translate-y-[1px] dark:border-white/15 dark:bg-white/20 dark:text-white"
+            >
+              Join Microsoft Teams meeting
+            </Link>
+            <Link
+              href="https://www.james-square.com/egm"
+              target="_blank"
+              rel="noreferrer noopener"
+              className="inline-flex items-center justify-center rounded-xl border border-black/10 bg-white/85 px-4 py-3 text-sm font-semibold text-slate-900 shadow-sm transition-all duration-200 hover:-translate-y-0.5 hover:shadow-lg focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-slate-500 active:translate-y-[1px] dark:border-white/15 dark:bg-white/20 dark:text-white"
+            >
+              View meeting details
+            </Link>
+            <Link
+              href="/myreside"
+              className="inline-flex items-center justify-center rounded-xl border border-black/10 bg-white/85 px-4 py-3 text-sm font-semibold text-slate-900 shadow-sm transition-all duration-200 hover:-translate-y-0.5 hover:shadow-lg focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-slate-500 active:translate-y-[1px] dark:border-white/15 dark:bg-white/20 dark:text-white"
+            >
+              View Myreside factor info
+            </Link>
+            <Link
+              href="/newton"
+              className="inline-flex items-center justify-center rounded-xl border border-black/10 bg-white/85 px-4 py-3 text-sm font-semibold text-slate-900 shadow-sm transition-all duration-200 hover:-translate-y-0.5 hover:shadow-lg focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-slate-500 active:translate-y-[1px] dark:border-white/15 dark:bg-white/20 dark:text-white"
+            >
+              View Newton factor info
+            </Link>
+          </div>
+          <div className="inline-flex flex-col gap-1 rounded-full border border-slate-200/80 bg-white/70 px-4 py-2 text-xs text-slate-600 dark:border-white/10 dark:bg-white/5 dark:text-slate-300">
+            <span>Factor documentation is provided for information only.</span>
+            <span>Proposals are initial and subject to clarification and update ahead of the meeting.</span>
+          </div>
+        </div>
       </GlassCard>
     );
   }
@@ -200,16 +233,13 @@ function SgmSection() {
   return (
     <GlassCard
       title="Extraordinary General Meeting (EGM)"
-      subtitle="Wednesday 21 January 2026 • 6:00pm (online)"
+      subtitle="Factor review and decision"
       titleClassName="text-2xl font-semibold text-slate-900 dark:text-slate-100"
       className={egmCardClassName}
     >
       <p className="text-sm md:text-base text-slate-700 dark:text-slate-200">
-        An Extraordinary General Meeting has been arranged for owners at James Square to discuss and vote on a potential
-        change to the property factor.
-      </p>
-      <p className="text-sm md:text-base text-slate-700 dark:text-slate-200">
-        The meeting will be held online via Microsoft Teams to allow as many owners as possible to attend.
+        This meeting has been arranged for owners to discuss and vote on a potential change to the property factor for
+        James Square. Owners are encouraged to review the information below in advance of the meeting.
       </p>
 
       <div className={glassPanel}>
@@ -233,59 +263,41 @@ function SgmSection() {
         </dl>
       </div>
 
-      <div className="space-y-2">
-        <Link
-          href="https://teams.microsoft.com/l/meetup-join/19%3ameeting_ZjI4NmMzZjYtYmI3OS00ZDk3LTg1ZDgtNGE5NDI3YmExNzA1%40thread.v2/0?context=%7b%22Tid%22%3a%22f5c44b19-1c42-4ad7-b10e-1d2fcf2b71d3%22%2c%22Oid%22%3a%2290c27962-4d1a-4d45-8e9e-ff0f7b30452b%22%7d"
-          target="_blank"
-          rel="noreferrer noopener"
-          className="inline-flex items-center justify-center rounded-full px-5 py-2.5 text-sm font-semibold text-white bg-slate-900 shadow-[0_6px_18px_rgba(0,0,0,0.18)] transition-all duration-200 hover:-translate-y-0.5 hover:scale-[1.01] hover:shadow-[0_10px_28px_rgba(0,0,0,0.2)] focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-slate-500 active:translate-y-[1px] dark:bg-white dark:text-slate-900"
-        >
-          Join meeting on Microsoft Teams
-        </Link>
-        <Link
-          href="https://www.james-square.com/egm"
-          target="_blank"
-          rel="noreferrer noopener"
-          className="inline-flex items-center justify-center rounded-xl border border-black/10 bg-white/85 px-4 py-2 text-sm font-medium text-slate-900 shadow-sm transition-all duration-200 hover:-translate-y-0.5 hover:shadow-lg focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-slate-500 active:translate-y-[1px] dark:border-white/15 dark:bg-white/20 dark:text-white"
-        >
-          View full meeting details
-        </Link>
-        <p className="text-xs text-slate-500 dark:text-slate-300">
-          Calendar options and meeting details are also available at james-square.com/egm.
-        </p>
-      </div>
-    </GlassCard>
-  );
-}
-
-function FactorReviewSection() {
-  return (
-    <GlassCard
-      title="Factor review information"
-      titleClassName="text-2xl font-semibold text-slate-900 dark:text-slate-100"
-    >
-      <p className="text-sm md:text-base text-slate-700 dark:text-slate-200">
-        Access neutral information and documentation for each proposed factor ahead of the general meeting.
-      </p>
-      <div className="grid gap-4 sm:grid-cols-2">
-        <Link
-          href="/myreside"
-          className="group rounded-2xl border border-slate-200/80 bg-white/80 p-5 text-left text-sm font-semibold text-slate-900 shadow-sm transition hover:-translate-y-0.5 hover:shadow-md focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-cyan-500/60 dark:border-white/10 dark:bg-white/5 dark:text-white"
-        >
-          <p className="text-base font-semibold">View Myreside Management information</p>
-          <p className="mt-2 text-sm font-normal text-slate-600 dark:text-slate-300">
-            Review the Myreside proposal, caretaker approach, costs, and tender documentation.
-          </p>
-        </Link>
-        <Link
-          href="/newton"
-          className="group rounded-2xl border border-slate-200/80 bg-white/80 p-5 text-left text-sm font-semibold text-slate-900 shadow-sm transition hover:-translate-y-0.5 hover:shadow-md focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-cyan-500/60 dark:border-white/10 dark:bg-white/5 dark:text-white"
-        >
-          <p className="text-base font-semibold">View Newton Property Management information</p>
-          <p className="mt-2 text-sm font-normal text-slate-600 dark:text-slate-300">
-            Review the Newton proposal, caretaker approach, costs, and tender documentation.
-          </p>
-        </Link>
+      <div className="space-y-4">
+        <div className="grid gap-3 sm:grid-cols-2">
+          <Link
+            href="https://teams.microsoft.com/l/meetup-join/19%3ameeting_ZjI4NmMzZjYtYmI3OS00ZDk3LTg1ZDgtNGE5NDI3YmExNzA1%40thread.v2/0?context=%7b%22Tid%22%3a%22f5c44b19-1c42-4ad7-b10e-1d2fcf2b71d3%22%2c%22Oid%22%3a%2290c27962-4d1a-4d45-8e9e-ff0f7b30452b%22%7d"
+            target="_blank"
+            rel="noreferrer noopener"
+            className="inline-flex items-center justify-center rounded-xl border border-black/10 bg-white/85 px-4 py-3 text-sm font-semibold text-slate-900 shadow-sm transition-all duration-200 hover:-translate-y-0.5 hover:shadow-lg focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-slate-500 active:translate-y-[1px] dark:border-white/15 dark:bg-white/20 dark:text-white"
+          >
+            Join Microsoft Teams meeting
+          </Link>
+          <Link
+            href="https://www.james-square.com/egm"
+            target="_blank"
+            rel="noreferrer noopener"
+            className="inline-flex items-center justify-center rounded-xl border border-black/10 bg-white/85 px-4 py-3 text-sm font-semibold text-slate-900 shadow-sm transition-all duration-200 hover:-translate-y-0.5 hover:shadow-lg focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-slate-500 active:translate-y-[1px] dark:border-white/15 dark:bg-white/20 dark:text-white"
+          >
+            View meeting details
+          </Link>
+          <Link
+            href="/myreside"
+            className="inline-flex items-center justify-center rounded-xl border border-black/10 bg-white/85 px-4 py-3 text-sm font-semibold text-slate-900 shadow-sm transition-all duration-200 hover:-translate-y-0.5 hover:shadow-lg focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-slate-500 active:translate-y-[1px] dark:border-white/15 dark:bg-white/20 dark:text-white"
+          >
+            View Myreside factor info
+          </Link>
+          <Link
+            href="/newton"
+            className="inline-flex items-center justify-center rounded-xl border border-black/10 bg-white/85 px-4 py-3 text-sm font-semibold text-slate-900 shadow-sm transition-all duration-200 hover:-translate-y-0.5 hover:shadow-lg focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-slate-500 active:translate-y-[1px] dark:border-white/15 dark:bg-white/20 dark:text-white"
+          >
+            View Newton factor info
+          </Link>
+        </div>
+        <div className="inline-flex flex-col gap-1 rounded-full border border-slate-200/80 bg-white/70 px-4 py-2 text-xs text-slate-600 dark:border-white/10 dark:bg-white/5 dark:text-slate-300">
+          <span>Factor documentation is provided for information only.</span>
+          <span>Proposals are initial and subject to clarification and update ahead of the meeting.</span>
+        </div>
       </div>
     </GlassCard>
   );

--- a/src/app/owners/secure/page.tsx
+++ b/src/app/owners/secure/page.tsx
@@ -1,6 +1,5 @@
 'use client';
 
-import Image from 'next/image';
 import Link from 'next/link';
 import { useRouter } from 'next/navigation';
 import { useEffect, useState, type ReactNode } from 'react';
@@ -258,36 +257,18 @@ function SgmSection() {
             >
               View meeting details
             </Link>
-            <div className="flex flex-col items-center gap-2">
-              <Link
-                href="/myreside"
-                className="inline-flex w-full items-center justify-center rounded-xl border border-black/10 bg-white/85 px-4 py-3 text-sm font-semibold text-slate-900 shadow-sm transition-all duration-200 hover:-translate-y-0.5 hover:shadow-lg focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-slate-500 active:translate-y-[1px] dark:border-white/15 dark:bg-white/20 dark:text-white"
-              >
-                View Myreside Management information
-              </Link>
-              <Image
-                src="/images/logo/myreside-logo-removebg-preview.png"
-                alt="Myreside Management logo"
-                width={160}
-                height={40}
-                className="h-10 w-auto object-contain opacity-60"
-              />
-            </div>
-            <div className="flex flex-col items-center gap-2">
-              <Link
-                href="/newton"
-                className="inline-flex w-full items-center justify-center rounded-xl border border-black/10 bg-white/85 px-4 py-3 text-sm font-semibold text-slate-900 shadow-sm transition-all duration-200 hover:-translate-y-0.5 hover:shadow-lg focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-slate-500 active:translate-y-[1px] dark:border-white/15 dark:bg-white/20 dark:text-white"
-              >
-                View Newton Property Management information
-              </Link>
-              <Image
-                src="/images/logo/newton-logo-removebg-preview.png"
-                alt="Newton Property Management logo"
-                width={160}
-                height={40}
-                className="h-10 w-auto object-contain opacity-60"
-              />
-            </div>
+            <Link
+              href="/myreside"
+              className="inline-flex items-center justify-center rounded-xl border border-black/10 bg-white/85 px-4 py-3 text-sm font-semibold text-slate-900 shadow-sm transition-all duration-200 hover:-translate-y-0.5 hover:shadow-lg focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-slate-500 active:translate-y-[1px] dark:border-white/15 dark:bg-white/20 dark:text-white"
+            >
+              View Myreside Management information
+            </Link>
+            <Link
+              href="/newton"
+              className="inline-flex items-center justify-center rounded-xl border border-black/10 bg-white/85 px-4 py-3 text-sm font-semibold text-slate-900 shadow-sm transition-all duration-200 hover:-translate-y-0.5 hover:shadow-lg focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-slate-500 active:translate-y-[1px] dark:border-white/15 dark:bg-white/20 dark:text-white"
+            >
+              View Newton Property Management information
+            </Link>
           </div>
           <p className="text-xs text-slate-500 dark:text-slate-300 text-center sm:text-left">
             Proposal documents are provided for information only and may be updated ahead of the meeting.
@@ -352,9 +333,9 @@ function SgmSection() {
           </div>
         </div>
 
-        <div className="grid gap-3 sm:grid-cols-2">
-          <Link
-            href={EGM_TEAMS_LINK}
+          <div className="grid gap-3 sm:grid-cols-2">
+            <Link
+              href={EGM_TEAMS_LINK}
             target="_blank"
             rel="noreferrer noopener"
             className="inline-flex items-center justify-center rounded-xl border border-black/10 bg-white/85 px-4 py-3 text-sm font-semibold text-slate-900 shadow-sm transition-all duration-200 hover:-translate-y-0.5 hover:shadow-lg focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-slate-500 active:translate-y-[1px] dark:border-white/15 dark:bg-white/20 dark:text-white"
@@ -366,40 +347,22 @@ function SgmSection() {
             target="_blank"
             rel="noreferrer noopener"
             className="inline-flex items-center justify-center rounded-xl border border-black/10 bg-white/85 px-4 py-3 text-sm font-semibold text-slate-900 shadow-sm transition-all duration-200 hover:-translate-y-0.5 hover:shadow-lg focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-slate-500 active:translate-y-[1px] dark:border-white/15 dark:bg-white/20 dark:text-white"
-          >
-            View meeting details
-          </Link>
-          <div className="flex flex-col items-center gap-2">
+            >
+              View meeting details
+            </Link>
             <Link
               href="/myreside"
-              className="inline-flex w-full items-center justify-center rounded-xl border border-black/10 bg-white/85 px-4 py-3 text-sm font-semibold text-slate-900 shadow-sm transition-all duration-200 hover:-translate-y-0.5 hover:shadow-lg focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-slate-500 active:translate-y-[1px] dark:border-white/15 dark:bg-white/20 dark:text-white"
+              className="inline-flex items-center justify-center rounded-xl border border-black/10 bg-white/85 px-4 py-3 text-sm font-semibold text-slate-900 shadow-sm transition-all duration-200 hover:-translate-y-0.5 hover:shadow-lg focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-slate-500 active:translate-y-[1px] dark:border-white/15 dark:bg-white/20 dark:text-white"
             >
               View Myreside Management information
             </Link>
-            <Image
-              src="/images/logo/myreside-logo-removebg-preview.png"
-              alt="Myreside Management logo"
-              width={160}
-              height={40}
-              className="h-10 w-auto object-contain opacity-60"
-            />
-          </div>
-          <div className="flex flex-col items-center gap-2">
             <Link
               href="/newton"
-              className="inline-flex w-full items-center justify-center rounded-xl border border-black/10 bg-white/85 px-4 py-3 text-sm font-semibold text-slate-900 shadow-sm transition-all duration-200 hover:-translate-y-0.5 hover:shadow-lg focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-slate-500 active:translate-y-[1px] dark:border-white/15 dark:bg-white/20 dark:text-white"
+              className="inline-flex items-center justify-center rounded-xl border border-black/10 bg-white/85 px-4 py-3 text-sm font-semibold text-slate-900 shadow-sm transition-all duration-200 hover:-translate-y-0.5 hover:shadow-lg focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-slate-500 active:translate-y-[1px] dark:border-white/15 dark:bg-white/20 dark:text-white"
             >
               View Newton Property Management information
             </Link>
-            <Image
-              src="/images/logo/newton-logo-removebg-preview.png"
-              alt="Newton Property Management logo"
-              width={160}
-              height={40}
-              className="h-10 w-auto object-contain opacity-60"
-            />
           </div>
-        </div>
         <p className="text-xs text-slate-500 dark:text-slate-300 text-center sm:text-left">
           Proposal documents are provided for information only and may be updated ahead of the meeting.
         </p>

--- a/src/components/FactorInfoPage.tsx
+++ b/src/components/FactorInfoPage.tsx
@@ -12,12 +12,9 @@ type FactorInfoPageProps = {
   logoSrc: string;
   logoAlt: string;
   managementTitle: string;
-  managementPoints: string[];
-  caretakerTitle: string;
-  caretakerIntro: string;
-  caretakerPoints: string[];
-  communicationPoints: string[];
-  costs: string[];
+  managementText: string;
+  communicationText: string;
+  costs: Array<{ label: string; value: string }>;
   documentationHref: string;
   documentationLabel: string;
 };
@@ -29,19 +26,16 @@ const FactorInfoPage = ({
   logoSrc,
   logoAlt,
   managementTitle,
-  managementPoints,
-  caretakerTitle,
-  caretakerIntro,
-  caretakerPoints,
-  communicationPoints,
+  managementText,
+  communicationText,
   costs,
   documentationHref,
   documentationLabel,
 }: FactorInfoPageProps) => {
   return (
     <GradientBG className="relative isolate min-h-screen w-screen -ml-[calc((100vw-100%)/2)] -mr-[calc((100vw-100%)/2)] px-4 md:px-8 py-12">
-      <div className="relative mx-auto max-w-5xl px-2 sm:px-4 md:px-0 space-y-8">
-        <header className="pt-5 md:pt-6 space-y-4 md:space-y-5 text-center md:text-left">
+      <div className="relative mx-auto max-w-5xl px-2 sm:px-4 md:px-0 space-y-10">
+        <header className="pt-5 md:pt-6 space-y-4 md:space-y-6 text-center md:text-left">
           <div className="flex flex-col items-center gap-4 md:flex-row md:items-center md:gap-6">
             <Image
               src={logoSrc}
@@ -51,7 +45,7 @@ const FactorInfoPage = ({
               className="h-20 w-auto object-contain"
               priority
             />
-            <div className="space-y-1">
+            <div className="space-y-2">
               <h1 className="text-3xl md:text-4xl font-semibold text-neutral-900 dark:text-white">{title}</h1>
               <p className="text-sm md:text-base text-slate-600 dark:text-slate-300">{subtitle}</p>
             </div>
@@ -61,36 +55,21 @@ const FactorInfoPage = ({
 
         <div className="space-y-6">
           <GlassCard title={managementTitle} titleClassName="text-2xl font-semibold text-slate-900 dark:text-slate-100">
-            <ul className="list-disc space-y-2 pl-5 text-sm md:text-base text-slate-700 dark:text-slate-200">
-              {managementPoints.map((point) => (
-                <li key={point}>{point}</li>
-              ))}
-            </ul>
-          </GlassCard>
-
-          <GlassCard title={caretakerTitle} titleClassName="text-2xl font-semibold text-slate-900 dark:text-slate-100">
-            <p className="text-sm md:text-base text-slate-700 dark:text-slate-200">{caretakerIntro}</p>
-            <ul className="list-disc space-y-2 pl-5 text-sm md:text-base text-slate-700 dark:text-slate-200">
-              {caretakerPoints.map((point) => (
-                <li key={point}>{point}</li>
-              ))}
-            </ul>
+            <p className="text-sm md:text-base text-slate-700 dark:text-slate-200">{managementText}</p>
           </GlassCard>
 
           <GlassCard title="Communication & maintenance" titleClassName="text-2xl font-semibold text-slate-900 dark:text-slate-100">
-            <ul className="list-disc space-y-2 pl-5 text-sm md:text-base text-slate-700 dark:text-slate-200">
-              {communicationPoints.map((point) => (
-                <li key={point}>{point}</li>
-              ))}
-            </ul>
+            <p className="text-sm md:text-base text-slate-700 dark:text-slate-200">{communicationText}</p>
           </GlassCard>
 
           <GlassCard title="Costs summary" titleClassName="text-2xl font-semibold text-slate-900 dark:text-slate-100">
-            <ul className="list-disc space-y-2 pl-5 text-sm md:text-base text-slate-700 dark:text-slate-200">
+            <div className="space-y-2 text-sm md:text-base text-slate-700 dark:text-slate-200">
               {costs.map((cost) => (
-                <li key={cost}>{cost}</li>
+                <p key={cost.label}>
+                  <span className="font-semibold text-slate-900 dark:text-slate-100">{cost.label}</span> {cost.value}
+                </p>
               ))}
-            </ul>
+            </div>
           </GlassCard>
 
           <GlassCard title="Documentation" titleClassName="text-2xl font-semibold text-slate-900 dark:text-slate-100">
@@ -102,6 +81,7 @@ const FactorInfoPage = ({
             >
               {documentationLabel}
             </a>
+            <p className="text-xs text-slate-500 dark:text-slate-300">This document is provided for information only.</p>
           </GlassCard>
 
           <div className="rounded-2xl border border-slate-200/80 bg-slate-50/80 p-6 shadow-sm dark:border-white/10 dark:bg-white/5">

--- a/src/components/FactorInfoPage.tsx
+++ b/src/components/FactorInfoPage.tsx
@@ -1,0 +1,120 @@
+'use client';
+
+import Image from 'next/image';
+
+import { GlassCard } from '@/components/GlassCard';
+import GradientBG from '@/components/GradientBG';
+
+type FactorInfoPageProps = {
+  title: string;
+  subtitle: string;
+  intro: string;
+  logoSrc: string;
+  logoAlt: string;
+  managementTitle: string;
+  managementPoints: string[];
+  caretakerTitle: string;
+  caretakerIntro: string;
+  caretakerPoints: string[];
+  communicationPoints: string[];
+  costs: string[];
+  documentationHref: string;
+  documentationLabel: string;
+};
+
+const FactorInfoPage = ({
+  title,
+  subtitle,
+  intro,
+  logoSrc,
+  logoAlt,
+  managementTitle,
+  managementPoints,
+  caretakerTitle,
+  caretakerIntro,
+  caretakerPoints,
+  communicationPoints,
+  costs,
+  documentationHref,
+  documentationLabel,
+}: FactorInfoPageProps) => {
+  return (
+    <GradientBG className="relative isolate min-h-screen w-screen -ml-[calc((100vw-100%)/2)] -mr-[calc((100vw-100%)/2)] px-4 md:px-8 py-12">
+      <div className="relative mx-auto max-w-5xl px-2 sm:px-4 md:px-0 space-y-8">
+        <header className="pt-5 md:pt-6 space-y-4 md:space-y-5 text-center md:text-left">
+          <div className="flex flex-col items-center gap-4 md:flex-row md:items-center md:gap-6">
+            <Image
+              src={logoSrc}
+              alt={logoAlt}
+              width={220}
+              height={80}
+              className="h-20 w-auto object-contain"
+              priority
+            />
+            <div className="space-y-1">
+              <h1 className="text-3xl md:text-4xl font-semibold text-neutral-900 dark:text-white">{title}</h1>
+              <p className="text-sm md:text-base text-slate-600 dark:text-slate-300">{subtitle}</p>
+            </div>
+          </div>
+          <p className="max-w-3xl text-sm md:text-base text-slate-600 dark:text-slate-300">{intro}</p>
+        </header>
+
+        <div className="space-y-6">
+          <GlassCard title={managementTitle} titleClassName="text-2xl font-semibold text-slate-900 dark:text-slate-100">
+            <ul className="list-disc space-y-2 pl-5 text-sm md:text-base text-slate-700 dark:text-slate-200">
+              {managementPoints.map((point) => (
+                <li key={point}>{point}</li>
+              ))}
+            </ul>
+          </GlassCard>
+
+          <GlassCard title={caretakerTitle} titleClassName="text-2xl font-semibold text-slate-900 dark:text-slate-100">
+            <p className="text-sm md:text-base text-slate-700 dark:text-slate-200">{caretakerIntro}</p>
+            <ul className="list-disc space-y-2 pl-5 text-sm md:text-base text-slate-700 dark:text-slate-200">
+              {caretakerPoints.map((point) => (
+                <li key={point}>{point}</li>
+              ))}
+            </ul>
+          </GlassCard>
+
+          <GlassCard title="Communication & maintenance" titleClassName="text-2xl font-semibold text-slate-900 dark:text-slate-100">
+            <ul className="list-disc space-y-2 pl-5 text-sm md:text-base text-slate-700 dark:text-slate-200">
+              {communicationPoints.map((point) => (
+                <li key={point}>{point}</li>
+              ))}
+            </ul>
+          </GlassCard>
+
+          <GlassCard title="Costs summary" titleClassName="text-2xl font-semibold text-slate-900 dark:text-slate-100">
+            <ul className="list-disc space-y-2 pl-5 text-sm md:text-base text-slate-700 dark:text-slate-200">
+              {costs.map((cost) => (
+                <li key={cost}>{cost}</li>
+              ))}
+            </ul>
+          </GlassCard>
+
+          <GlassCard title="Documentation" titleClassName="text-2xl font-semibold text-slate-900 dark:text-slate-100">
+            <a
+              href={documentationHref}
+              className="inline-flex items-center text-sm font-semibold text-cyan-700 hover:text-cyan-600 dark:text-cyan-300 dark:hover:text-cyan-200"
+              target="_blank"
+              rel="noreferrer noopener"
+            >
+              {documentationLabel}
+            </a>
+          </GlassCard>
+
+          <div className="rounded-2xl border border-slate-200/80 bg-slate-50/80 p-6 shadow-sm dark:border-white/10 dark:bg-white/5">
+            <h2 className="text-base font-semibold text-slate-900 dark:text-slate-100">Important note</h2>
+            <p className="mt-2 text-sm text-slate-700 dark:text-slate-200">
+              The documents linked on this page are initial proposals provided for information only. They are subject to
+              clarification and change. Updated documents will be uploaded in due course ahead of the general meeting.
+            </p>
+          </div>
+        </div>
+      </div>
+    </GradientBG>
+  );
+};
+
+export default FactorInfoPage;


### PR DESCRIPTION
### Motivation
- Provide neutral, informational pages for two proposed property factors so owners can review proposals and documents ahead of the general meeting.
- Ensure both pages are identical in structure and styling and are accessible from the secure owners area while remaining public without authentication.
- Use existing logos and provide direct links to tender PDF documents for transparency. 
- Include a clearly visible, neutral disclaimer to emphasise that documents are preliminary.

### Description
- Add a reusable factor layout component at `src/components/FactorInfoPage.tsx` that implements the required sections, logo handling, documentation link and disclaimer. 
- Create two pages using the shared layout: `src/app/myreside/page.tsx` (Myreside Management) and `src/app/newton/page.tsx` (Newton Property Management) with the supplied content, logos and PDF links. 
- Update the owners secure area at `src/app/owners/secure/page.tsx` to add a `Factor review information` section that links equally to both pages. 
- Use existing site components and styling (`GlassCard`, `GradientBG`, `next/image`) and ensure logos are displayed with constrained height and maintained aspect ratio.

### Testing
- Started the dev server with `npm run dev -- --hostname 0.0.0.0 --port 3000`; pages compiled but requests resulted in a runtime `Firebase: Error (auth/invalid-api-key)` causing a `500` when rendering due to missing Firebase config. 
- Ran an automated Playwright script that successfully captured a screenshot of `/myreside` to `artifacts/myreside-page.png` (screenshot artifact available). 
- Observed Google Fonts download failures during compilation which caused fallback fonts to be used (build continued despite font fetch errors).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_695fe43c7cec8324b60171b7b1b65ab5)