### PR TITLE
Adjust app-mode top spacing and nav clearance

### DIFF
--- a/src/app/HomePageClient.tsx
+++ b/src/app/HomePageClient.tsx
@@ -197,7 +197,7 @@ export default function HomePageClient() {
   return (
     <main className="px-4 py-10 sm:py-14">
       {/* HERO */}
-      <section className="mx-auto max-w-6xl">
+      <section className="hero mx-auto max-w-6xl">
         <motion.div
           initial={{ opacity: 0, y: 10 }}
           animate={{ opacity: 1, y: 0 }}

--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -19,8 +19,8 @@
   --glass-strong: 0 0% 100% / 0.82;
   --glass-border: 215 30% 62% / 0.24;
   --nav-height: 64px;
-  --safe-top: 0px;
-  --content-gap: 12px;
+  --app-safe-top: 0px;
+  --page-top-gap: 24px;
 
   --status-emerald: 145 63% 49%;  /* #2ECC71 - your booking */
   --status-slate:   204 8% 52%;   /* #7F8C8D - booked by another */
@@ -68,14 +68,16 @@ body {
 }
 
 body.app-mode {
-  --safe-top: env(safe-area-inset-top, 0px);
+  --nav-height: 72px;
+  --app-safe-top: env(safe-area-inset-top, 0px);
+  --page-top-gap: 12px;
 }
 
 .header-safe-wrapper {
   position: sticky;
   top: 0;
   z-index: 50;
-  padding-top: var(--safe-top);
+  padding-top: 0;
   pointer-events: none;
 }
 
@@ -123,25 +125,33 @@ body.app-mode .site-header:active {
   -webkit-backdrop-filter: blur(24px) saturate(150%);
 }
 
-body.app-mode nav {
+body.app-mode nav.site-header {
   position: sticky;
   top: 0;
   z-index: 50;
   overflow: visible;
+  padding-top: var(--app-safe-top);
+  height: calc(var(--nav-height) + var(--app-safe-top));
 }
 
 body.app-mode .site-content {
-  padding-top: calc(var(--safe-top) + var(--nav-height) + var(--content-gap));
   position: relative;
   z-index: 1;
 }
 
 body.app-mode .site-content * {
-  scroll-margin-top: calc(var(--safe-top) + var(--nav-height) + 8px);
+  scroll-margin-top: calc(
+    var(--app-safe-top) + var(--nav-height) + var(--page-top-gap) + 8px
+  );
 }
 
 body.app-mode .dashboard-tabs {
-  top: calc(var(--safe-top) + var(--nav-height));
+  top: calc(var(--app-safe-top) + var(--nav-height));
+}
+
+body.app-mode .hero,
+body.app-mode .page-hero {
+  margin-top: 0;
 }
 
 @supports (padding: env(safe-area-inset-top)) {

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -65,7 +65,9 @@ export default function RootLayout({ children }: { children: React.ReactNode }) 
         <AppLaunchShell>
           <AuthProvider>
             <Header />
-            <main className="site-content max-w-6xl mx-auto px-4 sm:px-6 py-8">{children}</main>
+            <main className="site-content relative max-w-6xl mx-auto px-4 sm:px-6 pt-[calc(var(--nav-height)+var(--app-safe-top)+var(--page-top-gap))] pb-16">
+              {children}
+            </main>
           </AuthProvider>
         </AppLaunchShell>
       </body>

--- a/src/app/local/page.tsx
+++ b/src/app/local/page.tsx
@@ -252,7 +252,7 @@ export default function UsefulInfoPage() {
       <BackgroundOrbs />
 
       {/* Hero */}
-      <section className="text-center mb-10 relative">
+      <section className="page-hero text-center mb-10 relative">
         <h1 className="text-4xl md:text-5xl font-semibold tracking-tight">
           Useful Information
         </h1>

--- a/src/components/Header.tsx
+++ b/src/components/Header.tsx
@@ -210,7 +210,7 @@ export default function Header() {
       ].join(" ")}
     >
       <div className="site-header-shell">
-        <header className="site-header mx-auto max-w-6xl px-4 sm:px-6">
+        <nav className="site-header mx-auto max-w-6xl px-4 sm:px-6" aria-label="Primary">
           <div className="flex items-center justify-between px-3 sm:px-4 py-2">
             {/* Brand */}
             <motion.div whileHover={{ scale: 1.02 }} className="rounded-xl">
@@ -247,7 +247,7 @@ export default function Header() {
             </motion.div>
 
             {/* Desktop nav */}
-            <nav className="hidden sm:block">
+            <div className="hidden sm:block">
               <ul className="flex items-center gap-2 text-sm">
                 <NavLink href="/book" label="Book Facilities" />
                 <NavLink href="/dashboard" label="My Dashboard" />
@@ -278,7 +278,7 @@ export default function Header() {
                   <NavLink href="/login" label="Sign In" />
                 )}
               </ul>
-            </nav>
+            </div>
 
             {/* Mobile toggle */}
             <motion.button
@@ -295,7 +295,7 @@ export default function Header() {
               <span className="relative z-10">{open ? "Close" : "Menu"}</span>
             </motion.button>
           </div>
-        </header>
+        </nav>
       </div>
 
       {/* Mobile sheet */}


### PR DESCRIPTION
### Motivation
- Remove the doubled top offset in app/standalone mode by making the nav own safe-area clearance and centralising page breathing room so heroes sit directly under the nav.

### Description
- Introduce new CSS tokens and behaviour in `src/app/globals.css`: add `--app-safe-top` and `--page-top-gap`, set `body.app-mode` `--nav-height`, move safe-area handling into the nav, and add `body.app-mode .hero, .page-hero { margin-top: 0; }` to prevent per-page hero spacing in app mode.
- Update the global layout container in `src/app/layout.tsx` to apply top padding from `calc(var(--nav-height) + var(--app-safe-top) + var(--page-top-gap))` and use a consistent bottom padding.
- Adjust header semantics in `src/components/Header.tsx` by using `nav.site-header` as the primary sticky element and simplifying the internal nav wrapper so the header fully owns the top clearance.
- Mark hero sections by adding `hero` to `src/app/HomePageClient.tsx` and `page-hero` to `src/app/local/page.tsx` so the new app-mode override removes extra top margins.

### Testing
- Started the dev server with `npm run dev -- --hostname 0.0.0.0 --port 3000`, which launched Next but encountered runtime issues: Google Fonts fetch retries and a `Firebase: Error (auth/invalid-api-key)` reported during SSR, so server-side auth failed (partial/failing run).
- Ran a Playwright script that loaded the home page and produced a screenshot (`artifacts/app-home.png`) successfully, demonstrating the updated spacing rendering in the browser snapshot.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_696b86c84f588324b202bb17d834ff29)