### PR TITLE
Rebuild how-to-add page with guided carousel and focus highlight

### DIFF
--- a/public/images/howto/step-1.svg
+++ b/public/images/howto/step-1.svg
@@ -1,0 +1,9 @@
+<svg width="750" height="1580" viewBox="0 0 750 1580" fill="none" xmlns="http://www.w3.org/2000/svg">
+  <rect width="750" height="1580" rx="80" fill="#F8FAFC"/>
+  <rect x="40" y="80" width="670" height="1420" rx="60" fill="#E2E8F0"/>
+  <rect x="120" y="220" width="510" height="80" rx="40" fill="#CBD5F5"/>
+  <rect x="120" y="360" width="420" height="40" rx="20" fill="#CBD5F5"/>
+  <rect x="120" y="430" width="360" height="40" rx="20" fill="#CBD5F5"/>
+  <text x="120" y="820" fill="#334155" font-family="Arial" font-size="54" font-weight="600">Open Safari</text>
+  <text x="120" y="900" fill="#64748B" font-family="Arial" font-size="36">Go to james-square.com</text>
+</svg>

--- a/public/images/howto/step-2.svg
+++ b/public/images/howto/step-2.svg
@@ -1,0 +1,11 @@
+<svg width="750" height="1580" viewBox="0 0 750 1580" fill="none" xmlns="http://www.w3.org/2000/svg">
+  <rect width="750" height="1580" rx="80" fill="#F8FAFC"/>
+  <rect x="40" y="80" width="670" height="1420" rx="60" fill="#E2E8F0"/>
+  <rect x="120" y="260" width="510" height="280" rx="40" fill="#CBD5F5"/>
+  <rect x="120" y="620" width="430" height="40" rx="20" fill="#CBD5F5"/>
+  <rect x="120" y="690" width="380" height="40" rx="20" fill="#CBD5F5"/>
+  <rect x="120" y="760" width="300" height="40" rx="20" fill="#CBD5F5"/>
+  <rect x="300" y="1320" width="150" height="80" rx="40" fill="#94A3B8"/>
+  <text x="120" y="1080" fill="#334155" font-family="Arial" font-size="52" font-weight="600">Tap Share</text>
+  <text x="120" y="1160" fill="#64748B" font-family="Arial" font-size="36">Use the share icon below</text>
+</svg>

--- a/public/images/howto/step-3.svg
+++ b/public/images/howto/step-3.svg
@@ -1,0 +1,11 @@
+<svg width="750" height="1580" viewBox="0 0 750 1580" fill="none" xmlns="http://www.w3.org/2000/svg">
+  <rect width="750" height="1580" rx="80" fill="#F8FAFC"/>
+  <rect x="40" y="80" width="670" height="1420" rx="60" fill="#E2E8F0"/>
+  <rect x="120" y="240" width="510" height="900" rx="40" fill="#CBD5F5"/>
+  <rect x="160" y="320" width="430" height="80" rx="32" fill="#94A3B8"/>
+  <rect x="160" y="440" width="380" height="60" rx="30" fill="#CBD5F5"/>
+  <rect x="160" y="520" width="360" height="60" rx="30" fill="#CBD5F5"/>
+  <rect x="160" y="600" width="340" height="60" rx="30" fill="#CBD5F5"/>
+  <text x="120" y="1220" fill="#334155" font-family="Arial" font-size="52" font-weight="600">Add to Home Screen</text>
+  <text x="120" y="1300" fill="#64748B" font-family="Arial" font-size="36">Select it from the list</text>
+</svg>

--- a/public/images/howto/step-4.svg
+++ b/public/images/howto/step-4.svg
@@ -1,0 +1,10 @@
+<svg width="750" height="1580" viewBox="0 0 750 1580" fill="none" xmlns="http://www.w3.org/2000/svg">
+  <rect width="750" height="1580" rx="80" fill="#F8FAFC"/>
+  <rect x="40" y="80" width="670" height="1420" rx="60" fill="#E2E8F0"/>
+  <rect x="120" y="260" width="510" height="220" rx="40" fill="#CBD5F5"/>
+  <rect x="120" y="520" width="430" height="60" rx="30" fill="#CBD5F5"/>
+  <rect x="120" y="610" width="320" height="60" rx="30" fill="#CBD5F5"/>
+  <rect x="520" y="190" width="140" height="60" rx="30" fill="#94A3B8"/>
+  <text x="120" y="1000" fill="#334155" font-family="Arial" font-size="52" font-weight="600">Name &amp; Add</text>
+  <text x="120" y="1080" fill="#64748B" font-family="Arial" font-size="36">Tap Add to finish</text>
+</svg>

