### PR TITLE
Add mode-aware hero image dissolve layers

### DIFF
--- a/src/app/HomePageClient.tsx
+++ b/src/app/HomePageClient.tsx
@@ -336,7 +336,7 @@ export default function HomePageClient() {
           </div>
 
           <div className="p-6 sm:p-10">
-            <header className="text-center">
+            <header className="text-center -mt-3 sm:-mt-4">
               <h1 className="text-3xl sm:text-4xl font-bold leading-tight">
                 James <span className="text-slate-500">Square</span>
                 <br />

--- a/src/app/HomePageClient.tsx
+++ b/src/app/HomePageClient.tsx
@@ -284,18 +284,43 @@ export default function HomePageClient() {
                 "
               />
 
-              {/* DARK MODE — bottom blend into surface */}
-              <div
-                className="
-                  absolute bottom-0 inset-x-0
-                  h-32 sm:h-40
-                  bg-gradient-to-t
-                  from-[#020617]
-                  via-[#020617]/92
-                  to-transparent
-                  hidden dark:block
-                "
-              />
+              {/* DARK MODE — contrast-first blend (prevents cut line) */}
+              <div className="pointer-events-none absolute inset-0 hidden dark:block">
+                {/* Stage 1: contrast dampening (this is the key) */}
+                <div
+                  className="
+                    absolute bottom-0 inset-x-0
+                    h-32 sm:h-40
+                    bg-gradient-to-t
+                    from-black/20
+                    via-black/10
+                    to-transparent
+                  "
+                />
+
+                {/* Stage 2: luminance reduction (softens image without blur) */}
+                <div
+                  className="
+                    absolute bottom-0 inset-x-0
+                    h-28 sm:h-36
+                    bg-gradient-to-t
+                    from-black/35
+                    to-transparent
+                    mix-blend-mode:multiply
+                  "
+                />
+
+                {/* Stage 3: final colour integration */}
+                <div
+                  className="
+                    absolute bottom-0 inset-x-0
+                    h-24 sm:h-32
+                    bg-gradient-to-t
+                    from-[#020617]
+                    to-transparent
+                  "
+                />
+              </div>
 
               {/* Micro edge blur — line breaker only */}
               <div

--- a/src/app/HomePageClient.tsx
+++ b/src/app/HomePageClient.tsx
@@ -245,7 +245,7 @@ export default function HomePageClient() {
               <div
                 className="
                   absolute bottom-0 inset-x-0
-                  h-24 sm:h-28
+                  h-16 sm:h-20
                   bg-gradient-to-t
                   from-[#f4f7fa]
                   via-[#f4f7fa]/85
@@ -297,12 +297,12 @@ export default function HomePageClient() {
                 "
               />
 
-              {/* Micro blur band — kills visible edge in BOTH modes */}
+              {/* Micro edge blur — line breaker only */}
               <div
                 className="
                   absolute bottom-0 inset-x-0
-                  h-36 sm:h-44
-                  backdrop-blur-[1.25px]
+                  h-6 sm:h-8
+                  backdrop-blur-[0.75px]
                 "
               />
             </div>

--- a/src/app/HomePageClient.tsx
+++ b/src/app/HomePageClient.tsx
@@ -216,9 +216,6 @@ export default function HomePageClient() {
               }}
               style={{
                 willChange: 'transform',
-                maskImage: 'radial-gradient(ellipse at center, black 65%, transparent 100%)',
-                WebkitMaskImage:
-                  'radial-gradient(ellipse at center, black 65%, transparent 100%)',
               }}
             >
               {/* Light mode – daytime drone */}
@@ -241,6 +238,74 @@ export default function HomePageClient() {
                 className="w-full h-[200px] sm:h-[320px] object-cover hidden dark:block"
               />
             </motion.div>
+
+            {/* Mode-aware hero image dissolve */}
+            <div className="pointer-events-none absolute inset-0">
+              {/* LIGHT MODE — bottom-only, late, soft fade */}
+              <div
+                className="
+                  absolute bottom-0 inset-x-0
+                  h-24 sm:h-28
+                  bg-gradient-to-t
+                  from-[#f4f7fa]
+                  via-[#f4f7fa]/85
+                  to-transparent
+                  dark:hidden
+                "
+              />
+
+              {/* DARK MODE — subtle top softening (keeps castle clear) */}
+              <div
+                className="
+                  absolute top-0 inset-x-0
+                  h-14 sm:h-18
+                  bg-gradient-to-b
+                  from-black/25
+                  to-transparent
+                  hidden dark:block
+                "
+              />
+
+              {/* DARK MODE — side softening (stronger near bottom) */}
+              <div
+                className="
+                  absolute inset-y-0 left-0 w-10
+                  bg-gradient-to-r
+                  from-black/30 to-transparent
+                  hidden dark:block
+                "
+              />
+              <div
+                className="
+                  absolute inset-y-0 right-0 w-10
+                  bg-gradient-to-l
+                  from-black/30 to-transparent
+                  hidden dark:block
+                "
+              />
+
+              {/* DARK MODE — bottom blend into surface */}
+              <div
+                className="
+                  absolute bottom-0 inset-x-0
+                  h-32 sm:h-40
+                  bg-gradient-to-t
+                  from-[#020617]
+                  via-[#020617]/92
+                  to-transparent
+                  hidden dark:block
+                "
+              />
+
+              {/* Micro blur band — kills visible edge in BOTH modes */}
+              <div
+                className="
+                  absolute bottom-0 inset-x-0
+                  h-36 sm:h-44
+                  backdrop-blur-[1.25px]
+                "
+              />
+            </div>
 
             <div className="relative h-[200px] sm:h-[320px]" />
           </div>


### PR DESCRIPTION
### Motivation
- Replace the previous radial mask approach with a layered, mode-aware dissolve so the hero images blend naturally into the card surface without hard edges.
- Preserve the square and castle focal points while providing distinct, subtle fades for light and dark themes.

### Description
- Removed the radial `maskImage` / `WebkitMaskImage` from the hero image container to allow the new dissolve layers to control the fade.
- Added a `pointer-events-none absolute inset-0` dissolve block containing mode-aware gradient layers: a late soft bottom fade for light mode and a set of top/side/bottom gradient layers for dark mode.
- Added a micro blur band (`backdrop-blur-[1.25px]`) across the bottom to remove visible gradient cutoff lines in both modes.
- Kept the motion/scale behavior intact and only adjusted the inline `style` to remove the mask, leaving `willChange: 'transform'`.

### Testing
- Started the dev server with `npm run dev`, which compiled the app successfully but reported font download warnings and a `FirebaseError: auth/invalid-api-key` that caused the app GET to return `500` during the run.
- Ran an automated Playwright script that loaded the home page and captured light and dark screenshots, which completed and produced artifacts (`artifacts/home-hero-light.png` and `artifacts/home-hero-dark.png`).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_696b62af863483249eb5681f48fc7604)