### PR TITLE
Fix motion easing type and polish iPhone-first onboarding UI

### DIFF
--- a/src/app/how-to-app/page.tsx
+++ b/src/app/how-to-app/page.tsx
@@ -4,6 +4,7 @@ import Link from 'next/link';
 import Image from 'next/image';
 import { AnimatePresence, motion, useReducedMotion } from 'framer-motion';
 import { useState } from 'react';
+import FocusHighlight from '@/components/FocusHighlight';
 
 const iPhoneSteps = [
   {
@@ -38,6 +39,14 @@ const androidSteps = [
   'Tap the menu (three dots) in the top-right corner.',
   'Tap Add to Home screen or Install app.',
   'Confirm when prompted.',
+];
+
+const focusHighlights = [
+  { top: '87%', left: '90%', size: 44, label: 'Menu' },
+  { top: '58%', left: '50%', size: 56, label: 'Share' },
+  { top: '72%', left: '50%', size: 58 },
+  { top: '6%', left: '88%', size: 44, label: 'Add' },
+  { top: '32%', left: '50%', size: 64 },
 ];
 
 export default function HowToAppPage() {
@@ -160,6 +169,7 @@ export default function HowToAppPage() {
                             height={520}
                             className="h-auto w-full rounded-xl border border-black/5"
                           />
+                          <FocusHighlight {...focusHighlights[index]} isActive={isActive} />
                         </motion.div>
                         <motion.div
                           className="space-y-2"

--- a/src/app/how-to-app/page.tsx
+++ b/src/app/how-to-app/page.tsx
@@ -41,7 +41,7 @@ const androidSteps = [
   'Confirm when prompted.',
 ];
 
-export const IPHONE_FOCUS = [
+const IPHONE_FOCUS = [
   { x: '66%', y: '79%', size: 78, label: 'Menu', enterFrom: 'right' },
   { x: '42%', y: '48%', size: 82, label: 'Share', enterFrom: 'bottom' },
   { x: '50%', y: '79%', size: 92, enterFrom: 'top' },

--- a/src/app/how-to-app/page.tsx
+++ b/src/app/how-to-app/page.tsx
@@ -2,125 +2,201 @@
 
 import Link from 'next/link';
 import Image from 'next/image';
-import { motion } from 'framer-motion';
+import { AnimatePresence, motion, useReducedMotion } from 'framer-motion';
+import { useState } from 'react';
+
+const iPhoneSteps = [
+  {
+    title: 'Open Safari',
+    text: 'Go to www.james-square.com, then tap the three dots in the bottom-right corner.',
+    image: '/images/brands/step1-removebg-preview.png',
+  },
+  {
+    title: 'Tap Share',
+    text: 'From the menu, tap Share to open the iOS sharing options.',
+    image: '/images/brands/step2-removebg-preview.png',
+  },
+  {
+    title: 'Add to Home Screen',
+    text: 'Scroll down and tap Add to Home Screen.',
+    image: '/images/brands/step3-removebg-preview.png',
+  },
+  {
+    title: 'Confirm details',
+    text: 'Check the details and make sure Open as Web App is enabled, then tap Add.',
+    image: '/images/brands/step4-removebg-preview.png',
+  },
+  {
+    title: 'Launch James Square',
+    text: 'James Square will now appear on your home screen. Tap it to open like an app.',
+    image: '/images/brands/step5-removebg-preview.png',
+  },
+];
+
+const androidSteps = [
+  'Open James Square in Chrome.',
+  'Tap the menu (three dots) in the top-right corner.',
+  'Tap Add to Home screen or Install app.',
+  'Confirm when prompted.',
+];
 
 export default function HowToAppPage() {
-  const stepVariants = {
-    hidden: { opacity: 0, y: 6 },
-    show: { opacity: 1, y: 0 },
-  };
+  const shouldReduceMotion = useReducedMotion();
+  const [activeStep, setActiveStep] = useState(0);
+  const [isAndroidOpen, setIsAndroidOpen] = useState(false);
+  const progress = iPhoneSteps.length > 1 ? activeStep / (iPhoneSteps.length - 1) : 0;
+
+  const easedOut = [0.16, 1, 0.3, 1] as const;
+  const stepTransition = shouldReduceMotion ? { duration: 0 } : { duration: 0.45, ease: easedOut };
+  const delayedTransition = shouldReduceMotion
+    ? { duration: 0 }
+    : { duration: 0.4, ease: easedOut, delay: 0.07 };
 
   const sectionVariants = {
-    hidden: { opacity: 0, y: 10 },
+    hidden: { opacity: 0, y: shouldReduceMotion ? 0 : 10 },
     show: { opacity: 1, y: 0 },
   };
 
-  const containerVariants = {
-    hidden: {},
-    show: {
-      transition: {
-        staggerChildren: 0.08,
-      },
-    },
-  };
-
-  const iPhoneSteps = [
-    {
-      text: 'Open Safari and go to www.james-square.com, then tap the three dots in the bottom-right corner.',
-      image: '/images/brands/step1-removebg-preview.png',
-    },
-    {
-      text: 'From the menu, tap Share to open the iOS sharing options.',
-      image: '/images/brands/step2-removebg-preview.png',
-    },
-    {
-      text: 'Scroll down and tap Add to Home Screen.',
-      image: '/images/brands/step3-removebg-preview.png',
-    },
-    {
-      text: 'Check the details and make sure Open as Web App is enabled, then tap Add.',
-      image: '/images/brands/step4-removebg-preview.png',
-    },
-    {
-      text: 'James Square will now appear on your home screen. Tap it to open like an app.',
-      image: '/images/brands/step5-removebg-preview.png',
-    },
-  ];
-
-  const androidSteps = [
-    'Open James Square in Chrome.',
-    'Tap the menu (three dots) in the top-right corner.',
-    'Tap Add to Home screen or Install app.',
-    'Confirm when prompted.',
-  ];
-
   return (
-    <div className="mx-auto max-w-4xl px-4 pb-12 pt-10 sm:px-6 lg:px-8">
+    <div className="mx-auto max-w-5xl px-4 pb-[calc(3rem+env(safe-area-inset-bottom))] pt-[calc(2.5rem+env(safe-area-inset-top))] sm:px-6 lg:px-8">
       <motion.div
-        className="space-y-8 text-[color:var(--text-primary)]"
+        className="space-y-10 text-[color:var(--text-primary)]"
         initial="hidden"
         animate="show"
-        variants={containerVariants}
+        variants={{
+          hidden: {},
+          show: { transition: { staggerChildren: 0.1 } },
+        }}
       >
         {/* Header */}
-        <motion.header variants={sectionVariants} className="space-y-3">
+        <motion.header variants={sectionVariants} className="space-y-4">
           <p className="text-xs font-semibold uppercase tracking-[0.28em] text-[color:var(--muted)]">
-            Helpful guide
+            App-style setup
           </p>
-          <h1 className="text-3xl font-extrabold leading-tight sm:text-4xl">
-            Use James Square as an app on your phone
+          <h1 className="text-4xl font-semibold leading-tight tracking-tight sm:text-5xl sm:leading-tight">
+            Use James Square like a native app
           </h1>
-          <p className="text-[color:var(--text-secondary)]">
-            If you regularly use James Square on your phone, you can add it to your home screen and open it like an app.
-          </p>
-          <p className="text-[color:var(--text-secondary)]">
-            This does not install anything from an app store. It simply creates an app-style shortcut that opens James
-            Square full screen for quicker access.
-          </p>
+          <div className="space-y-3 text-[color:var(--text-secondary)]">
+            <p>
+              Add James Square to your home screen for a fast, full-screen experience that feels just like an app.
+            </p>
+            <p>
+              Nothing installs from an app store. You simply create a shortcut that opens James Square instantly.
+            </p>
+          </div>
         </motion.header>
 
         {/* iPhone section */}
         <motion.section
           variants={sectionVariants}
-          className="glass-surface glass-outline space-y-6 rounded-2xl border border-[color:var(--glass-border)] bg-white/60 p-5 sm:p-6"
+          className="glass-surface glass-outline space-y-8 rounded-2xl border border-[color:var(--glass-border)] bg-white/60 p-5 sm:p-7"
         >
-          <p className="text-[11px] font-semibold uppercase tracking-[0.28em] text-[color:var(--muted)]">
-            iPhone (Safari)
-          </p>
-          <h2 className="text-xl font-semibold">On iPhone</h2>
+          <div className="space-y-2">
+            <p className="text-[11px] font-semibold uppercase tracking-[0.28em] text-[color:var(--muted)]">
+              iPhone · Safari
+            </p>
+            <h2 className="text-2xl font-semibold">Your guided setup</h2>
+            <p className="text-sm text-[color:var(--text-secondary)]">
+              Follow each step to add James Square to your home screen.
+            </p>
+          </div>
 
-          <motion.ol variants={containerVariants} className="space-y-6">
-            {iPhoneSteps.map((step, index) => (
-              <motion.li
-                key={index}
-                variants={stepVariants}
-                className="flex flex-col gap-4 sm:flex-row sm:items-start sm:gap-6"
+          <div className="relative space-y-6">
+            <div className="absolute left-[11px] top-5 h-[calc(100%-2.5rem)] w-px bg-[color:var(--glass-border)]/70" />
+            <motion.div
+              className="absolute left-[11px] top-5 h-[calc(100%-2.5rem)] w-px origin-top bg-[color:var(--btn-bg)]/50"
+              animate={{ scaleY: progress }}
+              transition={stepTransition}
+            />
+            <div className="space-y-6">
+              {iPhoneSteps.map((step, index) => {
+                const isActive = index === activeStep;
+                const isPast = index < activeStep;
+                return (
+                  <motion.div
+                    key={step.title}
+                    className="grid grid-cols-[24px,1fr] items-start gap-4 sm:gap-6"
+                    initial="hidden"
+                    whileInView="show"
+                    viewport={{ amount: 0.5, once: true }}
+                    onViewportEnter={() => setActiveStep(index)}
+                  >
+                    <div className="relative flex h-full items-start justify-center pt-2 sm:pt-3">
+                      <div
+                        className={`flex h-6 w-6 items-center justify-center rounded-full border text-xs font-semibold transition-colors ${
+                          isActive
+                            ? 'border-[color:var(--btn-bg)] bg-[color:var(--btn-bg)] text-white'
+                            : isPast
+                              ? 'border-[color:var(--glass-border)]/70 bg-white/60 text-[color:var(--muted)]'
+                              : 'border-[color:var(--glass-border)] bg-white/40 text-[color:var(--text-secondary)]'
+                        }`}
+                      >
+                        {index + 1}
+                      </div>
+                    </div>
+                    <motion.div
+                      className={`glass-surface glass-outline rounded-2xl border border-[color:var(--glass-border)]/70 bg-white/70 p-4 shadow-sm transition-all duration-200 hover:-translate-y-0.5 hover:shadow-md active:scale-[0.99] sm:p-5 ${
+                        isPast ? 'opacity-70' : 'opacity-100'
+                      } ${isActive ? 'shadow-md' : ''}`}
+                      variants={{
+                        hidden: { opacity: 0, y: shouldReduceMotion ? 0 : 8 },
+                        show: { opacity: 1, y: 0 },
+                      }}
+                      transition={stepTransition}
+                    >
+                      <div className="flex flex-col gap-4 md:flex-row md:items-start md:gap-6">
+                        <motion.div
+                          className="relative w-full max-w-[260px] overflow-hidden rounded-2xl border border-white/60 bg-white/70 p-3 shadow-inner"
+                          variants={{
+                            hidden: { opacity: 0, scale: shouldReduceMotion ? 1 : 0.96 },
+                            show: { opacity: 1, scale: 1 },
+                          }}
+                          transition={stepTransition}
+                        >
+                          <Image
+                            src={step.image}
+                            alt={`Step ${index + 1} - ${step.title}`}
+                            width={260}
+                            height={520}
+                            className="h-auto w-full rounded-xl border border-black/5"
+                          />
+                        </motion.div>
+                        <motion.div
+                          className="space-y-2"
+                          variants={{
+                            hidden: { opacity: 0, y: shouldReduceMotion ? 0 : 6 },
+                            show: { opacity: 1, y: 0 },
+                          }}
+                          transition={delayedTransition}
+                        >
+                          <h3 className="text-lg font-semibold">{step.title}</h3>
+                          <p className="text-[color:var(--text-secondary)]">{step.text}</p>
+                        </motion.div>
+                      </div>
+                    </motion.div>
+                  </motion.div>
+                );
+              })}
+            </div>
+          </div>
+
+          <div className="glass-surface glass-outline flex items-center gap-3 rounded-2xl border border-[color:var(--glass-border)]/70 bg-white/60 p-4 text-sm text-[color:var(--text-secondary)] sm:p-5">
+            <span className="flex h-9 w-9 items-center justify-center rounded-full bg-emerald-500/10 text-emerald-600">
+              <svg
+                aria-hidden="true"
+                viewBox="0 0 20 20"
+                className="h-5 w-5"
+                fill="currentColor"
               >
-                {/* Step number */}
-                <span className="flex h-8 w-8 shrink-0 items-center justify-center rounded-full bg-[color:var(--btn-bg)]/10 text-sm font-semibold">
-                  {index + 1}
-                </span>
-
-                {/* Image + text */}
-                <div className="flex flex-1 flex-col gap-3">
-                  <div className="relative w-full max-w-[260px]">
-                    <Image
-                      src={step.image}
-                      alt={`Step ${index + 1}`}
-                      width={260}
-                      height={520}
-                      className="rounded-xl border border-black/5"
-                    />
-                  </div>
-                  <p className="text-[color:var(--text-secondary)]">{step.text}</p>
-                </div>
-              </motion.li>
-            ))}
-          </motion.ol>
-
-          <p className="text-sm text-[color:var(--text-secondary)]">
-            Once added, James Square opens full screen and behaves like a dedicated app.
-          </p>
+                <path
+                  fillRule="evenodd"
+                  d="M16.704 5.29a1 1 0 0 1 0 1.42l-7.2 7.2a1 1 0 0 1-1.42 0l-3.6-3.6a1 1 0 1 1 1.42-1.42l2.89 2.89 6.49-6.49a1 1 0 0 1 1.42 0Z"
+                  clipRule="evenodd"
+                />
+              </svg>
+            </span>
+            <p>James Square will now open full screen like an app.</p>
+          </div>
         </motion.section>
 
         {/* Android section */}
@@ -128,21 +204,45 @@ export default function HowToAppPage() {
           variants={sectionVariants}
           className="glass-surface glass-outline space-y-4 rounded-2xl border border-[color:var(--glass-border)] bg-white/60 p-5 sm:p-6"
         >
-          <p className="text-[11px] font-semibold uppercase tracking-[0.28em] text-[color:var(--muted)]">
-            Android (Chrome)
-          </p>
-          <h2 className="text-xl font-semibold">On Android</h2>
+          <div className="flex flex-wrap items-center justify-between gap-4">
+            <div className="space-y-2">
+              <p className="text-[11px] font-semibold uppercase tracking-[0.28em] text-[color:var(--muted)]">
+                Android · Chrome
+              </p>
+              <h2 className="text-xl font-semibold">Android setup</h2>
+            </div>
+            <button
+              type="button"
+              onClick={() => setIsAndroidOpen((prev) => !prev)}
+              className="rounded-full border border-[color:var(--glass-border)]/70 bg-white/70 px-4 py-2 text-xs font-semibold uppercase tracking-[0.18em] text-[color:var(--text-secondary)] transition hover:bg-white/90"
+              aria-expanded={isAndroidOpen}
+            >
+              {isAndroidOpen ? 'Hide steps' : 'Show steps'}
+            </button>
+          </div>
 
-          <motion.ol variants={containerVariants} className="space-y-3">
-            {androidSteps.map((step, index) => (
-              <motion.li key={step} variants={stepVariants} className="flex items-start gap-3">
-                <span className="flex h-8 w-8 shrink-0 items-center justify-center rounded-full bg-[color:var(--btn-bg)]/10 text-sm font-semibold">
-                  {index + 1}
-                </span>
-                <p className="text-[color:var(--text-secondary)]">{step}</p>
-              </motion.li>
-            ))}
-          </motion.ol>
+          <AnimatePresence initial={false}>
+            {isAndroidOpen && (
+              <motion.div
+                initial={{ height: 0, opacity: 0 }}
+                animate={{ height: 'auto', opacity: 1 }}
+                exit={{ height: 0, opacity: 0 }}
+                transition={stepTransition}
+                className="overflow-hidden"
+              >
+                <ol className="space-y-3 pt-2 text-[color:var(--text-secondary)]">
+                  {androidSteps.map((step, index) => (
+                    <li key={step} className="flex items-start gap-3 text-sm">
+                      <span className="flex h-7 w-7 shrink-0 items-center justify-center rounded-full border border-[color:var(--glass-border)] bg-white/60 text-xs font-semibold text-[color:var(--muted)]">
+                        {index + 1}
+                      </span>
+                      <span>{step}</span>
+                    </li>
+                  ))}
+                </ol>
+              </motion.div>
+            )}
+          </AnimatePresence>
         </motion.section>
 
         {/* Reassurance */}

--- a/src/app/how-to-app/page.tsx
+++ b/src/app/how-to-app/page.tsx
@@ -42,11 +42,11 @@ const androidSteps = [
 ];
 
 export const IPHONE_FOCUS = [
-  { x: '66%', y: '79%', size: 78, label: 'Menu' },
-  { x: '42%', y: '48%', size: 82, label: 'Share' },
-  { x: '50%', y: '79%', size: 92 },
-  { x: '77%', y: '14%', size: 82, label: 'Add' },
-  { x: '72%', y: '58%', size: 68 },
+  { x: '66%', y: '79%', size: 78, label: 'Menu', enterFrom: 'right' },
+  { x: '42%', y: '48%', size: 82, label: 'Share', enterFrom: 'bottom' },
+  { x: '50%', y: '79%', size: 92, enterFrom: 'top' },
+  { x: '77%', y: '14%', size: 82, label: 'Add', enterFrom: 'right' },
+  { x: '72%', y: '58%', size: 68, enterFrom: 'left' },
 ];
 
 export default function HowToAppPage() {

--- a/src/app/how-to-app/page.tsx
+++ b/src/app/how-to-app/page.tsx
@@ -41,12 +41,12 @@ const androidSteps = [
   'Confirm when prompted.',
 ];
 
-const focusHighlights = [
-  { top: '87%', left: '90%', size: 44, label: 'Menu' },
-  { top: '58%', left: '50%', size: 56, label: 'Share' },
-  { top: '72%', left: '50%', size: 58 },
-  { top: '6%', left: '88%', size: 44, label: 'Add' },
-  { top: '32%', left: '50%', size: 64 },
+export const IPHONE_FOCUS = [
+  { x: '66%', y: '79%', size: 78, label: 'Menu' },
+  { x: '42%', y: '48%', size: 82, label: 'Share' },
+  { x: '50%', y: '79%', size: 92 },
+  { x: '77%', y: '14%', size: 82, label: 'Add' },
+  { x: '72%', y: '58%', size: 68 },
 ];
 
 export default function HowToAppPage() {
@@ -169,7 +169,7 @@ export default function HowToAppPage() {
                             height={520}
                             className="h-auto w-full rounded-xl border border-black/5"
                           />
-                          <FocusHighlight {...focusHighlights[index]} isActive={isActive} />
+                          <FocusHighlight {...IPHONE_FOCUS[index]} isActive={isActive} />
                         </motion.div>
                         <motion.div
                           className="space-y-2"

--- a/src/components/FocusHighlight.tsx
+++ b/src/components/FocusHighlight.tsx
@@ -8,6 +8,7 @@ export interface FocusHighlightProps {
   size?: number;
   label?: string;
   isActive?: boolean;
+  enterFrom?: 'left' | 'right' | 'top' | 'bottom';
 }
 
 export default function FocusHighlight({
@@ -16,10 +17,26 @@ export default function FocusHighlight({
   size = 44,
   label,
   isActive = false,
+  enterFrom = 'left',
 }: FocusHighlightProps) {
   const shouldReduceMotion = useReducedMotion();
   const showPulse = isActive && !shouldReduceMotion;
   const glowOpacity = showPulse ? [0.35, 0.6, 0.35] : 0.4;
+  const entryOffset = 28;
+  const entryDelta =
+    enterFrom === 'right'
+      ? { x: entryOffset, y: 0 }
+      : enterFrom === 'top'
+        ? { x: 0, y: -entryOffset }
+        : enterFrom === 'bottom'
+          ? { x: 0, y: entryOffset }
+          : { x: -entryOffset, y: 0 };
+  const entryTransition = showPulse
+    ? { duration: 0.6, ease: [0.22, 1, 0.36, 1] }
+    : { duration: 0 };
+  const pulseTransition = showPulse
+    ? { duration: 1.6, ease: [0.45, 0, 0.25, 1], repeat: 2, delay: 0.3 }
+    : { duration: 0 };
 
   return (
     <div
@@ -36,37 +53,32 @@ export default function FocusHighlight({
       <motion.div
         className="absolute flex items-center justify-center"
         style={{ top: y, left: x, transform: 'translate(-50%, -50%)' }}
-        initial={{ opacity: 0, scale: shouldReduceMotion ? 1 : 0.98 }}
-        animate={
-          showPulse
-            ? {
-                opacity: 1,
-                scale: [1, 1.04, 1],
-              }
-            : { opacity: 1, scale: 1 }
+        initial={
+          shouldReduceMotion
+            ? { opacity: 1, scale: 1, x: 0, y: 0 }
+            : { opacity: 0, scale: 0.94, x: entryDelta.x, y: entryDelta.y }
         }
-        transition={
-          showPulse
-            ? { duration: 1.6, ease: [0.45, 0, 0.25, 1], repeat: 2 }
-            : { duration: 0 }
-        }
+        animate={{ opacity: 1, scale: 1, x: 0, y: 0 }}
+        transition={entryTransition}
       >
         <motion.div
-          className="absolute rounded-full bg-white/30 blur-lg"
+          className="absolute rounded-full bg-white/35 blur-xl"
           style={{ width: size * 1.4, height: size * 1.4 }}
           animate={showPulse ? { opacity: glowOpacity } : { opacity: glowOpacity }}
-          transition={showPulse ? { duration: 1.6, ease: [0.45, 0, 0.25, 1], repeat: 2 } : { duration: 0 }}
+          transition={pulseTransition}
         />
-        <div
+        <motion.div
           className="relative rounded-full border-2 border-white/85 bg-white/10 shadow-[0_0_16px_rgba(255,255,255,0.35)]"
           style={{ width: size, height: size }}
+          animate={showPulse ? { scale: [1, 1.03, 1] } : { scale: 1 }}
+          transition={pulseTransition}
         >
           <motion.span
             className="absolute left-1/2 top-1/2 h-2 w-2 -translate-x-1/2 -translate-y-1/2 rounded-full bg-white/70"
             animate={showPulse ? { scale: [1, 1.2, 1], opacity: [0.6, 0.9, 0.6] } : { scale: 1, opacity: 0.7 }}
-            transition={showPulse ? { duration: 1.6, ease: [0.45, 0, 0.25, 1], repeat: 2 } : { duration: 0 }}
+            transition={pulseTransition}
           />
-        </div>
+        </motion.div>
       </motion.div>
       {label ? (
         <div

--- a/src/components/FocusHighlight.tsx
+++ b/src/components/FocusHighlight.tsx
@@ -3,51 +3,76 @@
 import { motion, useReducedMotion } from 'framer-motion';
 
 export interface FocusHighlightProps {
-  top: string;
-  left: string;
+  x: string;
+  y: string;
   size?: number;
   label?: string;
   isActive?: boolean;
 }
 
 export default function FocusHighlight({
-  top,
-  left,
+  x,
+  y,
   size = 44,
   label,
   isActive = false,
 }: FocusHighlightProps) {
   const shouldReduceMotion = useReducedMotion();
   const showPulse = isActive && !shouldReduceMotion;
+  const glowOpacity = showPulse ? [0.35, 0.6, 0.35] : 0.4;
 
   return (
     <div
-      className="pointer-events-none absolute"
-      style={{ top, left, transform: 'translate(-50%, -50%)' }}
+      className="pointer-events-none absolute inset-0"
       aria-hidden="true"
     >
+      <div
+        className="absolute inset-0 rounded-[inherit] bg-black/20"
+        style={{
+          maskImage: `radial-gradient(circle ${size / 2}px at ${x} ${y}, transparent 55%, black 60%)`,
+          WebkitMaskImage: `radial-gradient(circle ${size / 2}px at ${x} ${y}, transparent 55%, black 60%)`,
+        }}
+      />
       <motion.div
-        className="relative flex items-center justify-center"
+        className="absolute flex items-center justify-center"
+        style={{ top: y, left: x, transform: 'translate(-50%, -50%)' }}
+        initial={{ opacity: 0, scale: shouldReduceMotion ? 1 : 0.98 }}
         animate={
           showPulse
             ? {
-                scale: [1, 1.05, 1],
+                opacity: 1,
+                scale: [1, 1.04, 1],
               }
-            : { scale: 1 }
+            : { opacity: 1, scale: 1 }
         }
         transition={
           showPulse
-            ? { duration: 1.8, repeat: Infinity, ease: [0.45, 0, 0.25, 1] }
+            ? { duration: 1.6, ease: [0.45, 0, 0.25, 1], repeat: 2 }
             : { duration: 0 }
         }
       >
-        <div
-          className="rounded-full border-2 border-white/80 bg-white/10 shadow-[0_0_18px_rgba(255,255,255,0.35)]"
-          style={{ width: size, height: size }}
+        <motion.div
+          className="absolute rounded-full bg-white/30 blur-lg"
+          style={{ width: size * 1.4, height: size * 1.4 }}
+          animate={showPulse ? { opacity: glowOpacity } : { opacity: glowOpacity }}
+          transition={showPulse ? { duration: 1.6, ease: [0.45, 0, 0.25, 1], repeat: 2 } : { duration: 0 }}
         />
+        <div
+          className="relative rounded-full border-2 border-white/85 bg-white/10 shadow-[0_0_16px_rgba(255,255,255,0.35)]"
+          style={{ width: size, height: size }}
+        >
+          <motion.span
+            className="absolute left-1/2 top-1/2 h-2 w-2 -translate-x-1/2 -translate-y-1/2 rounded-full bg-white/70"
+            animate={showPulse ? { scale: [1, 1.2, 1], opacity: [0.6, 0.9, 0.6] } : { scale: 1, opacity: 0.7 }}
+            transition={showPulse ? { duration: 1.6, ease: [0.45, 0, 0.25, 1], repeat: 2 } : { duration: 0 }}
+          />
+        </div>
       </motion.div>
       {label ? (
-        <div className="mt-2 text-[11px] font-semibold uppercase tracking-[0.2em] text-white/80 drop-shadow-sm">
+        <div
+          className="absolute mt-2 text-[11px] font-semibold uppercase tracking-[0.2em] text-white/85 drop-shadow-sm"
+          style={{ top: y, left: x, transform: 'translate(-50%, calc(-50% + 2.4rem))' }}
+        >
           {label}
         </div>
       ) : null}

--- a/src/components/FocusHighlight.tsx
+++ b/src/components/FocusHighlight.tsx
@@ -1,0 +1,56 @@
+'use client';
+
+import { motion, useReducedMotion } from 'framer-motion';
+
+export interface FocusHighlightProps {
+  top: string;
+  left: string;
+  size?: number;
+  label?: string;
+  isActive?: boolean;
+}
+
+export default function FocusHighlight({
+  top,
+  left,
+  size = 44,
+  label,
+  isActive = false,
+}: FocusHighlightProps) {
+  const shouldReduceMotion = useReducedMotion();
+  const showPulse = isActive && !shouldReduceMotion;
+
+  return (
+    <div
+      className="pointer-events-none absolute"
+      style={{ top, left, transform: 'translate(-50%, -50%)' }}
+      aria-hidden="true"
+    >
+      <motion.div
+        className="relative flex items-center justify-center"
+        animate={
+          showPulse
+            ? {
+                scale: [1, 1.05, 1],
+              }
+            : { scale: 1 }
+        }
+        transition={
+          showPulse
+            ? { duration: 1.8, repeat: Infinity, ease: [0.45, 0, 0.25, 1] }
+            : { duration: 0 }
+        }
+      >
+        <div
+          className="rounded-full border-2 border-white/80 bg-white/10 shadow-[0_0_18px_rgba(255,255,255,0.35)]"
+          style={{ width: size, height: size }}
+        />
+      </motion.div>
+      {label ? (
+        <div className="mt-2 text-[11px] font-semibold uppercase tracking-[0.2em] text-white/80 drop-shadow-sm">
+          {label}
+        </div>
+      ) : null}
+    </div>
+  );
+}


### PR DESCRIPTION
### Motivation
- Resolve a TypeScript build error caused by using a string easing (`'easeOut'`) in Framer Motion transitions. 
- Keep the guided, iPhone-first onboarding experience for `/how-to-app` while preserving reduced-motion behavior. 
- Improve visual hierarchy, safe-area handling, and step progression clarity with a progress rail and per-step animations. 
- Make Android instructions secondary and collapsible to keep focus on the iPhone flow.

### Description
- Replace string easing with a typed cubic-bezier array (`const easedOut = [0.16, 1, 0.3, 1] as const`) and apply it to `stepTransition` and `delayedTransition`, keeping `useReducedMotion` fallbacks. 
- Refactor `src/app/how-to-app/page.tsx` to add `useState` (`activeStep`, `isAndroidOpen`), a progress rail animated via `scaleY`, and per-step entry/image animations using `motion`. 
- Add `AnimatePresence` to animate the Android accordion, improve layout/copy, and add safe-area padding and subtle UI polish for step cards and completion state. 
- Minor variant and spacing adjustments to staging animations and container staggering for a smoother onboarding feel.

### Testing
- No automated unit or integration tests were executed for this change. 
- A TypeScript/Next build error previously reported for `page.tsx` (invalid `ease` type) is addressed by the easing type change and should resolve the CI build failure. 
- Changes were committed successfully to the branch; no CI build or visual verification was performed as part of this PR. 
- Manual/visual QA is recommended once the app is built or run locally to validate animations and layout in-browser.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6961326a171883249a4ee39fe94a20fa)