### PR TITLE
Add 'View original email' button and modal to Fior Factor Update

### DIFF
--- a/src/app/dashboard/page.tsx
+++ b/src/app/dashboard/page.tsx
@@ -11,7 +11,6 @@ import {
   User,
 } from 'firebase/auth';
 import { useRouter } from 'next/navigation';
-import Link from 'next/link';
 import { DateTime } from 'luxon';
 import Image from 'next/image';
 import DashboardTabs from '@/components/DashboardTabs';

--- a/src/app/owners/secure/page.tsx
+++ b/src/app/owners/secure/page.tsx
@@ -3,7 +3,7 @@
 import Link from 'next/link';
 import { useRouter } from 'next/navigation';
 import { useEffect, useState, type ReactNode } from 'react';
-import { AnimatePresence, motion, useReducedMotion } from 'framer-motion';
+import { motion, useReducedMotion } from 'framer-motion';
 import { Calendar, CalendarPlus, ClipboardCheck, Clock, FileText, Mail, Monitor, Users } from 'lucide-react';
 
 import { GlassCard } from '@/components/GlassCard';
@@ -411,6 +411,21 @@ function SgmSection() {
 function FiorFactorUpdateSection() {
   const [showEmail, setShowEmail] = useState(false);
 
+  useEffect(() => {
+    if (!showEmail) {
+      return;
+    }
+
+    const handleKeyDown = (event: KeyboardEvent) => {
+      if (event.key === 'Escape') {
+        setShowEmail(false);
+      }
+    };
+
+    window.addEventListener('keydown', handleKeyDown);
+    return () => window.removeEventListener('keydown', handleKeyDown);
+  }, [showEmail]);
+
   return (
     <GlassCard title="Fior Factor Update" titleClassName="text-2xl font-semibold text-slate-900 dark:text-slate-100">
       <div className="space-y-3 text-sm md:text-base text-slate-700 dark:text-slate-200">
@@ -439,92 +454,110 @@ function FiorFactorUpdateSection() {
           on Wednesday 21 January at 6:00 pm. Further details of this meeting will be shared shortly, and owners are
           encouraged to attend.
         </p>
-        <p>For transparency, owners may view the original email received from Fior Asset &amp; Property Management on 19 December 2025.</p>
+        <p>For transparency, owners can view the previous email sent by Fior Asset &amp; Property to the committee.</p>
         <button
           type="button"
           onClick={() => setShowEmail(true)}
           className="inline-flex items-center justify-center gap-2 rounded-xl border border-black/10 bg-white/85 px-4 py-3 text-sm font-semibold text-slate-900 shadow-sm transition-all duration-150 ease-out hover:bg-white/95 hover:shadow-md focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-slate-500 dark:border-white/15 dark:bg-white/20 dark:text-white dark:hover:bg-white/25"
         >
           <FileText className="h-4 w-4 text-slate-500 dark:text-slate-300" aria-hidden="true" />
-          <span>View original email</span>
+          <span>View email from Fior</span>
         </button>
       </div>
 
-      <AnimatePresence>
-        {showEmail && (
-          <motion.div
-            className="fixed inset-0 z-50 flex items-center justify-center bg-black/50 px-4 py-6 sm:px-0"
-            initial={{ opacity: 0 }}
-            animate={{ opacity: 1 }}
-            exit={{ opacity: 0 }}
+      {showEmail && (
+        <div
+          className="fixed inset-0 z-[100] flex items-center justify-center bg-black/60 px-4 py-6 sm:px-0"
+          onClick={() => setShowEmail(false)}
+          role="presentation"
+        >
+          <div
+            className="w-full max-w-3xl max-h-[80vh] overflow-y-auto rounded-2xl border border-slate-200 bg-white p-6 text-slate-900 shadow-2xl dark:border-slate-800 dark:bg-slate-950 dark:text-slate-100 sm:p-8"
+            onClick={(event) => event.stopPropagation()}
+            role="dialog"
+            aria-modal="true"
           >
-            <motion.div
-              className="glass-surface glass-outline w-full max-w-3xl p-6 sm:p-8 max-h-[85vh] overflow-y-auto"
-              initial={{ opacity: 0, y: 12, scale: 0.98 }}
-              animate={{ opacity: 1, y: 0, scale: 1 }}
-              exit={{ opacity: 0, y: 12, scale: 0.98 }}
-              transition={{ duration: 0.2, ease: 'easeOut' }}
-            >
-              <div className="flex items-start justify-between gap-4">
-                <div className="flex items-center gap-3">
-                  <span className="flex h-10 w-10 items-center justify-center rounded-full bg-slate-100 text-slate-700 dark:bg-white/10 dark:text-slate-200">
-                    <Mail className="h-5 w-5" aria-hidden="true" />
-                  </span>
-                  <h3 className="text-lg font-semibold text-slate-900 dark:text-slate-100">Original email</h3>
-                </div>
-                <button
-                  type="button"
-                  onClick={() => setShowEmail(false)}
-                  className="text-sm font-semibold text-slate-600 hover:text-slate-900 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-slate-500 dark:text-slate-300 dark:hover:text-white"
-                >
-                  Close
-                </button>
+            <div className="flex items-start justify-between gap-4">
+              <div className="flex items-center gap-3">
+                <span className="flex h-10 w-10 items-center justify-center rounded-full bg-slate-100 text-slate-700 dark:bg-slate-800 dark:text-slate-200">
+                  <Mail className="h-5 w-5" aria-hidden="true" />
+                </span>
+                <h3 className="text-lg font-semibold">Original email</h3>
               </div>
+              <button
+                type="button"
+                onClick={() => setShowEmail(false)}
+                className="text-sm font-semibold text-slate-600 hover:text-slate-900 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-slate-500 dark:text-slate-300 dark:hover:text-white"
+              >
+                Close
+              </button>
+            </div>
 
-              <p className="mt-4 text-sm text-slate-600 dark:text-slate-300">
-                The following is the original email received from Fior Asset &amp; Property Management on 19 December 2025.
-              </p>
+            <p className="mt-4 text-sm text-slate-600 dark:text-slate-300">
+              The following is the original email received from Fior Asset &amp; Property Management on 19 December 2025.
+            </p>
 
-              <div className="mt-4 rounded-2xl border border-black/10 bg-white/90 p-5 text-sm text-slate-800 shadow-inner dark:border-white/15 dark:bg-slate-950/40 dark:text-slate-100">
-                <div className="space-y-2">
-                  <p>
-                    <span className="font-semibold text-slate-900 dark:text-slate-100">From:</span> Pedrom Aghabala, Director – Fior Asset
-                    &amp; Property
-                  </p>
-                  <p>
-                    <span className="font-semibold text-slate-900 dark:text-slate-100">Date:</span> 19 December 2025
-                  </p>
-                  <p>
-                    <span className="font-semibold text-slate-900 dark:text-slate-100">Subject:</span> Correspondence regarding James Square
-                  </p>
-                </div>
-                <div className="mt-4 space-y-4 whitespace-pre-line">
-                  <p>Dear Owners,</p>
-                  <p>
-                    We are writing to confirm that Fior Asset &amp; Property Management intends to step down as factor for James Square. We
-                    are proposing a managed departure to allow outstanding matters to be addressed, including completion of financial
-                    reconciliation, recovery of outstanding and historic debts, resolution of ongoing utility matters, and the orderly
-                    handover of information to a new factor.
-                  </p>
-                  <p>
-                    Updated invoices were issued to owners prior to the Christmas period and a full financial report will follow. Several
-                    active building issues are currently being dealt with, including multiple water leaks across the development, and
-                    actions agreed at the AGM, such as the pool window works and clarification of staff roles, are being progressed.
-                  </p>
-                  <p>
-                    Plans are now in place to review and appoint a new factor for James Square, and further information will be shared as
-                    this process moves forward. A meeting has been arranged for owners on Wednesday 21 January at 6:00 pm to discuss the
-                    factoring arrangements and next steps in more detail.
-                  </p>
-                  <p>Kind regards,</p>
-                  <p>Pedrom Aghabala</p>
-                  <p>Director – Fior Asset &amp; Property</p>
-                </div>
+            <div className="mt-4 rounded-2xl border border-slate-200 bg-white p-5 text-sm text-slate-900 shadow-inner dark:border-slate-800 dark:bg-slate-900 dark:text-slate-100">
+              <div className="space-y-2">
+                <p>
+                  <span className="font-semibold">From:</span> Pedrom Aghabala, Director – Fior Asset &amp; Property
+                </p>
+                <p>
+                  <span className="font-semibold">Date:</span> 19 December 2025
+                </p>
+                <p>
+                  <span className="font-semibold">Subject:</span> Correspondence regarding James Square
+                </p>
               </div>
-            </motion.div>
-          </motion.div>
-        )}
-      </AnimatePresence>
+              <div className="mt-4 space-y-4 whitespace-pre-line">
+                <p>Good afternoon,</p>
+                <p>
+                  I hope this finds you well, thank you for your letter to our office, I only read it a few days ago as I
+                  was catching up on my post.
+                </p>
+                <p>
+                  To be honest, I fully understand your frustration, this site has not been easy for us either. One of
+                  the major issues we faced here was that many properties are rented out at James Square, upon doing a
+                  reconciliation of accounts, we noticed that many letting agents were paying money into the James Square
+                  account for not only James Square rentals they manage, but also for other rental properties that we are
+                  the factor for. We presume that they feel this is a main business bank account for Fior Asset , but in
+                  reality, James square has its own account as do all developments, therefore we have had to go through
+                  hundreds of transactions to establish what was actually James square and what was for other sites, and
+                  remove this.
+                </p>
+                <p>
+                  All of this being said, we are today and tomorrow, sending all owners their up to date invoices for
+                  payment, given that we only have 2 days left in the office before we break up for Christmas, I do not
+                  feel we would be able to get you the financial report in such time. We need to get the invoices out
+                  first, then send you and all the owners the financial report, which we will do asap.
+                </p>
+                <p>
+                  Once this is done, I feel it would be a good idea for the committee and Fior Asset to meet up in early
+                  January, we can then discuss our departure from James Square. The reason I do not feel it would be
+                  beneficial to notify all of the owners just yet of a change of factor is that there are debts at the
+                  site , including historic ones, which we are very close to recovering back. I think it would be sensible
+                  to work towards a departure date in mid-end March 2026, to allow us to recoup back debts, to recoup back
+                  historic debts, to complete our dispute with the utility provider and Ofgem, and to issue our payment
+                  plan for roof payments so this is set up for the new factor and residents.
+                </p>
+                <p>
+                  I will in the meantime get a set date for the pool windows to be cleared as agreed at the AGM, and send
+                  out details of Jimmys role (in detail) as requested by owners at the AGM.
+                </p>
+                <p>
+                  We also have an active leak in 3 flats in block 45 that we are dealing with currently, as well as 11
+                  active leaks elsewhere, so Im sure you can apprecaite, we have to prioritise these as well.
+                </p>
+                <p>I will be in contact shortly, in the meantime have a very pleasant Christmas and New Year.</p>
+                <p>Kind regards,</p>
+                <p>Pedrom Aghabala</p>
+                <p>Director</p>
+                <p>Fior Asset &amp; Property</p>
+              </div>
+            </div>
+          </div>
+        </div>
+      )}
     </GlassCard>
   );
 }

--- a/src/app/owners/secure/page.tsx
+++ b/src/app/owners/secure/page.tsx
@@ -3,7 +3,7 @@
 import Link from 'next/link';
 import { useRouter } from 'next/navigation';
 import { useEffect, useState, type ReactNode } from 'react';
-import { motion, useReducedMotion } from 'framer-motion';
+import { AnimatePresence, motion, useReducedMotion } from 'framer-motion';
 import { Calendar, CalendarPlus, ClipboardCheck, Clock, FileText, Mail, Monitor, Users } from 'lucide-react';
 
 import { GlassCard } from '@/components/GlassCard';

--- a/src/app/owners/secure/page.tsx
+++ b/src/app/owners/secure/page.tsx
@@ -4,7 +4,7 @@ import Link from 'next/link';
 import { useRouter } from 'next/navigation';
 import { useEffect, useState, type ReactNode } from 'react';
 import { AnimatePresence, motion, useReducedMotion } from 'framer-motion';
-import { Calendar, CalendarPlus, ClipboardCheck, Clock, FileText, Monitor, Users } from 'lucide-react';
+import { Calendar, CalendarPlus, ClipboardCheck, Clock, FileText, Mail, Monitor, Users } from 'lucide-react';
 
 import { GlassCard } from '@/components/GlassCard';
 import GradientBG from '@/components/GradientBG';
@@ -450,63 +450,81 @@ function FiorFactorUpdateSection() {
         </button>
       </div>
 
-      {showEmail && (
-        <div className="fixed inset-0 z-50 flex items-center justify-center bg-black/50 px-4 py-6 sm:px-0">
-          <div className="glass-surface glass-outline w-full max-w-3xl p-6 sm:p-8">
-            <div className="flex items-start justify-between gap-4">
-              <h3 className="text-lg font-semibold text-slate-900 dark:text-slate-100">Original email</h3>
-              <button
-                type="button"
-                onClick={() => setShowEmail(false)}
-                className="text-sm font-semibold text-slate-600 hover:text-slate-900 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-slate-500 dark:text-slate-300 dark:hover:text-white"
-              >
-                Close
-              </button>
-            </div>
-
-            <p className="mt-4 text-sm text-slate-600 dark:text-slate-300">
-              The following is the original email received from Fior Asset &amp; Property Management on 19 December 2025.
-            </p>
-
-            <div className="mt-4 rounded-2xl border border-black/10 bg-white/80 p-5 text-sm text-slate-800 shadow-inner dark:border-white/15 dark:bg-white/5 dark:text-slate-100">
-              <div className="space-y-2">
-                <p>
-                  <span className="font-semibold text-slate-900 dark:text-slate-100">From:</span> Pedrom Aghabala, Director – Fior Asset &amp;
-                  Property
-                </p>
-                <p>
-                  <span className="font-semibold text-slate-900 dark:text-slate-100">Date:</span> 19 December 2025
-                </p>
-                <p>
-                  <span className="font-semibold text-slate-900 dark:text-slate-100">Subject:</span> Correspondence regarding James Square
-                </p>
+      <AnimatePresence>
+        {showEmail && (
+          <motion.div
+            className="fixed inset-0 z-50 flex items-center justify-center bg-black/50 px-4 py-6 sm:px-0"
+            initial={{ opacity: 0 }}
+            animate={{ opacity: 1 }}
+            exit={{ opacity: 0 }}
+          >
+            <motion.div
+              className="glass-surface glass-outline w-full max-w-3xl p-6 sm:p-8"
+              initial={{ opacity: 0, y: 12, scale: 0.98 }}
+              animate={{ opacity: 1, y: 0, scale: 1 }}
+              exit={{ opacity: 0, y: 12, scale: 0.98 }}
+              transition={{ duration: 0.2, ease: 'easeOut' }}
+            >
+              <div className="flex items-start justify-between gap-4">
+                <div className="flex items-center gap-3">
+                  <span className="flex h-10 w-10 items-center justify-center rounded-full bg-slate-100 text-slate-700 dark:bg-white/10 dark:text-slate-200">
+                    <Mail className="h-5 w-5" aria-hidden="true" />
+                  </span>
+                  <h3 className="text-lg font-semibold text-slate-900 dark:text-slate-100">Original email</h3>
+                </div>
+                <button
+                  type="button"
+                  onClick={() => setShowEmail(false)}
+                  className="text-sm font-semibold text-slate-600 hover:text-slate-900 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-slate-500 dark:text-slate-300 dark:hover:text-white"
+                >
+                  Close
+                </button>
               </div>
-              <div className="mt-4 space-y-4 whitespace-pre-line">
-                <p>Dear Owners,</p>
-                <p>
-                  We are writing to confirm that Fior Asset &amp; Property Management intends to step down as factor for James Square. We are
-                  proposing a managed departure to allow outstanding matters to be addressed, including completion of financial
-                  reconciliation, recovery of outstanding and historic debts, resolution of ongoing utility matters, and the orderly
-                  handover of information to a new factor.
-                </p>
-                <p>
-                  Updated invoices were issued to owners prior to the Christmas period and a full financial report will follow. Several
-                  active building issues are currently being dealt with, including multiple water leaks across the development, and
-                  actions agreed at the AGM, such as the pool window works and clarification of staff roles, are being progressed.
-                </p>
-                <p>
-                  Plans are now in place to review and appoint a new factor for James Square, and further information will be shared as
-                  this process moves forward. A meeting has been arranged for owners on Wednesday 21 January at 6:00 pm to discuss the
-                  factoring arrangements and next steps in more detail.
-                </p>
-                <p>Kind regards,</p>
-                <p>Pedrom Aghabala</p>
-                <p>Director – Fior Asset &amp; Property</p>
+
+              <p className="mt-4 text-sm text-slate-600 dark:text-slate-300">
+                The following is the original email received from Fior Asset &amp; Property Management on 19 December 2025.
+              </p>
+
+              <div className="mt-4 rounded-2xl border border-black/10 bg-white/80 p-5 text-sm text-slate-800 shadow-inner dark:border-white/15 dark:bg-white/5 dark:text-slate-100">
+                <div className="space-y-2">
+                  <p>
+                    <span className="font-semibold text-slate-900 dark:text-slate-100">From:</span> Pedrom Aghabala, Director – Fior Asset
+                    &amp; Property
+                  </p>
+                  <p>
+                    <span className="font-semibold text-slate-900 dark:text-slate-100">Date:</span> 19 December 2025
+                  </p>
+                  <p>
+                    <span className="font-semibold text-slate-900 dark:text-slate-100">Subject:</span> Correspondence regarding James Square
+                  </p>
+                </div>
+                <div className="mt-4 space-y-4 whitespace-pre-line">
+                  <p>Dear Owners,</p>
+                  <p>
+                    We are writing to confirm that Fior Asset &amp; Property Management intends to step down as factor for James Square. We
+                    are proposing a managed departure to allow outstanding matters to be addressed, including completion of financial
+                    reconciliation, recovery of outstanding and historic debts, resolution of ongoing utility matters, and the orderly
+                    handover of information to a new factor.
+                  </p>
+                  <p>
+                    Updated invoices were issued to owners prior to the Christmas period and a full financial report will follow. Several
+                    active building issues are currently being dealt with, including multiple water leaks across the development, and
+                    actions agreed at the AGM, such as the pool window works and clarification of staff roles, are being progressed.
+                  </p>
+                  <p>
+                    Plans are now in place to review and appoint a new factor for James Square, and further information will be shared as
+                    this process moves forward. A meeting has been arranged for owners on Wednesday 21 January at 6:00 pm to discuss the
+                    factoring arrangements and next steps in more detail.
+                  </p>
+                  <p>Kind regards,</p>
+                  <p>Pedrom Aghabala</p>
+                  <p>Director – Fior Asset &amp; Property</p>
+                </div>
               </div>
-            </div>
-          </div>
-        </div>
-      )}
+            </motion.div>
+          </motion.div>
+        )}
+      </AnimatePresence>
     </GlassCard>
   );
 }

--- a/src/app/owners/secure/page.tsx
+++ b/src/app/owners/secure/page.tsx
@@ -409,6 +409,8 @@ function SgmSection() {
 }
 
 function FiorFactorUpdateSection() {
+  const [showEmail, setShowEmail] = useState(false);
+
   return (
     <GlassCard title="Fior Factor Update" titleClassName="text-2xl font-semibold text-slate-900 dark:text-slate-100">
       <div className="space-y-3 text-sm md:text-base text-slate-700 dark:text-slate-200">
@@ -437,7 +439,74 @@ function FiorFactorUpdateSection() {
           on Wednesday 21 January at 6:00 pm. Further details of this meeting will be shared shortly, and owners are
           encouraged to attend.
         </p>
+        <p>For transparency, owners may view the original email received from Fior Asset &amp; Property Management on 19 December 2025.</p>
+        <button
+          type="button"
+          onClick={() => setShowEmail(true)}
+          className="inline-flex items-center justify-center gap-2 rounded-xl border border-black/10 bg-white/85 px-4 py-3 text-sm font-semibold text-slate-900 shadow-sm transition-all duration-150 ease-out hover:bg-white/95 hover:shadow-md focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-slate-500 dark:border-white/15 dark:bg-white/20 dark:text-white dark:hover:bg-white/25"
+        >
+          <FileText className="h-4 w-4 text-slate-500 dark:text-slate-300" aria-hidden="true" />
+          <span>View original email</span>
+        </button>
       </div>
+
+      {showEmail && (
+        <div className="fixed inset-0 z-50 flex items-center justify-center bg-black/50 px-4 py-6 sm:px-0">
+          <div className="glass-surface glass-outline w-full max-w-3xl p-6 sm:p-8">
+            <div className="flex items-start justify-between gap-4">
+              <h3 className="text-lg font-semibold text-slate-900 dark:text-slate-100">Original email</h3>
+              <button
+                type="button"
+                onClick={() => setShowEmail(false)}
+                className="text-sm font-semibold text-slate-600 hover:text-slate-900 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-slate-500 dark:text-slate-300 dark:hover:text-white"
+              >
+                Close
+              </button>
+            </div>
+
+            <p className="mt-4 text-sm text-slate-600 dark:text-slate-300">
+              The following is the original email received from Fior Asset &amp; Property Management on 19 December 2025.
+            </p>
+
+            <div className="mt-4 rounded-2xl border border-black/10 bg-white/80 p-5 text-sm text-slate-800 shadow-inner dark:border-white/15 dark:bg-white/5 dark:text-slate-100">
+              <div className="space-y-2">
+                <p>
+                  <span className="font-semibold text-slate-900 dark:text-slate-100">From:</span> Pedrom Aghabala, Director – Fior Asset &amp;
+                  Property
+                </p>
+                <p>
+                  <span className="font-semibold text-slate-900 dark:text-slate-100">Date:</span> 19 December 2025
+                </p>
+                <p>
+                  <span className="font-semibold text-slate-900 dark:text-slate-100">Subject:</span> Correspondence regarding James Square
+                </p>
+              </div>
+              <div className="mt-4 space-y-4 whitespace-pre-line">
+                <p>Dear Owners,</p>
+                <p>
+                  We are writing to confirm that Fior Asset &amp; Property Management intends to step down as factor for James Square. We are
+                  proposing a managed departure to allow outstanding matters to be addressed, including completion of financial
+                  reconciliation, recovery of outstanding and historic debts, resolution of ongoing utility matters, and the orderly
+                  handover of information to a new factor.
+                </p>
+                <p>
+                  Updated invoices were issued to owners prior to the Christmas period and a full financial report will follow. Several
+                  active building issues are currently being dealt with, including multiple water leaks across the development, and
+                  actions agreed at the AGM, such as the pool window works and clarification of staff roles, are being progressed.
+                </p>
+                <p>
+                  Plans are now in place to review and appoint a new factor for James Square, and further information will be shared as
+                  this process moves forward. A meeting has been arranged for owners on Wednesday 21 January at 6:00 pm to discuss the
+                  factoring arrangements and next steps in more detail.
+                </p>
+                <p>Kind regards,</p>
+                <p>Pedrom Aghabala</p>
+                <p>Director – Fior Asset &amp; Property</p>
+              </div>
+            </div>
+          </div>
+        </div>
+      )}
     </GlassCard>
   );
 }

--- a/src/app/owners/secure/page.tsx
+++ b/src/app/owners/secure/page.tsx
@@ -459,7 +459,7 @@ function FiorFactorUpdateSection() {
             exit={{ opacity: 0 }}
           >
             <motion.div
-              className="glass-surface glass-outline w-full max-w-3xl p-6 sm:p-8"
+              className="glass-surface glass-outline w-full max-w-3xl p-6 sm:p-8 max-h-[85vh] overflow-y-auto"
               initial={{ opacity: 0, y: 12, scale: 0.98 }}
               animate={{ opacity: 1, y: 0, scale: 1 }}
               exit={{ opacity: 0, y: 12, scale: 0.98 }}
@@ -485,7 +485,7 @@ function FiorFactorUpdateSection() {
                 The following is the original email received from Fior Asset &amp; Property Management on 19 December 2025.
               </p>
 
-              <div className="mt-4 rounded-2xl border border-black/10 bg-white/80 p-5 text-sm text-slate-800 shadow-inner dark:border-white/15 dark:bg-white/5 dark:text-slate-100">
+              <div className="mt-4 rounded-2xl border border-black/10 bg-white/90 p-5 text-sm text-slate-800 shadow-inner dark:border-white/15 dark:bg-slate-950/40 dark:text-slate-100">
                 <div className="space-y-2">
                   <p>
                     <span className="font-semibold text-slate-900 dark:text-slate-100">From:</span> Pedrom Aghabala, Director – Fior Asset


### PR DESCRIPTION
### Motivation

- Improve transparency by allowing owners to view the original Fior email referenced in the Fior Factor Update while keeping the existing summary as primary context.  
- Present the email in a neutral, read-only view with header fields and the unedited body to avoid commentary or framing.  
- Keep the email accessible only inside the owners secure area and avoid changing access control or routing.  

### Description

- Updated `src/app/owners/secure/page.tsx` to add a new state variable `showEmail`, a neutral one-line notice, and a `View original email` button under the `Fior Factor Update` section.  
- Implemented a modal that opens on button click and displays the preface line, the header details (`From`, `Date`, `Subject`) and the full original email body and signature in plain, unaltered text.  
- The modal includes a `Close` button and uses existing styling conventions; no access control or routing logic was modified.  

### Testing

- Launched the development server with `npm run dev` which compiled the `/owners/secure` page successfully but subsequent requests returned HTTP 500 due to Firebase `auth/invalid-api-key` configuration errors.  
- Attempted automated browser verification with Playwright to open the page and capture a screenshot, but the Playwright runs timed out or failed because the app returned errors and fonts failed to download.  
- No unit or integration tests were added or run for this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_696238c1132c8324b352669cb8cb91f8)