### PR TITLE
Flatten EGM section layout and convert calendar links to buttons

### DIFF
--- a/src/app/myreside/page.tsx
+++ b/src/app/myreside/page.tsx
@@ -1,0 +1,34 @@
+import type { Metadata } from 'next';
+
+import FactorInfoPage from '@/components/FactorInfoPage';
+
+export const metadata: Metadata = {
+  title: 'Myreside Management | James Square',
+  description: 'Information for James Square owners about Myreside Management factoring proposal.',
+};
+
+const MyresidePage = () => {
+  return (
+    <FactorInfoPage
+      title="Myreside Management"
+      subtitle="Information for James Square owners"
+      intro="Myreside Management is an Edinburgh-based property factor with over 25 years’ experience managing residential developments across the city and surrounding areas. The company presents itself as a hands-on, relationship-led factor with strong director involvement."
+      logoSrc="/images/logo/myreside-logo-removebg-preview.png"
+      logoAlt="Myreside Management logo"
+      managementTitle="How Myreside would manage James Square"
+      managementText="Myreside Management operates a traditional factoring model, with an emphasis on in-house service delivery and regular site inspections. Their approach focuses on maintaining a close working relationship with the owners’ committee and dealing with issues in a practical and flexible manner rather than relying on rigid systems or processes."
+      communicationText="Communication would be handled directly through a named property manager, with issues raised by phone or email. Maintenance would be coordinated using Myreside’s internal teams or approved contractors, with committee involvement where appropriate and agreed."
+      costs={[
+        { label: 'Total annual budget:', value: 'approximately £179,000' },
+        { label: 'Approximate cost per flat:', value: 'around £1,740 per year (about £145 per month)' },
+        { label: 'Management fee:', value: '£150 plus VAT per flat per year' },
+        { label: 'Float required:', value: '£450 per flat (refundable)' },
+        { label: 'Insurance commission:', value: 'none taken' },
+      ]}
+      documentationHref="/images/venues/myreside-tender-doc.pdf"
+      documentationLabel="View Myreside tender documentation (PDF)"
+    />
+  );
+};
+
+export default MyresidePage;

--- a/src/app/newton/page.tsx
+++ b/src/app/newton/page.tsx
@@ -1,0 +1,34 @@
+import type { Metadata } from 'next';
+
+import FactorInfoPage from '@/components/FactorInfoPage';
+
+export const metadata: Metadata = {
+  title: 'Newton Property Management | James Square',
+  description: 'Information for James Square owners about Newton Property Management factoring proposal.',
+};
+
+const NewtonPage = () => {
+  return (
+    <FactorInfoPage
+      title="Newton Property Management"
+      subtitle="Information for James Square owners"
+      intro="Newton Property Management is an established Scottish property factor operating across multiple regions, including Edinburgh, Glasgow, Aberdeen, and Inverness. Newton manages a range of residential developments, including large and complex sites with shared facilities."
+      logoSrc="/images/logo/newton-logo-removebg-preview.png"
+      logoAlt="Newton Property Management logo"
+      managementTitle="How Newton would manage James Square"
+      managementText="Newton Property Management operates a structured, systems-based factoring model with defined processes for reporting, escalation, and oversight. Management would be delivered through a named property manager supported by centralised systems designed to provide consistency and visibility across maintenance and compliance matters."
+      communicationText="Maintenance issues would be logged, tracked, and assigned through Newton’s internal systems, with responsibility held by a named property manager. Progress would be monitored and escalated where required, with updates available to the committee as matters are progressed."
+      costs={[
+        { label: 'Total annual budget:', value: 'approximately £192,700' },
+        { label: 'Approximate cost per flat:', value: 'around £1,870 per year (about £156 per month)' },
+        { label: 'Management fee:', value: '£180 plus VAT per flat per year' },
+        { label: 'Float required:', value: '£300 per flat (refundable)' },
+        { label: 'Insurance:', value: 'potential savings identified' },
+      ]}
+      documentationHref="/images/venues/newton-tender-doc.pdf"
+      documentationLabel="View Newton tender documentation (PDF)"
+    />
+  );
+};
+
+export default NewtonPage;

