### PR TITLE
Support scheduled voting windows, validate custom windows, and surface publish errors

### DIFF
--- a/firestore.rules
+++ b/firestore.rules
@@ -210,8 +210,10 @@ service cloud.firestore {
       // Anyone can create; basic shape and status validation
       allow create: if request.resource.data.keys().hasAll(['title', 'status', 'createdAt', 'options'])
         && request.resource.data.title is string
-        && request.resource.data.status in ['open', 'closed']
+        && request.resource.data.status in ['open', 'closed', 'scheduled']
         && request.resource.data.options is list
+        && (!('startsAt' in request.resource.data) || request.resource.data.startsAt is timestamp)
+        && (!('expiresAt' in request.resource.data) || request.resource.data.expiresAt is timestamp)
         && (!('voteTotals' in request.resource.data) || request.resource.data.voteTotals is map);
 
       // Admins can update/delete questions

--- a/src/app/voting/components/Results.tsx
+++ b/src/app/voting/components/Results.tsx
@@ -175,13 +175,19 @@ const Results: React.FC = () => {
       {/* Individual Question Cards */}
       <div className="space-y-6">
         {stats.map((stat) => {
+          const startsAt =
+            stat.question.startsAt instanceof Date
+              ? stat.question.startsAt
+              : stat.question.startsAt
+                ? new Date(stat.question.startsAt)
+                : null;
           const expiresAt =
             stat.question.expiresAt instanceof Date
               ? stat.question.expiresAt
               : stat.question.expiresAt
                 ? new Date(stat.question.expiresAt)
                 : null;
-          const voteStatus = getVoteStatus(new Date(now), expiresAt);
+          const voteStatus = getVoteStatus(new Date(now), expiresAt, startsAt);
 
           return (
           <div key={stat.question.id} className="
@@ -196,8 +202,10 @@ const Results: React.FC = () => {
                 <h2 className="text-lg font-bold text-slate-900 leading-snug">{stat.question.title}</h2>
                 <span
                   className={`inline-flex px-3 py-1 text-xs font-semibold rounded-full border ${
-                    voteStatus.isExpired
+                    voteStatus.kind === 'closed'
                       ? 'bg-slate-100 text-slate-600 border-slate-200 dark:bg-white/10 dark:text-white/70 dark:border-white/15'
+                      : voteStatus.kind === 'scheduled'
+                        ? 'bg-amber-50 text-amber-700 border-amber-200 dark:bg-amber-500/15 dark:text-amber-100 dark:border-amber-300/60'
                       : 'bg-emerald-50 text-emerald-700 border-emerald-200 dark:bg-emerald-500/15 dark:text-emerald-100 dark:border-emerald-300/60'
                   }`}
                 >

--- a/src/app/voting/types.ts
+++ b/src/app/voting/types.ts
@@ -1,6 +1,6 @@
 import type { DurationPreset } from '@/lib/voteExpiry';
 
-export type QuestionStatus = 'open' | 'closed';
+export type QuestionStatus = 'open' | 'closed' | 'scheduled';
 
 export interface Option {
   id: string;
@@ -15,7 +15,8 @@ export interface Question {
   status: QuestionStatus;
   createdAt: number;
   durationPreset?: DurationPreset;
-  expiresAt?: number | Date | null;
+  startsAt?: Date | string | number | null;
+  expiresAt?: Date | string | number | null;
   voteTotals?: Record<string, number>;
 }
 

--- a/src/lib/voteExpiry.ts
+++ b/src/lib/voteExpiry.ts
@@ -38,18 +38,30 @@ export function formatTimeRemaining(ms: number): string {
   return "Closes soon";
 }
 
-export function getVoteStatus(now: Date, expiresAt?: Date | null) {
+export function getVoteStatus(now: Date, expiresAt?: Date | null, startsAt?: Date | null) {
+  if (startsAt && now.getTime() < startsAt.getTime()) {
+    return {
+      isExpired: false,
+      isOpen: false,
+      isScheduled: true,
+      label: 'Scheduled',
+      kind: 'scheduled' as const,
+    };
+  }
+
   if (!expiresAt) {
-    return { isExpired: false, label: "Open", kind: "open" as const };
+    return { isExpired: false, isOpen: true, isScheduled: false, label: "Open", kind: "open" as const };
   }
 
   const ms = expiresAt.getTime() - now.getTime();
   if (ms <= 0) {
-    return { isExpired: true, label: "Closed", kind: "closed" as const };
+    return { isExpired: true, isOpen: false, isScheduled: false, label: "Closed", kind: "closed" as const };
   }
 
   return {
     isExpired: false,
+    isOpen: true,
+    isScheduled: false,
     label: formatTimeRemaining(ms),
     kind: "open" as const,
   };


### PR DESCRIPTION
### Motivation
- Allow owners to publish scheduled polls with explicit `startsAt`/`expiresAt` windows and ensure the client validates and surfaces errors when publishing fails.
- Prevent silent failures when creating questions with custom voting windows by validating inputs and wiring schedule fields through to storage.
- Update vote status logic so the UI correctly shows "scheduled", "open", and "closed" states based on start/end timestamps.

### Description
- Updated Firestore rules in `firestore.rules` to allow `status: 'scheduled'` on `voting_questions` and to validate optional `startsAt`/`expiresAt` timestamp fields on create.
- Extended the storage layer in `src/app/voting/services/storageService.ts` by adding `customWindow` support to `addQuestion`, storing `startsAt`/`expiresAt` (and setting `status` to `scheduled`), and mapping `startsAt` when reading question docs.
- Added `startsAt` handling to `getVoteStatus` in `src/lib/voteExpiry.ts` so scheduled questions are reported as `scheduled` until the start time and updated return shape to include `isOpen`/`isScheduled`/`kind`.
- Updated types in `src/app/voting/types.ts` to accept `startsAt` on `Question` and to include `scheduled` as a `QuestionStatus`.
- UI changes across `OwnersVotingPage` (`src/app/owners/voting/VotingClient.tsx`), `AskQuestion` (`src/app/voting/components/AskQuestion.tsx`), `Vote` (`src/app/voting/components/Vote.tsx`) and `Results` (`src/app/voting/components/Results.tsx`) to add custom window controls, client-side validation for `startsAt`/`endsAt`, an `askSubmitError` banner to surface publish failures or validation guidance, and to show scheduled/open/closed states and messages consistently.

### Testing
- No automated tests were run for this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_696bef61adb48324b86e56d212cbb5eb)