--- a/src/app/how-to-add/page.tsx
+++ b/src/app/how-to-add/page.tsx
@@ -1,0 +1,28 @@
+import HowToCarousel from '@/components/howto/HowToCarousel';
+
+const HowToAddPage = () => {
+  return (
+    <main className="min-h-screen bg-slate-50 px-6 pb-16 pt-16 text-slate-900 md:px-12">
+      <div className="mx-auto flex w-full max-w-6xl flex-col gap-12">
+        <header className="max-w-2xl space-y-4">
+          <p className="text-xs font-semibold uppercase tracking-[0.3em] text-slate-400">How it works</p>
+          <h1 className="text-4xl font-semibold tracking-tight text-slate-900 md:text-5xl">
+            Add James Square to your Home Screen
+          </h1>
+          <p className="text-base leading-relaxed text-slate-600 md:text-lg">
+            Follow the guided steps below to save James Square like a real app. Each step is built to
+            keep you moving left to right, just like iOS.
+          </p>
+        </header>
+
+        <HowToCarousel />
+
+        <footer className="rounded-2xl border border-slate-200 bg-white px-6 py-4 text-sm text-slate-600 shadow-sm">
+          James Square will open full-screen like an app once it is saved to your Home Screen.
+        </footer>
+      </div>
+    </main>
+  );
+};
+
+export default HowToAddPage;

--- a/src/components/howto/FocusHighlight.tsx
+++ b/src/components/howto/FocusHighlight.tsx
@@ -1,0 +1,53 @@
+'use client';
+
+import { motion, useReducedMotion } from 'framer-motion';
+
+export type FocusHighlightProps = {
+  x: string;
+  y: string;
+  size: number;
+  className?: string;
+};
+
+const easeOutCubic: [number, number, number, number] = [0.33, 1, 0.68, 1];
+
+const FocusHighlight = ({ x, y, size, className }: FocusHighlightProps) => {
+  const prefersReducedMotion = useReducedMotion();
+
+  if (prefersReducedMotion) {
+    return (
+      <div
+        className={
+          className ??
+          'pointer-events-none absolute rounded-full border border-white/70 bg-white/15 shadow-[0_0_24px_rgba(59,130,246,0.45)]'
+        }
+        style={{ left: x, top: y, width: size, height: size, transform: 'translate(-50%, -50%)' }}
+      />
+    );
+  }
+
+  return (
+    <motion.div
+      initial={{ x: '-40%', opacity: 0, scale: 0.92 }}
+      animate={{ x: ['-40%', '6%', '0%'], opacity: [0, 1, 1], scale: [0.92, 1.05, 1] }}
+      transition={{ duration: 0.9, ease: easeOutCubic }}
+      className="pointer-events-none absolute"
+      style={{ left: x, top: y, transform: 'translate(-50%, -50%)' }}
+    >
+      <motion.div
+        animate={{ scale: [1, 1.06, 1] }}
+        transition={{ duration: 2.4, repeat: Infinity, ease: easeOutCubic }}
+        className={
+          className ??
+          'relative flex items-center justify-center rounded-full border border-white/70 bg-white/20 shadow-[0_0_30px_rgba(59,130,246,0.45)]'
+        }
+        style={{ width: size, height: size }}
+      >
+        <div className="absolute inset-2 rounded-full bg-white/25 backdrop-blur" />
+        <div className="absolute -inset-3 rounded-full bg-blue-400/20 blur-xl" />
+      </motion.div>
+    </motion.div>
+  );
+};
+
+export default FocusHighlight;