--- a/src/app/owners/secure/page.tsx
+++ b/src/app/owners/secure/page.tsx
@@ -12,6 +12,18 @@ import GradientBG from '@/components/GradientBG';
 const OWNERS_ACCESS_KEY = 'owners_secure_access';
 const EGM_END = new Date('2026-01-21T20:30:00Z');
 const VOTING_DEADLINE = new Date('2026-01-23T23:59:00Z');
+const EGM_TITLE = 'James Square – Extraordinary General Meeting';
+const EGM_PAGE_URL = 'https://www.james-square.com/egm';
+const EGM_TEAMS_LINK =
+  'https://teams.microsoft.com/l/meetup-join/19%3ameeting_ZjI4NmMzZjYtYmI3OS00ZDk3LTg1ZDgtNGE5NDI3YmExNzA1%40thread.v2/0?context=%7b%22Tid%22%3a%22f5c44b19-1c42-4ad7-b10e-1d2fcf2b71d3%22%2c%22Oid%22%3a%2290c27962-4d1a-4d45-8e9e-ff0f7b30452b%22%7d';
+const EGM_DESCRIPTION =
+  'This meeting has been arranged for owners to discuss and vote on a potential change to the property factor for James Square. Join via Microsoft Teams.';
+const GOOGLE_CALENDAR_URL = `https://calendar.google.com/calendar/render?action=TEMPLATE&text=${encodeURIComponent(
+  EGM_TITLE,
+)}&dates=20260121T180000Z/20260121T203000Z&details=${encodeURIComponent(
+  `${EGM_DESCRIPTION}\n\nMicrosoft Teams: ${EGM_TEAMS_LINK}\nEGM details: ${EGM_PAGE_URL}`,
+)}&location=${encodeURIComponent('Microsoft Teams')}`;
+const EGM_ICS_PATH = '/calendar/james-square-egm-2026.ics';
 
 const glassPanel =
   'rounded-2xl border border-white/40 bg-white/65 p-4 shadow-sm backdrop-blur dark:border-white/10 dark:bg-white/5';
