### PR TITLE
Add AppModeGate + global safe-area spacing (site-content)

### DIFF
--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -18,6 +18,9 @@
   --glass: 0 0% 100% / 0.68;
   --glass-strong: 0 0% 100% / 0.82;
   --glass-border: 215 30% 62% / 0.24;
+  --nav-height: 64px;
+  --safe-top: 0px;
+  --content-gap: 12px;
 
   --status-emerald: 145 63% 49%;  /* #2ECC71 - your booking */
   --status-slate:   204 8% 52%;   /* #7F8C8D - booked by another */
@@ -64,12 +67,26 @@ body {
   -moz-osx-font-smoothing: grayscale;
 }
 
-.safe-top {
-  padding-top: env(safe-area-inset-top);
+body.app-mode {
+  --safe-top: env(safe-area-inset-top, 0px);
 }
 
 .site-header {
   width: 100%;
+}
+
+body.app-mode .site-header {
+  padding-top: var(--safe-top);
+  backdrop-filter: blur(18px);
+  -webkit-backdrop-filter: blur(18px);
+}
+
+body.app-mode .site-header.is-fixed {
+  top: var(--safe-top);
+}
+
+body.app-mode .site-content {
+  padding-top: calc(var(--safe-top) + var(--nav-height) + var(--content-gap));
 }
 
 @supports (padding: env(safe-area-inset-top)) {

--- a/src/app/how-to-app/page.tsx
+++ b/src/app/how-to-app/page.tsx
@@ -88,7 +88,7 @@ export default function HowToAppPage() {
 
   return (
     <motion.main
-      className="min-h-[calc(100vh-64px)] w-full bg-slate-50 text-slate-900 dark:bg-[#070B14] dark:text-white"
+      className="min-h-screen w-full bg-slate-50 text-slate-900 dark:bg-[#070B14] dark:text-white"
       initial={{ opacity: 0 }}
       animate={{ opacity: 1 }}
       transition={{ duration: 0.4 }}

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -5,6 +5,7 @@ import "./globals.css";
 import Header from "@/components/Header";
 import { AuthProvider } from "@/context/AuthContext";
 import AppLaunchShell from "@/components/AppLaunchShell";
+import AppModeGate from "@/components/layout/AppModeGate";
 
 const geistSans = Geist({ subsets: ["latin"], variable: "--font-geist-sans" });
 const geistMono = Geist_Mono({ subsets: ["latin"], variable: "--font-geist-mono" });
@@ -60,10 +61,11 @@ export default function RootLayout({ children }: { children: React.ReactNode }) 
         <meta name="apple-mobile-web-app-status-bar-style" content="black-translucent" />
       </head>
       <body className={`${geistSans.variable} ${geistMono.variable} antialiased min-h-screen`}>
+        <AppModeGate />
         <AppLaunchShell>
           <AuthProvider>
             <Header />
-            <main className="max-w-6xl mx-auto px-4 sm:px-6 py-8">{children}</main>
+            <main className="site-content max-w-6xl mx-auto px-4 sm:px-6 py-8">{children}</main>
           </AuthProvider>
         </AppLaunchShell>
       </body>

--- a/src/components/Header.tsx
+++ b/src/components/Header.tsx
@@ -194,7 +194,7 @@ export default function Header() {
   return (
     <header
       className={[
-        "site-header fixed top-0 left-0 right-0 z-50 safe-top",
+        "site-header is-fixed fixed top-0 left-0 right-0 z-50",
         "transition-transform duration-300 ease-out",
         hidden ? "-translate-y-full" : "translate-y-0",
         "md:translate-y-0"

--- a/src/components/layout/AppModeGate.tsx
+++ b/src/components/layout/AppModeGate.tsx
@@ -1,0 +1,15 @@
+"use client";
+
+import { useEffect } from "react";
+import { useAppMode } from "@/hooks/useAppMode";
+
+export default function AppModeGate() {
+  const isApp = useAppMode();
+
+  useEffect(() => {
+    document.body.classList.toggle("app-mode", isApp);
+    document.body.setAttribute("data-display-mode", isApp ? "standalone" : "browser");
+  }, [isApp]);
+
+  return null;
+}

--- a/src/hooks/useAppMode.ts
+++ b/src/hooks/useAppMode.ts
@@ -1,0 +1,17 @@
+"use client";
+
+import { useEffect, useState } from "react";
+
+export function useAppMode() {
+  const [isApp, setIsApp] = useState(false);
+
+  useEffect(() => {
+    const iosStandalone = (window.navigator as { standalone?: boolean }).standalone === true;
+    const standalone = window.matchMedia?.("(display-mode: standalone)")?.matches;
+    const fullscreen = window.matchMedia?.("(display-mode: fullscreen)")?.matches;
+
+    setIsApp(Boolean(iosStandalone || standalone || fullscreen));
+  }, []);
+
+  return isApp;
+}


### PR DESCRIPTION
### Motivation

- Ensure the top navigation never overlaps page content when the site runs in app/standalone mode by reserving safe-area + nav space globally.  
- Detect app/standalone modes on the client without converting the server `RootLayout` to a client component.  
- Let CSS handle offsets via variables so every page inherits the fix and per-page hacks are no longer needed.  
- Keep browser mode behavior unchanged.

### Description

- Add a client hook `useAppMode` at `src/hooks/useAppMode.ts` to detect `standalone`/`fullscreen`/iOS `navigator.standalone`.  
- Add a client bridge `AppModeGate` at `src/components/layout/AppModeGate.tsx` that toggles `body.app-mode` and `data-display-mode`.  
- Inject `AppModeGate` into the server `RootLayout` (`src/app/layout.tsx`) and wrap children in a `.site-content` main to receive the global top padding.  
- Update `src/app/globals.css` to add `--nav-height`, `--safe-top`, and `--content-gap` and apply `body.app-mode` rules to pad `.site-header` and add `padding-top` to `.site-content`; update `Header.tsx` and `how-to-app` to use the global layout instead of per-page padding.

### Testing

- Started the dev server with `npm run dev` and Next compiled `/how-to-app` successfully, but a runtime Firebase error `auth/invalid-api-key` caused the page to return HTTP 500.  
- Attempted an automated Playwright screenshot, which timed out/failed because the app endpoint returned an error and the script could not complete.  
- Grep/inspections were run to confirm `AppModeGate` is referenced in `layout.tsx` and `.site-content` is used instead of the previous per-page wrapper.  
- No unit/CI tests were executed as part of this change set.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69626a6e8140832497c5b6f118e4dd02)