### PR TITLE
Add custom voting windows and scheduled status

### DIFF
--- a/src/app/owners/voting/VotingClient.tsx
+++ b/src/app/owners/voting/VotingClient.tsx
@@ -67,6 +67,7 @@ export default function OwnersVotingPage() {
   }>({});
   const [askSuccess, setAskSuccess] = useState(false);
   const [submittingQuestion, setSubmittingQuestion] = useState(false);
+  const [askSubmitError, setAskSubmitError] = useState<string | null>(null);
   const [durationPreset, setDurationPreset] = useState<DurationPreset>("1m");
   const [useCustomWindow, setUseCustomWindow] = useState(false);
   const [startsAt, setStartsAt] = useState("");
@@ -253,7 +254,11 @@ export default function OwnersVotingPage() {
 
   const handleCreateQuestion = async (event: React.FormEvent) => {
     event.preventDefault();
-    if (!validateAsk()) return;
+    setAskSubmitError(null);
+    if (!validateAsk()) {
+      setAskSubmitError("Please fix the highlighted fields before publishing.");
+      return;
+    }
     setSubmittingQuestion(true);
     try {
       const filled = options.filter((o) => o.trim().length > 0);
@@ -270,6 +275,7 @@ export default function OwnersVotingPage() {
       const qs = await getQuestions();
       setQuestions(qs);
       setAskSuccess(true);
+      setAskSubmitError(null);
       setTitle("");
       setDescription("");
       setOptions(["", ""]);
@@ -280,6 +286,7 @@ export default function OwnersVotingPage() {
       setActiveTab("vote");
     } catch (error) {
       console.error("Failed to add question", error);
+      setAskSubmitError("Failed to publish question. Please try again.");
     } finally {
       setSubmittingQuestion(false);
     }
@@ -480,6 +487,12 @@ export default function OwnersVotingPage() {
                   <div className="flex items-center gap-3 text-sm bg-emerald-500/10 p-4 rounded-xl border border-emerald-500/20 shadow-inner shadow-emerald-900/20 text-emerald-800 dark:text-emerald-200">
                     <CheckCircle2 size={18} className="shrink-0" />
                     Question published. You can switch to the Vote tab to cast the first vote.
+                  </div>
+                )}
+                {askSubmitError && (
+                  <div className="flex items-center gap-3 text-sm bg-red-500/10 p-4 rounded-xl border border-red-500/20 text-red-700 dark:text-red-200">
+                    <AlertCircle size={18} className="shrink-0" />
+                    {askSubmitError}
                   </div>
                 )}
 

--- a/src/app/voting/components/Results.tsx
+++ b/src/app/voting/components/Results.tsx
@@ -175,13 +175,19 @@ const Results: React.FC = () => {
       {/* Individual Question Cards */}
       <div className="space-y-6">
         {stats.map((stat) => {
+          const startsAt =
+            stat.question.startsAt instanceof Date
+              ? stat.question.startsAt
+              : stat.question.startsAt
+                ? new Date(stat.question.startsAt)
+                : null;
           const expiresAt =
             stat.question.expiresAt instanceof Date
               ? stat.question.expiresAt
               : stat.question.expiresAt
                 ? new Date(stat.question.expiresAt)
                 : null;
-          const voteStatus = getVoteStatus(new Date(now), expiresAt);
+          const voteStatus = getVoteStatus(new Date(now), expiresAt, startsAt);
 
           return (
           <div key={stat.question.id} className="
@@ -196,8 +202,10 @@ const Results: React.FC = () => {
                 <h2 className="text-lg font-bold text-slate-900 leading-snug">{stat.question.title}</h2>
                 <span
                   className={`inline-flex px-3 py-1 text-xs font-semibold rounded-full border ${
-                    voteStatus.isExpired
+                    voteStatus.kind === 'closed'
                       ? 'bg-slate-100 text-slate-600 border-slate-200 dark:bg-white/10 dark:text-white/70 dark:border-white/15'
+                      : voteStatus.kind === 'scheduled'
+                        ? 'bg-amber-50 text-amber-700 border-amber-200 dark:bg-amber-500/15 dark:text-amber-100 dark:border-amber-300/60'
                       : 'bg-emerald-50 text-emerald-700 border-emerald-200 dark:bg-emerald-500/15 dark:text-emerald-100 dark:border-emerald-300/60'
                   }`}
                 >

--- a/src/app/voting/types.ts
+++ b/src/app/voting/types.ts
@@ -1,6 +1,6 @@
 import type { DurationPreset } from '@/lib/voteExpiry';
 
-export type QuestionStatus = 'open' | 'closed';
+export type QuestionStatus = 'open' | 'closed' | 'scheduled';
 
 export interface Option {
   id: string;
@@ -15,7 +15,8 @@ export interface Question {
   status: QuestionStatus;
   createdAt: number;
   durationPreset?: DurationPreset;
-  expiresAt?: number | Date | null;
+  startsAt?: Date | string | number | null;
+  expiresAt?: Date | string | number | null;
   voteTotals?: Record<string, number>;
 }
 

--- a/src/lib/voteExpiry.ts
+++ b/src/lib/voteExpiry.ts
@@ -38,18 +38,30 @@ export function formatTimeRemaining(ms: number): string {
   return "Closes soon";
 }
 
-export function getVoteStatus(now: Date, expiresAt?: Date | null) {
+export function getVoteStatus(now: Date, expiresAt?: Date | null, startsAt?: Date | null) {
+  if (startsAt && now.getTime() < startsAt.getTime()) {
+    return {
+      isExpired: false,
+      isOpen: false,
+      isScheduled: true,
+      label: 'Scheduled',
+      kind: 'scheduled' as const,
+    };
+  }
+
   if (!expiresAt) {
-    return { isExpired: false, label: "Open", kind: "open" as const };
+    return { isExpired: false, isOpen: true, isScheduled: false, label: "Open", kind: "open" as const };
   }
 
   const ms = expiresAt.getTime() - now.getTime();
   if (ms <= 0) {
-    return { isExpired: true, label: "Closed", kind: "closed" as const };
+    return { isExpired: true, isOpen: false, isScheduled: false, label: "Closed", kind: "closed" as const };
   }
 
   return {
     isExpired: false,
+    isOpen: true,
+    isScheduled: false,
     label: formatTimeRemaining(ms),
     kind: "open" as const,
   };


### PR DESCRIPTION
### Motivation
- Allow admins to create polls with an explicit UK start/end datetime window as an optional alternative to existing duration presets so votes can be scheduled and open/close automatically. 
- Keep the existing duration-preset flow fully intact and make the time logic a single source of truth. 
- Surface scheduled state to voters (visible but locked until start) and prevent early submissions at the UI/service level. 

### Description
- Extended the question model to include `startsAt?: Date | string | number | null` and added a `scheduled` status to `QuestionStatus` in `src/app/voting/types.ts`. 
- Added a `startsAt`-aware `getVoteStatus(now, expiresAt?, startsAt?)` in `src/lib/voteExpiry.ts` which returns `kind`/`isOpen`/`isScheduled` flags and a label used by the UI. 
- Updated storage APIs in `src/app/voting/services/storageService.ts` to accept a new optional `customWindow?: { startsAt: Date; expiresAt: Date }` argument in `addQuestion()`, persist `startsAt` when provided, keep `expiresAt` always, and set `status` to `scheduled` for custom windows while preserving duration presets for the existing flow. 
- Enhanced the Ask Question UI (`src/app/voting/components/AskQuestion.tsx`) with a mode selector (preset vs custom window), native `datetime-local` inputs, validation (both dates required, end > start, start in the future), and passing the `customWindow` to `addQuestion()`. 
- Updated all voting UI and clients (`Vote.tsx`, `Results.tsx`, `src/app/owners/voting/VotingClient.tsx`) to consume `startsAt`, use `getVoteStatus(...)` everywhere, show scheduled messaging ("Voting will open on ..."), and block submissions when a vote is not open. 
- Preserved backward compatibility: existing questions without `startsAt` keep using duration presets and unchanged behaviour; no Firestore migrations were required. 

### Testing
- Started the local voting sub-app dependencies with `npm install` in `src/app/voting` which completed successfully. 
- Launched the dev server with `npm run dev` for the voting sub-app and the Vite server reported ready and served the app (dev server start succeeded). 
- Ran a Playwright-based smoke script that captured a full-page screenshot (`artifacts/voting-page.png`) of the voting UI, which succeeded. 
- Attempted an automated interaction test to toggle the custom-window radio and capture a screenshot, but the locator step timed out (the interaction test failed to find the control in that run). 
- While exercising the UI, the Vite server reported an alias/import resolution issue for `@/lib/firebase` in the voting sub-app environment during one attempt; this did not affect committed code changes but impacted some local UI automation runs.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_696bef61adb48324b86e56d212cbb5eb)