@@ -152,6 +164,7 @@ function SgmSection() {
     return (
       <GlassCard
         title="Extraordinary General Meeting (EGM)"
+        subtitle="Factor review and decision"
         titleClassName="text-2xl font-semibold text-slate-900 dark:text-slate-100"
         className={egmCardClassName}
       >
@@ -189,6 +202,72 @@ function SgmSection() {
             </div>
           </>
         )}
+        <div className="grid gap-4 text-sm text-slate-700 dark:text-slate-200 md:grid-cols-[140px_1fr]">
+          <div className="font-semibold text-slate-900 dark:text-slate-100">Date</div>
+          <div>Wednesday 21 January 2026</div>
+          <div className="font-semibold text-slate-900 dark:text-slate-100">Time</div>
+          <div>From 18:00 (UK time)</div>
+          <div className="font-semibold text-slate-900 dark:text-slate-100">Format</div>
+          <div>Online via Microsoft Teams</div>
+          <div className="font-semibold text-slate-900 dark:text-slate-100">Audience</div>
+          <div>James Square owners</div>
+        </div>
+        <div className="space-y-3">
+          <p className="text-xs font-semibold uppercase tracking-[0.18em] text-slate-500 dark:text-slate-300">
+            Add meeting to calendar
+          </p>
+          <div className="grid gap-3 sm:grid-cols-2">
+            <a
+              href={GOOGLE_CALENDAR_URL}
+              target="_blank"
+              rel="noreferrer noopener"
+              className="inline-flex items-center justify-center rounded-lg border border-slate-200/80 bg-white/80 px-3 py-2 text-xs font-semibold text-slate-700 shadow-sm transition-colors duration-150 ease-out hover:bg-white/95 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-slate-500 dark:border-white/10 dark:bg-white/10 dark:text-slate-200 dark:hover:bg-white/15"
+            >
+              Add to Google Calendar
+            </a>
+            <a
+              href={EGM_ICS_PATH}
+              download="james-square-egm-2026.ics"
+              className="inline-flex items-center justify-center rounded-lg border border-slate-200/80 bg-white/80 px-3 py-2 text-xs font-semibold text-slate-700 shadow-sm transition-colors duration-150 ease-out hover:bg-white/95 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-slate-500 dark:border-white/10 dark:bg-white/10 dark:text-slate-200 dark:hover:bg-white/15"
+            >
+              Add to Apple Calendar
+            </a>
+          </div>
+        </div>
+        <div className="grid gap-3 sm:grid-cols-2">
+          <Link
+            href={EGM_TEAMS_LINK}
+            target="_blank"
+            rel="noreferrer noopener"
+            className="inline-flex items-center justify-center rounded-xl border border-black/10 bg-white/85 px-4 py-3 text-sm font-semibold text-slate-900 shadow-sm transition-all duration-150 ease-out hover:bg-white/95 hover:shadow-md focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-slate-500 dark:border-white/15 dark:bg-white/20 dark:text-white dark:hover:bg-white/25"
+          >
+            Join Microsoft Teams meeting
+          </Link>
+          <Link
+            href={EGM_PAGE_URL}
+            target="_blank"
+            rel="noreferrer noopener"
+            className="inline-flex items-center justify-center rounded-xl border border-black/10 bg-white/85 px-4 py-3 text-sm font-semibold text-slate-900 shadow-sm transition-all duration-150 ease-out hover:bg-white/95 hover:shadow-md focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-slate-500 dark:border-white/15 dark:bg-white/20 dark:text-white dark:hover:bg-white/25"
+          >
+            View meeting details
+          </Link>
+          <Link
+            href="/myreside"
+            className="inline-flex items-center justify-center rounded-xl border border-black/10 bg-white/85 px-4 py-3 text-sm font-semibold text-slate-900 shadow-sm transition-all duration-150 ease-out hover:bg-white/95 hover:shadow-md focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-slate-500 dark:border-white/15 dark:bg-white/20 dark:text-white dark:hover:bg-white/25"
+          >
+            View Myreside Management information
+          </Link>
+          <Link
+            href="/newton"
+            className="inline-flex items-center justify-center rounded-xl border border-black/10 bg-white/85 px-4 py-3 text-sm font-semibold text-slate-900 shadow-sm transition-all duration-150 ease-out hover:bg-white/95 hover:shadow-md focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-slate-500 dark:border-white/15 dark:bg-white/20 dark:text-white dark:hover:bg-white/25"
+          >
+            View Newton Property Management information
+          </Link>
+        </div>
+        <p className="text-sm text-slate-500 dark:text-slate-300">
+          Factor documentation is provided for information only. Proposals are initial and subject to clarification and
+          update ahead of the meeting.
+        </p>
       </GlassCard>
     );
   }