--- a/src/components/howto/HowToCarousel.tsx
+++ b/src/components/howto/HowToCarousel.tsx
@@ -1,0 +1,163 @@
+'use client';
+
+import { KeyboardEvent, useEffect, useMemo, useRef, useState } from 'react';
+import { motion, useReducedMotion } from 'framer-motion';
+import HowToStepCard, { HowToStep } from './HowToStepCard';
+
+const easeOutCubic: [number, number, number, number] = [0.33, 1, 0.68, 1];
+
+const HOW_TO_STEPS: HowToStep[] = [
+  {
+    id: 1,
+    title: 'Open Safari',
+    description: 'Go to www.james-square.com in Safari.',
+    image: '/images/howto/step-1.svg',
+  },
+  {
+    id: 2,
+    title: 'Tap Share',
+    description: 'Tap the share icon at the bottom of the screen.',
+    image: '/images/howto/step-2.svg',
+    focus: { x: '90%', y: '92%', size: 56 },
+  },
+  {
+    id: 3,
+    title: 'Add to Home Screen',
+    description: 'Select “Add to Home Screen” from the share sheet.',
+    image: '/images/howto/step-3.svg',
+    focus: { x: '50%', y: '54%', size: 64 },
+  },
+  {
+    id: 4,
+    title: 'Name & Add',
+    description: 'Confirm the name, then tap Add in the top-right corner.',
+    image: '/images/howto/step-4.svg',
+    focus: { x: '83%', y: '10%', size: 50 },
+  },
+];
+
+const HowToCarousel = () => {
+  const prefersReducedMotion = useReducedMotion();
+  const containerRef = useRef<HTMLDivElement | null>(null);
+  const cardRefs = useRef<(HTMLDivElement | null)[]>([]);
+  const [activeIndex, setActiveIndex] = useState(0);
+
+  const stepCount = HOW_TO_STEPS.length;
+
+  useEffect(() => {
+    const container = containerRef.current;
+    if (!container) return;
+
+    const observer = new IntersectionObserver(
+      (entries) => {
+        entries.forEach((entry) => {
+          if (entry.isIntersecting) {
+            const index = cardRefs.current.findIndex((node) => node === entry.target);
+            if (index >= 0) {
+              setActiveIndex(index);
+            }
+          }
+        });
+      },
+      { root: container, threshold: 0.6 },
+    );
+
+    cardRefs.current.forEach((card) => {
+      if (card) observer.observe(card);
+    });
+
+    return () => {
+      observer.disconnect();
+    };
+  }, []);
+
+  const scrollToStep = (index: number) => {
+    const container = containerRef.current;
+    const card = cardRefs.current[index];
+    if (!container || !card) return;
+
+    container.scrollTo({ left: card.offsetLeft, behavior: 'smooth' });
+  };
+
+  const handleArrowClick = (direction: 'prev' | 'next') => {
+    const nextIndex = direction === 'next' ? Math.min(activeIndex + 1, stepCount - 1) : Math.max(activeIndex - 1, 0);
+    scrollToStep(nextIndex);
+  };
+
+  const handleKeyDown = (event: KeyboardEvent<HTMLDivElement>) => {
+    if (event.key === 'ArrowRight') {
+      event.preventDefault();
+      handleArrowClick('next');
+    }
+    if (event.key === 'ArrowLeft') {
+      event.preventDefault();
+      handleArrowClick('prev');
+    }
+  };
+
+  const motionProps = useMemo(
+    () => ({
+      initial: { opacity: 0, y: 16 },
+      animate: { opacity: 1, y: 0 },
+      transition: prefersReducedMotion ? { duration: 0 } : { duration: 0.5, ease: easeOutCubic },
+    }),
+    [prefersReducedMotion],
+  );
+
+  return (
+    <section aria-label="How to add James Square to your home screen" className="relative">
+      <div className="hidden lg:flex items-center justify-end gap-3 pb-4">
+        <button
+          type="button"
+          onClick={() => handleArrowClick('prev')}
+          className="rounded-full border border-slate-200 bg-white px-4 py-2 text-sm font-semibold text-slate-700 shadow-sm transition hover:-translate-y-0.5 hover:bg-slate-50 focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-slate-800"
+          aria-label="Scroll to previous step"
+        >
+          Back
+        </button>
+        <button
+          type="button"
+          onClick={() => handleArrowClick('next')}
+          className="rounded-full border border-slate-200 bg-slate-900 px-4 py-2 text-sm font-semibold text-white shadow-sm transition hover:-translate-y-0.5 hover:bg-slate-800 focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-slate-800"
+          aria-label="Scroll to next step"
+        >
+          Next
+        </button>
+      </div>
+
+      <motion.div
+        {...motionProps}
+        ref={containerRef}
+        tabIndex={0}
+        onKeyDown={handleKeyDown}
+        className="flex gap-6 overflow-x-auto scroll-smooth px-2 pb-6 pt-1 outline-none snap-x snap-mandatory lg:gap-8 lg:px-1"
+      >
+        {HOW_TO_STEPS.map((step, index) => (
+          <div
+            key={step.id}
+            ref={(node) => {
+              cardRefs.current[index] = node;
+            }}
+            className="flex"
+          >
+            <HowToStepCard step={step} isActive={index === activeIndex} />
+          </div>
+        ))}
+      </motion.div>
+
+      <div className="mt-2 flex items-center justify-center gap-2 text-xs text-slate-500 lg:justify-start">
+        {HOW_TO_STEPS.map((step, index) => (
+          <button
+            key={step.id}
+            type="button"
+            onClick={() => scrollToStep(index)}
+            aria-label={`Scroll to step ${step.id}`}
+            className={`h-2 w-2 rounded-full transition ${index === activeIndex ? 'bg-slate-900' : 'bg-slate-300'}`}
+          />
+        ))}
+      </div>
+    </section>
+  );
+};
+
+export default HowToCarousel;

