### PR TITLE
Add light/dark theme support and platform carousel components for how-to-app

### DIFF
--- a/src/app/how-to-app/page.tsx
+++ b/src/app/how-to-app/page.tsx
@@ -1,180 +1,109 @@
-'use client';
+"use client";
 
-import Link from 'next/link';
-import Image from 'next/image';
-import { motion } from 'framer-motion';
+import { useState } from "react";
+import HowToCarousel from "@/components/howto/HowToCarousel";
+import AndroidCarousel from "@/components/howto/AndroidCarousel";
+import PlatformSwitcher from "@/components/howto/PlatformSwitcher";
+import type { HowToStep } from "@/components/howto/HowToCarousel";
 
 export default function HowToAppPage() {
-  const stepVariants = {
-    hidden: { opacity: 0, y: 6 },
-    show: { opacity: 1, y: 0 },
-  };
+  const [platform, setPlatform] = useState<"ios" | "android">("ios");
 
-  const sectionVariants = {
-    hidden: { opacity: 0, y: 10 },
-    show: { opacity: 1, y: 0 },
-  };
-
-  const containerVariants = {
-    hidden: {},
-    show: {
-      transition: {
-        staggerChildren: 0.08,
+  /**
+   * ✅ EDIT HIGHLIGHT POSITIONS HERE
+   * --------------------------------
+   * Each highlight uses % coordinates relative to the IMAGE area.
+   *
+   * xPct: 0–100 (left → right)
+   * yPct: 0–100 (top → bottom)
+   * rPct: ring radius (roughly “size”), also in % of the image width
+   *
+   * TIP:
+   * - If ring is too far RIGHT, reduce xPct.
+   * - If ring is too far LEFT, increase xPct.
+   * - If ring is too LOW, reduce yPct.
+   * - If ring is too HIGH, increase yPct.
+   * - If ring is too big/small, adjust rPct.
+   */
+  const steps: HowToStep[] = [
+    {
+      id: 1,
+      title: "Open Safari",
+      description:
+        "Open Safari and go to www.james-square.com, then tap the three dots in the bottom-right corner.",
+      imageSrc: "/images/brands/step1-removebg-preview.png",
+      highlight: {
+        xPct: 86,
+        yPct: 84,
+        rPct: 10,
       },
     },
-  };
-
-  const iPhoneSteps = [
     {
-      text: 'Open Safari and go to www.james-square.com, then tap the three dots in the bottom-right corner.',
-      image: '/images/brands/step1-removebg-preview.png',
+      id: 2,
+      title: "Tap Share",
+      description: "From the menu, tap Share to open the iOS sharing options.",
+      imageSrc: "/images/brands/step2-removebg-preview.png",
+      highlight: {
+        xPct: 50,
+        yPct: 56,
+        rPct: 12,
+      },
     },
     {
-      text: 'From the menu, tap Share to open the iOS sharing options.',
-      image: '/images/brands/step2-removebg-preview.png',
+      id: 3,
+      title: "Add to Home Screen",
+      description: "Scroll down and tap Add to Home Screen.",
+      imageSrc: "/images/brands/step3-removebg-preview.png",
+      highlight: {
+        xPct: 50,
+        yPct: 78,
+        rPct: 12,
+      },
     },
     {
-      text: 'Scroll down and tap Add to Home Screen.',
-      image: '/images/brands/step3-removebg-preview.png',
+      id: 4,
+      title: "Confirm details",
+      description: "Check the details and make sure Open as Web App is enabled, then tap Add.",
+      imageSrc: "/images/brands/step4-removebg-preview.png",
+      highlight: {
+        xPct: 86,
+        yPct: 17,
+        rPct: 10,
+      },
     },
     {
-      text: 'Check the details and make sure Open as Web App is enabled, then tap Add.',
-      image: '/images/brands/step4-removebg-preview.png',
+      id: 5,
+      title: "Launch James Square",
+      description:
+        "James Square will now appear on your home screen. Tap it to open like an app.",
+      imageSrc: "/images/brands/step5-removebg-preview.png",
+      highlight: {
+        xPct: 73,
+        yPct: 56,
+        rPct: 14,
+      },
     },
-    {
-      text: 'James Square will now appear on your home screen. Tap it to open like an app.',
-      image: '/images/brands/step5-removebg-preview.png',
-    },
-  ];
-
-  const androidSteps = [
-    'Open James Square in Chrome.',
-    'Tap the menu (three dots) in the top-right corner.',
-    'Tap Add to Home screen or Install app.',
-    'Confirm when prompted.',
   ];
 
   return (
-    <div className="mx-auto max-w-4xl px-4 pb-12 pt-10 sm:px-6 lg:px-8">
-      <motion.div
-        className="space-y-8 text-[color:var(--text-primary)]"
-        initial="hidden"
-        animate="show"
-        variants={containerVariants}
-      >
-        {/* Header */}
-        <motion.header variants={sectionVariants} className="space-y-3">
-          <p className="text-xs font-semibold uppercase tracking-[0.28em] text-[color:var(--muted)]">
-            Helpful guide
+    <main className="min-h-[calc(100vh-64px)] w-full bg-slate-50 text-slate-900 dark:bg-[#070B14] dark:text-white">
+      <section className="mx-auto w-full max-w-6xl px-4 py-10 sm:py-14">
+        <div className="mb-8">
+          <div className="mb-2 text-xs tracking-[0.28em] text-slate-500 dark:text-white/60">
+            ADD TO HOME SCREEN
+          </div>
+          <h1 className="text-3xl font-semibold sm:text-4xl">Your guided setup</h1>
+          <p className="mt-2 max-w-2xl text-slate-600 dark:text-white/70">
+            Follow the steps below to install James Square on your phone.
           </p>
-          <h1 className="text-3xl font-extrabold leading-tight sm:text-4xl">
-            Use James Square as an app on your phone
-          </h1>
-          <p className="text-[color:var(--text-secondary)]">
-            If you regularly use James Square on your phone, you can add it to your home screen and open it like an app.
-          </p>
-          <p className="text-[color:var(--text-secondary)]">
-            This does not install anything from an app store. It simply creates an app-style shortcut that opens James
-            Square full screen for quicker access.
-          </p>
-        </motion.header>
+        </div>
 
-        {/* iPhone section */}
-        <motion.section
-          variants={sectionVariants}
-          className="glass-surface glass-outline space-y-6 rounded-2xl border border-[color:var(--glass-border)] bg-white/60 p-5 sm:p-6"
-        >
-          <p className="text-[11px] font-semibold uppercase tracking-[0.28em] text-[color:var(--muted)]">
-            iPhone (Safari)
-          </p>
-          <h2 className="text-xl font-semibold">On iPhone</h2>
+        <PlatformSwitcher platform={platform} setPlatform={setPlatform} />
 
-          <motion.ol variants={containerVariants} className="space-y-6">
-            {iPhoneSteps.map((step, index) => (
-              <motion.li
-                key={index}
-                variants={stepVariants}
-                className="flex flex-col gap-4 sm:flex-row sm:items-start sm:gap-6"
-              >
-                {/* Step number */}
-                <span className="flex h-8 w-8 shrink-0 items-center justify-center rounded-full bg-[color:var(--btn-bg)]/10 text-sm font-semibold">
-                  {index + 1}
-                </span>
-
-                {/* Image + text */}
-                <div className="flex flex-1 flex-col gap-3">
-                  <div className="relative w-full max-w-[260px]">
-                    <Image
-                      src={step.image}
-                      alt={`Step ${index + 1}`}
-                      width={260}
-                      height={520}
-                      className="rounded-xl border border-black/5"
-                    />
-                  </div>
-                  <p className="text-[color:var(--text-secondary)]">{step.text}</p>
-                </div>
-              </motion.li>
-            ))}
-          </motion.ol>
-
-          <p className="text-sm text-[color:var(--text-secondary)]">
-            Once added, James Square opens full screen and behaves like a dedicated app.
-          </p>
-        </motion.section>
-
-        {/* Android section */}
-        <motion.section
-          variants={sectionVariants}
-          className="glass-surface glass-outline space-y-4 rounded-2xl border border-[color:var(--glass-border)] bg-white/60 p-5 sm:p-6"
-        >
-          <p className="text-[11px] font-semibold uppercase tracking-[0.28em] text-[color:var(--muted)]">
-            Android (Chrome)
-          </p>
-          <h2 className="text-xl font-semibold">On Android</h2>
-
-          <motion.ol variants={containerVariants} className="space-y-3">
-            {androidSteps.map((step, index) => (
-              <motion.li key={step} variants={stepVariants} className="flex items-start gap-3">
-                <span className="flex h-8 w-8 shrink-0 items-center justify-center rounded-full bg-[color:var(--btn-bg)]/10 text-sm font-semibold">
-                  {index + 1}
-                </span>
-                <p className="text-[color:var(--text-secondary)]">{step}</p>
-              </motion.li>
-            ))}
-          </motion.ol>
-        </motion.section>
-
-        {/* Reassurance */}
-        <motion.section
-          variants={sectionVariants}
-          className="space-y-3 rounded-2xl border border-dashed border-[color:var(--glass-border)] bg-white/40 p-5 sm:p-6"
-        >
-          <p className="text-[11px] font-semibold uppercase tracking-[0.28em] text-[color:var(--muted)]">
-            Note
-          </p>
-          <h2 className="text-base font-semibold">A quick reassurance</h2>
-          <p className="text-[color:var(--text-secondary)]">
-            This does not enable notifications, tracking, or background activity.
-          </p>
-          <p className="text-[color:var(--text-secondary)]">
-            It simply provides quicker access to the James Square website in an app-style view.
-          </p>
-        </motion.section>
-
-        {/* Back link */}
-        <motion.div variants={sectionVariants}>
-          <Link
-            href="/dashboard"
-            className="group inline-flex items-center gap-2 rounded-lg px-2 py-2 text-sm font-semibold"
-          >
-            <span className="text-base transition-transform duration-200 group-hover:-translate-x-0.5">←</span>
-            <span className="relative after:absolute after:inset-x-0 after:-bottom-0.5 after:h-px after:bg-current after:opacity-40 after:transition group-hover:after:opacity-80">
-              Back to dashboard
-            </span>
-          </Link>
-        </motion.div>
-      </motion.div>
-    </div>
+        <div className="mt-8">
+          {platform === "ios" ? <HowToCarousel steps={steps} /> : <AndroidCarousel />}
+        </div>
+      </section>
+    </main>
   );
 }

--- a/src/components/howto/AndroidCarousel.tsx
+++ b/src/components/howto/AndroidCarousel.tsx
@@ -1,0 +1,56 @@
+"use client";
+
+import AndroidStepCard from "./AndroidStepCard";
+
+const androidSteps = [
+  {
+    id: 1,
+    title: "Open Chrome",
+    text: "Open Google Chrome on your Android phone and go to www.james-square.com.",
+  },
+  {
+    id: 2,
+    title: "Open menu",
+    text: "Tap the three dots in the top-right corner of Chrome.",
+  },
+  {
+    id: 3,
+    title: "Add to Home screen",
+    text: "Tap “Add to Home screen” from the menu.",
+  },
+  {
+    id: 4,
+    title: "Confirm",
+    text: "Confirm the name and tap Add.",
+  },
+  {
+    id: 5,
+    title: "Launch",
+    text: "James Square will now appear on your home screen like an app.",
+  },
+];
+
+export default function AndroidCarousel() {
+  return (
+    <div
+      className="flex gap-4 overflow-x-auto pb-6 scroll-smooth [scrollbar-width:none] [-ms-overflow-style:none]"
+      style={{ scrollSnapType: "x mandatory" }}
+    >
+      <style jsx>{`
+        div::-webkit-scrollbar {
+          display: none;
+        }
+      `}</style>
+
+      <div className="w-4 shrink-0" />
+
+      {androidSteps.map((step) => (
+        <div key={step.id} className="shrink-0" style={{ scrollSnapAlign: "center" }}>
+          <AndroidStepCard step={step} />
+        </div>
+      ))}
+
+      <div className="w-4 shrink-0" />
+    </div>
+  );
+}

--- a/src/components/howto/AndroidStepCard.tsx
+++ b/src/components/howto/AndroidStepCard.tsx
@@ -1,0 +1,21 @@
+"use client";
+
+export default function AndroidStepCard({
+  step,
+}: {
+  step: { id: number; title: string; text: string };
+}) {
+  return (
+    <article className="w-[80vw] max-w-[420px] rounded-2xl border border-slate-200/80 bg-white px-6 py-7 shadow-sm backdrop-blur-lg dark:border-white/10 dark:bg-white/[0.04] dark:shadow-none">
+      <div className="text-xs tracking-[0.3em] text-slate-500 dark:text-white/50">
+        STEP {step.id}
+      </div>
+
+      <h2 className="mt-2 text-2xl font-semibold">{step.title}</h2>
+
+      <p className="mt-3 text-base leading-relaxed text-slate-600 dark:text-white/70">{step.text}</p>
+
+      <div className="mt-5 text-xs text-slate-500 dark:text-white/40">Swipe to continue →</div>
+    </article>
+  );
+}

--- a/src/components/howto/HighlightOverlay.tsx
+++ b/src/components/howto/HighlightOverlay.tsx
@@ -1,0 +1,65 @@
+"use client";
+
+import type { CSSProperties } from "react";
+import type { HighlightSpec } from "./HowToCarousel";
+
+export default function HighlightOverlay({ spec }: { spec: HighlightSpec }) {
+  const x = clamp(spec.xPct, 0, 100);
+  const y = clamp(spec.yPct, 0, 100);
+  const r = clamp(spec.rPct, 2, 40);
+
+  const style: CSSProperties = {
+    left: `${x}%`,
+    top: `${y}%`,
+    width: `${r * 2}%`,
+    height: `${r * 2}%`,
+    transform: "translate(-50%, -50%)",
+  };
+
+  return (
+    <div className="pointer-events-none absolute inset-0">
+      <div className="absolute rounded-full" style={style}>
+        <div className="absolute inset-0 rounded-full ring-base" />
+        <div className="absolute inset-0 rounded-full ring-pulse" />
+      </div>
+
+      <style jsx>{`
+        .ring-base {
+          border: 2px solid rgba(255, 255, 255, 0.85);
+          box-shadow:
+            0 0 0 2px rgba(255, 255, 255, 0.22),
+            0 0 18px rgba(80, 200, 255, 0.55),
+            0 0 42px rgba(80, 200, 255, 0.28);
+        }
+
+        .ring-pulse {
+          border: 2px solid rgba(120, 220, 255, 0.55);
+          box-shadow:
+            0 0 14px rgba(120, 220, 255, 0.45),
+            0 0 34px rgba(120, 220, 255, 0.22);
+          animation: pulseGlow 1.8s ease-in-out infinite;
+          opacity: 0.65;
+        }
+
+        @keyframes pulseGlow {
+          0% {
+            transform: scale(0.98);
+            opacity: 0.45;
+          }
+          50% {
+            transform: scale(1.03);
+            opacity: 0.85;
+          }
+          100% {
+            transform: scale(0.98);
+            opacity: 0.45;
+          }
+        }
+      `}</style>
+    </div>
+  );
+}
+
+function clamp(n: number, min: number, max: number) {
+  return Math.max(min, Math.min(max, n));
+}

--- a/src/components/howto/HowToCarousel.tsx
+++ b/src/components/howto/HowToCarousel.tsx
@@ -1,0 +1,144 @@
+"use client";
+
+import { useEffect, useRef, useState } from "react";
+import HowToStepCard from "./HowToStepCard";
+
+export type HighlightSpec = {
+  xPct: number;
+  yPct: number;
+  rPct: number;
+};
+
+export type HowToStep = {
+  id: number;
+  title: string;
+  description: string;
+  imageSrc: string;
+  highlight: HighlightSpec;
+};
+
+export default function HowToCarousel({ steps }: { steps: HowToStep[] }) {
+  const trackRef = useRef<HTMLDivElement | null>(null);
+  const [active, setActive] = useState(0);
+
+  const stepCount = steps.length;
+
+  const scrollToIndex = (idx: number) => {
+    const track = trackRef.current;
+    if (!track) return;
+
+    const clamped = Math.max(0, Math.min(stepCount - 1, idx));
+    const child = track.children.item(clamped) as HTMLElement | null;
+    if (!child) return;
+
+    child.scrollIntoView({
+      behavior: "smooth",
+      inline: "center",
+      block: "nearest",
+    });
+  };
+
+  useEffect(() => {
+    const track = trackRef.current;
+    if (!track) return;
+
+    const onScroll = () => {
+      const rect = track.getBoundingClientRect();
+      const centerX = rect.left + rect.width / 2;
+
+      let bestIdx = 0;
+      let bestDist = Number.POSITIVE_INFINITY;
+
+      Array.from(track.children).forEach((child, idx) => {
+        const childRect = (child as HTMLElement).getBoundingClientRect();
+        const childCenter = childRect.left + childRect.width / 2;
+        const dist = Math.abs(centerX - childCenter);
+        if (dist < bestDist) {
+          bestDist = dist;
+          bestIdx = idx;
+        }
+      });
+
+      setActive(bestIdx);
+    };
+
+    onScroll();
+    track.addEventListener("scroll", onScroll, { passive: true });
+    return () => track.removeEventListener("scroll", onScroll);
+  }, []);
+
+  const canPrev = active > 0;
+  const canNext = active < stepCount - 1;
+
+  return (
+    <div className="relative">
+      <div className="pointer-events-none absolute right-2 top-[-56px] hidden items-center gap-2 md:flex">
+        <button
+          type="button"
+          onClick={() => scrollToIndex(active - 1)}
+          disabled={!canPrev}
+          className="pointer-events-auto rounded-full border border-slate-200 bg-white/80 px-3 py-2 text-sm text-slate-700 shadow-sm backdrop-blur-md transition hover:bg-white disabled:opacity-40 dark:border-white/15 dark:bg-white/5 dark:text-white/80 dark:hover:bg-white/10"
+          aria-label="Previous step"
+        >
+          ←
+        </button>
+        <button
+          type="button"
+          onClick={() => scrollToIndex(active + 1)}
+          disabled={!canNext}
+          className="pointer-events-auto rounded-full border border-slate-200 bg-white/80 px-3 py-2 text-sm text-slate-700 shadow-sm backdrop-blur-md transition hover:bg-white disabled:opacity-40 dark:border-white/15 dark:bg-white/5 dark:text-white/80 dark:hover:bg-white/10"
+          aria-label="Next step"
+        >
+          →
+        </button>
+      </div>
+
+      <div
+        ref={trackRef}
+        className="flex w-full gap-5 overflow-x-auto pb-6 pt-2 [scrollbar-width:none] [-ms-overflow-style:none] scroll-smooth"
+        style={{
+          scrollSnapType: "x mandatory",
+        }}
+      >
+        <style jsx>{`
+          div::-webkit-scrollbar {
+            display: none;
+          }
+        `}</style>
+
+        <div className="w-4 shrink-0 sm:w-10" aria-hidden />
+
+        {steps.map((step, idx) => (
+          <div
+            key={step.id}
+            className="shrink-0"
+            style={{
+              scrollSnapAlign: "center",
+            }}
+          >
+            <HowToStepCard step={step} isActive={idx === active} />
+          </div>
+        ))}
+
+        <div className="w-4 shrink-0 sm:w-10" aria-hidden />
+      </div>
+
+      <div className="mt-2 flex items-center justify-center gap-2">
+        {steps.map((_, idx) => (
+          <button
+            key={`step-dot-${idx}`}
+            type="button"
+            onClick={() => scrollToIndex(idx)}
+            aria-label={`Go to step ${idx + 1}`}
+            className={[
+              "h-2.5 w-2.5 rounded-full transition",
+              idx === active
+                ? "bg-slate-900/70 dark:bg-white/80"
+                : "bg-slate-300 hover:bg-slate-400 dark:bg-white/20 dark:hover:bg-white/35",
+            ].join(" ")}
+          />
+        ))}
+      </div>
+    </div>
+  );
+}

--- a/src/components/howto/HowToStepCard.tsx
+++ b/src/components/howto/HowToStepCard.tsx
@@ -1,0 +1,58 @@
+"use client";
+
+import Image from "next/image";
+import HighlightOverlay from "./HighlightOverlay";
+import type { HowToStep } from "./HowToCarousel";
+
+export default function HowToStepCard({
+  step,
+  isActive,
+}: {
+  step: HowToStep;
+  isActive: boolean;
+}) {
+  return (
+    <article
+      className={[
+        "relative w-[86vw] max-w-[560px] rounded-3xl border border-slate-200/80 bg-white shadow-sm backdrop-blur-xl dark:border-white/10 dark:bg-white/[0.03] dark:shadow-none",
+        "px-5 py-6 sm:px-7 sm:py-7",
+        "transition",
+        isActive ? "opacity-100" : "opacity-65 hover:opacity-85",
+      ].join(" ")}
+    >
+      <div className="grid gap-6 md:grid-cols-[1fr_1.05fr] md:gap-7">
+        <div className="relative flex items-center justify-center">
+          <div className="relative w-full max-w-[320px] sm:max-w-[360px]">
+            <div className="relative aspect-[9/16] w-full">
+              <Image
+                src={step.imageSrc}
+                alt={`Step ${step.id} screenshot`}
+                fill
+                className="object-contain"
+                priority={step.id <= 2}
+              />
+              <HighlightOverlay spec={step.highlight} />
+            </div>
+          </div>
+        </div>
+
+        <div className="flex flex-col justify-center">
+          <div className="text-[11px] tracking-[0.32em] text-slate-500 dark:text-white/55">
+            STEP {step.id}
+          </div>
+          <h2 className="mt-2 text-2xl font-semibold tracking-tight sm:text-3xl">
+            {step.title}
+          </h2>
+          <p className="mt-2 text-base leading-relaxed text-slate-600 dark:text-white/70">
+            {step.description}
+          </p>
+
+          <div className="mt-5 inline-flex items-center gap-2 text-xs text-slate-500 dark:text-white/50">
+            <span className="h-1.5 w-1.5 rounded-full bg-slate-400 dark:bg-white/35" />
+            Swipe to continue
+          </div>
+        </div>
+      </div>
+    </article>
+  );
+}

--- a/src/components/howto/PlatformSwitcher.tsx
+++ b/src/components/howto/PlatformSwitcher.tsx
@@ -1,0 +1,39 @@
+"use client";
+
+export default function PlatformSwitcher({
+  platform,
+  setPlatform,
+}: {
+  platform: "ios" | "android";
+  setPlatform: (platform: "ios" | "android") => void;
+}) {
+  return (
+    <div className="inline-flex rounded-full border border-slate-200 bg-white/80 p-1 text-slate-700 shadow-sm backdrop-blur-md dark:border-white/15 dark:bg-white/5 dark:text-white">
+      <button
+        type="button"
+        onClick={() => setPlatform("ios")}
+        className={[
+          "rounded-full px-4 py-2 text-sm transition",
+          platform === "ios"
+            ? "bg-slate-900/10 text-slate-900 dark:bg-white/15 dark:text-white"
+            : "text-slate-500 hover:text-slate-900 dark:text-white/60 dark:hover:text-white",
+        ].join(" ")}
+      >
+        iPhone (Safari)
+      </button>
+
+      <button
+        type="button"
+        onClick={() => setPlatform("android")}
+        className={[
+          "rounded-full px-4 py-2 text-sm transition",
+          platform === "android"
+            ? "bg-slate-900/10 text-slate-900 dark:bg-white/15 dark:text-white"
+            : "text-slate-500 hover:text-slate-900 dark:text-white/60 dark:hover:text-white",
+        ].join(" ")}
+      >
+        Android (Chrome)
+      </button>
+    </div>
+  );
+}


### PR DESCRIPTION
### Motivation
- Make the `/how-to-app` UI readable and visually consistent in both light and dark modes.  
- Provide a platform chooser and swipeable walkthrough for iOS and Android flows.  
- Surface per-step editable highlight coordinates so ring highlights can be tuned from one place.  
- Replace in-route rendering with small, maintainable components that encapsulate carousel, card, and highlight logic.

### Description
- Updated `src/app/how-to-app/page.tsx` to use theme-safe Tailwind colors and to mount the new `PlatformSwitcher`, `HowToCarousel`, and `AndroidCarousel` components.  
- Added new how-to components: `src/components/howto/HowToCarousel.tsx`, `HowToStepCard.tsx`, `HighlightOverlay.tsx`, `PlatformSwitcher.tsx`, `AndroidCarousel.tsx`, and `AndroidStepCard.tsx` that implement the horizontal carousels, per-step cards, and crisp ring highlight with a pulse animation.  
- Added types and `HighlightSpec` (`xPct`, `yPct`, `rPct`) and clamping logic so highlights are editable and safe, and moved images to `imageSrc` fields per step.  
- Adjusted visual styling across components to use light/dark variants (`dark:` classes), subtle shadows in light mode, and accessible dot/controls coloring for both themes.

### Testing
- No automated tests were run for these changes.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6961907846d483249d3040e1e7e53cfa)