@@ -196,60 +275,83 @@ function SgmSection() {
   return (
     <GlassCard
       title="Extraordinary General Meeting (EGM)"
-      subtitle="Wednesday 21 January 2026 • 6:00pm (online)"
+      subtitle="Factor review and decision"
       titleClassName="text-2xl font-semibold text-slate-900 dark:text-slate-100"
       className={egmCardClassName}
     >
       <p className="text-sm md:text-base text-slate-700 dark:text-slate-200">
-        An Extraordinary General Meeting has been arranged for owners at James Square to discuss and vote on a potential
-        change to the property factor.
-      </p>
-      <p className="text-sm md:text-base text-slate-700 dark:text-slate-200">
-        The meeting will be held online via Microsoft Teams to allow as many owners as possible to attend.
+        This meeting has been arranged for owners to discuss and vote on a potential change to the property factor for
+        James Square. Owners are encouraged to review the information below in advance of the meeting.
       </p>
 
-      <div className={glassPanel}>
-        <dl className="grid grid-cols-1 gap-3 text-sm text-slate-800 dark:text-slate-100 sm:grid-cols-2 lg:grid-cols-4">
-          <div>
-            <dt className="font-semibold">Date</dt>
-            <dd>Wednesday 21 January 2026</dd>
-          </div>
-          <div>
-            <dt className="font-semibold">Time</dt>
-            <dd>From 18:00 (UK time)</dd>
-          </div>
-          <div>
-            <dt className="font-semibold">Format</dt>
-            <dd>Online via Microsoft Teams</dd>
-          </div>
-          <div>
-            <dt className="font-semibold">Audience</dt>
-            <dd>James Square owners</dd>
-          </div>
-        </dl>
+      <div className="grid gap-4 text-sm text-slate-700 dark:text-slate-200 md:grid-cols-[140px_1fr]">
+        <div className="font-semibold text-slate-900 dark:text-slate-100">Date</div>
+        <div>Wednesday 21 January 2026</div>
+        <div className="font-semibold text-slate-900 dark:text-slate-100">Time</div>
+        <div>From 18:00 (UK time)</div>
+        <div className="font-semibold text-slate-900 dark:text-slate-100">Format</div>
+        <div>Online via Microsoft Teams</div>
+        <div className="font-semibold text-slate-900 dark:text-slate-100">Audience</div>
+        <div>James Square owners</div>
       </div>
 
-      <div className="space-y-2">
-        <Link
-          href="https://teams.microsoft.com/l/meetup-join/19%3ameeting_ZjI4NmMzZjYtYmI3OS00ZDk3LTg1ZDgtNGE5NDI3YmExNzA1%40thread.v2/0?context=%7b%22Tid%22%3a%22f5c44b19-1c42-4ad7-b10e-1d2fcf2b71d3%22%2c%22Oid%22%3a%2290c27962-4d1a-4d45-8e9e-ff0f7b30452b%22%7d"
-          target="_blank"
-          rel="noreferrer noopener"
-          className="inline-flex items-center justify-center rounded-full px-5 py-2.5 text-sm font-semibold text-white bg-slate-900 shadow-[0_6px_18px_rgba(0,0,0,0.18)] transition-all duration-200 hover:-translate-y-0.5 hover:scale-[1.01] hover:shadow-[0_10px_28px_rgba(0,0,0,0.2)] focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-slate-500 active:translate-y-[1px] dark:bg-white dark:text-slate-900"
-        >
-          Join meeting on Microsoft Teams
-        </Link>
-        <Link
-          href="https://www.james-square.com/egm"
-          target="_blank"
-          rel="noreferrer noopener"
-          className="inline-flex items-center justify-center rounded-xl border border-black/10 bg-white/85 px-4 py-2 text-sm font-medium text-slate-900 shadow-sm transition-all duration-200 hover:-translate-y-0.5 hover:shadow-lg focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-slate-500 active:translate-y-[1px] dark:border-white/15 dark:bg-white/20 dark:text-white"
-        >
-          View full meeting details
-        </Link>
-        <p className="text-xs text-slate-500 dark:text-slate-300">
-          Calendar options and meeting details are also available at james-square.com/egm.
+      <div className="space-y-3">
+        <p className="text-xs font-semibold uppercase tracking-[0.18em] text-slate-500 dark:text-slate-300">
+          Add meeting to calendar
         </p>
+        <div className="grid gap-3 sm:grid-cols-2">
+          <a
+            href={GOOGLE_CALENDAR_URL}
+            target="_blank"
+            rel="noreferrer noopener"
+            className="inline-flex items-center justify-center rounded-lg border border-slate-200/80 bg-white/80 px-3 py-2 text-xs font-semibold text-slate-700 shadow-sm transition-colors duration-150 ease-out hover:bg-white/95 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-slate-500 dark:border-white/10 dark:bg-white/10 dark:text-slate-200 dark:hover:bg-white/15"
+          >
+            Add to Google Calendar
+          </a>
+          <a
+            href={EGM_ICS_PATH}
+            download="james-square-egm-2026.ics"
+            className="inline-flex items-center justify-center rounded-lg border border-slate-200/80 bg-white/80 px-3 py-2 text-xs font-semibold text-slate-700 shadow-sm transition-colors duration-150 ease-out hover:bg-white/95 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-slate-500 dark:border-white/10 dark:bg-white/10 dark:text-slate-200 dark:hover:bg-white/15"
+          >
+            Add to Apple Calendar
+          </a>
+        </div>
       </div>
+
+      <div className="grid gap-3 sm:grid-cols-2">
+        <Link
+          href={EGM_TEAMS_LINK}
+          target="_blank"
+          rel="noreferrer noopener"
+          className="inline-flex items-center justify-center rounded-xl border border-black/10 bg-white/85 px-4 py-3 text-sm font-semibold text-slate-900 shadow-sm transition-all duration-150 ease-out hover:bg-white/95 hover:shadow-md focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-slate-500 dark:border-white/15 dark:bg-white/20 dark:text-white dark:hover:bg-white/25"
+        >
+          Join Microsoft Teams meeting
+        </Link>
+        <Link
+          href={EGM_PAGE_URL}
+          target="_blank"
+          rel="noreferrer noopener"
+          className="inline-flex items-center justify-center rounded-xl border border-black/10 bg-white/85 px-4 py-3 text-sm font-semibold text-slate-900 shadow-sm transition-all duration-150 ease-out hover:bg-white/95 hover:shadow-md focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-slate-500 dark:border-white/15 dark:bg-white/20 dark:text-white dark:hover:bg-white/25"
+        >
+          View meeting details
+        </Link>
+        <Link
+          href="/myreside"
+          className="inline-flex items-center justify-center rounded-xl border border-black/10 bg-white/85 px-4 py-3 text-sm font-semibold text-slate-900 shadow-sm transition-all duration-150 ease-out hover:bg-white/95 hover:shadow-md focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-slate-500 dark:border-white/15 dark:bg-white/20 dark:text-white dark:hover:bg-white/25"
+        >
+          View Myreside Management information
+        </Link>
+        <Link
+          href="/newton"
+          className="inline-flex items-center justify-center rounded-xl border border-black/10 bg-white/85 px-4 py-3 text-sm font-semibold text-slate-900 shadow-sm transition-all duration-150 ease-out hover:bg-white/95 hover:shadow-md focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-slate-500 dark:border-white/15 dark:bg-white/20 dark:text-white dark:hover:bg-white/25"
+        >
+          View Newton Property Management information
+        </Link>
+      </div>
+      <p className="text-sm text-slate-500 dark:text-slate-300">
+        Factor documentation is provided for information only. Proposals are initial and subject to clarification and
+        update ahead of the meeting.
+      </p>
     </GlassCard>
   );
 }