--- a/src/components/howto/HowToStepCard.tsx
+++ b/src/components/howto/HowToStepCard.tsx
@@ -1,0 +1,74 @@
+'use client';
+
+import Image from 'next/image';
+import { motion, useReducedMotion } from 'framer-motion';
+import FocusHighlight from './FocusHighlight';
+
+export type HowToStep = {
+  id: number;
+  title: string;
+  description: string;
+  image: string;
+  focus?: {
+    x: string;
+    y: string;
+    size: number;
+  };
+};
+
+type HowToStepCardProps = {
+  step: HowToStep;
+  isActive?: boolean;
+};
+
+const easeOutCubic: [number, number, number, number] = [0.33, 1, 0.68, 1];
+
+const HowToStepCard = ({ step, isActive }: HowToStepCardProps) => {
+  const prefersReducedMotion = useReducedMotion();
+
+  const scaleClass = prefersReducedMotion ? 'md:scale-100' : isActive ? 'md:scale-[1.02]' : 'md:scale-100';
+
+  return (
+    <motion.article
+      initial={{ opacity: 0, y: 12 }}
+      animate={{ opacity: 1, y: 0 }}
+      transition={prefersReducedMotion ? { duration: 0 } : { duration: 0.45, ease: easeOutCubic }}
+      className={[
+        'snap-center flex w-[86vw] max-w-[360px] shrink-0 flex-col gap-4 rounded-3xl border border-slate-200/70 bg-white/90 p-5 shadow-[0_16px_45px_rgba(15,23,42,0.08)] backdrop-blur md:w-[340px]',
+        prefersReducedMotion ? '' : 'transition-transform duration-300 ease-out',
+        scaleClass,
+      ].join(' ')}
+    >
+      <div className="flex items-center justify-between">
+        <span className="inline-flex h-9 w-9 items-center justify-center rounded-full bg-slate-900 text-sm font-semibold text-white">
+          {step.id}
+        </span>
+        <span className="text-xs uppercase tracking-[0.2em] text-slate-400">Step</span>
+      </div>
+
+      <div className="relative overflow-hidden rounded-[2rem] border border-slate-200/70 bg-slate-50 shadow-inner">
+        <div className="relative aspect-[9/19] w-full">
+          <Image
+            src={step.image}
+            alt={step.title}
+            fill
+            sizes="(min-width: 1024px) 320px, 80vw"
+            className="object-cover"
+            priority={step.id === 1}
+          />
+        </div>
+        {step.focus && (
+          <FocusHighlight x={step.focus.x} y={step.focus.y} size={step.focus.size} />
+        )}
+      </div>
+
+      <div className="space-y-2">
+        <h3 className="text-lg font-semibold text-slate-900">{step.title}</h3>
+        <p className="text-sm leading-relaxed text-slate-600">{step.description}</p>
+      </div>
+
+    </motion.article>
+  );
+};
+
+export default HowToStepCard;


### PR DESCRIPTION
### Motivation
- Replace a broken HowToApp implementation with a purpose-built, data-driven guided page that feels app-like and horizontally oriented.
- Present the setup steps as compact cards with clear screenshots and a visual focus indicator to guide attention left → right.
- Provide a mobile-friendly swipeable carousel with keyboard and button navigation and reduced-motion support.

### Description
- Add a new page at `src/app/how-to-add/page.tsx` that renders a header, the `HowToCarousel`, and a footer note.
- Implement three new components under `src/components/howto/`: `HowToCarousel.tsx` (horizontal scroll, snap, keyboard/arrow controls, intersection observer), `HowToStepCard.tsx` (card layout, image framing, title/description), and `FocusHighlight.tsx` (animated focus ring with reduced-motion fallback).
- Introduce a data-driven `HOW_TO_STEPS` array inside `HowToCarousel` and add placeholder SVG assets under `public/images/howto/` for each step.
- Use `framer-motion` for entrance animations, `next/image` for optimized images, scroll snapping and smooth scrolling for a polished, accessible UX.

### Testing
- Started the Next dev server with `npm run dev` and the page compiled `(/how-to-add)` successfully in the dev build. (succeeded)
- Captured a visual snapshot using Playwright to verify layout and rendering and produced a screenshot artifact. (succeeded)
- A runtime request to `/how-to-add` returned a 500 due to an existing Firebase `auth/invalid-api-key` error during SSR, unrelated to the new components. (failed)
- No unit/integration test suite was executed as part of this rollout. (not run)

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_696188fc07048324849da20a2ca77bf8)