--- a/src/components/FactorInfoPage.tsx
+++ b/src/components/FactorInfoPage.tsx
@@ -1,0 +1,100 @@
+'use client';
+
+import Image from 'next/image';
+
+import { GlassCard } from '@/components/GlassCard';
+import GradientBG from '@/components/GradientBG';
+
+type FactorInfoPageProps = {
+  title: string;
+  subtitle: string;
+  intro: string;
+  logoSrc: string;
+  logoAlt: string;
+  managementTitle: string;
+  managementText: string;
+  communicationText: string;
+  costs: Array<{ label: string; value: string }>;
+  documentationHref: string;
+  documentationLabel: string;
+};
+
+const FactorInfoPage = ({
+  title,
+  subtitle,
+  intro,
+  logoSrc,
+  logoAlt,
+  managementTitle,
+  managementText,
+  communicationText,
+  costs,
+  documentationHref,
+  documentationLabel,
+}: FactorInfoPageProps) => {
+  return (
+    <GradientBG className="relative isolate min-h-screen w-screen -ml-[calc((100vw-100%)/2)] -mr-[calc((100vw-100%)/2)] px-4 md:px-8 py-12">
+      <div className="relative mx-auto max-w-5xl px-2 sm:px-4 md:px-0 space-y-10">
+        <header className="pt-5 md:pt-6 space-y-4 md:space-y-6 text-center md:text-left">
+          <div className="flex flex-col items-center gap-4 md:flex-row md:items-center md:gap-6">
+            <Image
+              src={logoSrc}
+              alt={logoAlt}
+              width={220}
+              height={80}
+              className="h-20 w-auto object-contain"
+              priority
+            />
+            <div className="space-y-2">
+              <h1 className="text-3xl md:text-4xl font-semibold text-neutral-900 dark:text-white">{title}</h1>
+              <p className="text-sm md:text-base text-slate-600 dark:text-slate-300">{subtitle}</p>
+            </div>
+          </div>
+          <p className="max-w-3xl text-sm md:text-base text-slate-600 dark:text-slate-300">{intro}</p>
+        </header>
+
+        <div className="space-y-6">
+          <GlassCard title={managementTitle} titleClassName="text-2xl font-semibold text-slate-900 dark:text-slate-100">
+            <p className="text-sm md:text-base text-slate-700 dark:text-slate-200">{managementText}</p>
+          </GlassCard>
+
+          <GlassCard title="Communication & maintenance" titleClassName="text-2xl font-semibold text-slate-900 dark:text-slate-100">
+            <p className="text-sm md:text-base text-slate-700 dark:text-slate-200">{communicationText}</p>
+          </GlassCard>
+
+          <GlassCard title="Costs summary" titleClassName="text-2xl font-semibold text-slate-900 dark:text-slate-100">
+            <div className="space-y-2 text-sm md:text-base text-slate-700 dark:text-slate-200">
+              {costs.map((cost) => (
+                <p key={cost.label}>
+                  <span className="font-semibold text-slate-900 dark:text-slate-100">{cost.label}</span> {cost.value}
+                </p>
+              ))}
+            </div>
+          </GlassCard>
+
+          <GlassCard title="Documentation" titleClassName="text-2xl font-semibold text-slate-900 dark:text-slate-100">
+            <a
+              href={documentationHref}
+              className="inline-flex items-center text-sm font-semibold text-cyan-700 hover:text-cyan-600 dark:text-cyan-300 dark:hover:text-cyan-200"
+              target="_blank"
+              rel="noreferrer noopener"
+            >
+              {documentationLabel}
+            </a>
+            <p className="text-xs text-slate-500 dark:text-slate-300">This document is provided for information only.</p>
+          </GlassCard>
+
+          <div className="rounded-2xl border border-slate-200/80 bg-slate-50/80 p-6 shadow-sm dark:border-white/10 dark:bg-white/5">
+            <h2 className="text-base font-semibold text-slate-900 dark:text-slate-100">Important note</h2>
+            <p className="mt-2 text-sm text-slate-700 dark:text-slate-200">
+              The documents linked on this page are initial proposals provided for information only. They are subject to
+              clarification and change. Updated documents will be uploaded in due course ahead of the general meeting.
+            </p>
+          </div>
+        </div>
+      </div>
+    </GradientBG>
+  );
+};
+
+export default FactorInfoPage;


### PR DESCRIPTION
### Motivation
- Remove the visual "box inside box" nesting so the EGM reads as a single editorial section rather than a subordinate widget.
- Surface meeting metadata as a simple label/value grid with clear hierarchy and generous spacing.
- Make calendar actions discoverable and usable by replacing plain links with two secondary buttons for Google and Apple calendars.
- Consolidate and de-duplicate disclaimer text into one muted line at the bottom of the EGM block.

### Description
- Flattened the EGM flow in `src/app/owners/secure/page.tsx` by removing nested inner panels and presenting the section top-to-bottom (heading → intro → details grid → calendar buttons → primary actions → disclaimer). 
- Replaced the boxed meeting details with a responsive two-column label/value grid and moved calendar actions to two small secondary buttons (`GOOGLE_CALENDAR_URL`, `EGM_ICS_PATH`) immediately beneath the details. 
- Reworked the primary actions into a clean 2×2 grid (desktop) / stacked (mobile) of equal buttons linking to `EGM_TEAMS_LINK`, `EGM_PAGE_URL`, `/myreside`, and `/newton` with simplified styling and no icons. 
- Added a reusable `FactorInfoPage` component and new pages `src/app/myreside/page.tsx` and `src/app/newton/page.tsx` to surface factor information pages referenced from the EGM actions.

### Testing
- Started the dev server with `npm run dev -- --hostname 0.0.0.0 --port 3000`; the app compiled but server-side runtime errors occurred due to Firebase auth configuration and Google Fonts download failures. 
- Executed a Playwright script to load `/owners/secure` and capture a full-page screenshot which produced `artifacts/owners-secure-egm-flat.png` (screenshot generation succeeded despite the runtime warnings/errors). 
- Observed runtime `Firebase: Error (auth/invalid-api-key)` preventing authenticated data paths during local dev, but static UI rendering compiled. 
- No unit tests were added for these UI/markup changes.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_695fe43c7cec8324b60171b7b1b65ab5)