### PR TITLE
Improve mobile voting title layout and phase-aware UI

### DIFF
--- a/src/app/voting/components/CountdownTimer.tsx
+++ b/src/app/voting/components/CountdownTimer.tsx
@@ -3,13 +3,15 @@ import React, { useEffect, useMemo, useState } from 'react';
 interface CountdownTimerProps {
   expiresAt: Date;
   createdAt?: Date;
+  label?: string;
+  helperText?: string | null;
 }
 
 const RADIUS = 34;
 const STROKE = 6;
 const CIRCUMFERENCE = 2 * Math.PI * RADIUS;
 
-export default function CountdownTimer({ expiresAt, createdAt }: CountdownTimerProps) {
+export default function CountdownTimer({ expiresAt, createdAt, label, helperText }: CountdownTimerProps) {
   const [now, setNow] = useState<Date>(new Date());
   const [prefersReducedMotion, setPrefersReducedMotion] = useState(false);
 
@@ -38,6 +40,7 @@ export default function CountdownTimer({ expiresAt, createdAt }: CountdownTimerP
   const minutes = Math.floor(remainingMs / 60000);
   const seconds = Math.floor((remainingMs % 60000) / 1000);
   const timeLabel = isExpired ? 'Closed' : `${minutes.toString().padStart(2, '0')}:${seconds.toString().padStart(2, '0')} remaining`;
+  const resolvedHelperText = helperText === undefined ? 'Voting closes automatically' : helperText;
 
   const strokeDashoffset = CIRCUMFERENCE * (1 - percent);
 
@@ -50,12 +53,15 @@ export default function CountdownTimer({ expiresAt, createdAt }: CountdownTimerP
 
   return (
     <div className="flex flex-col items-center gap-2 text-center">
+      {label ? (
+        <div className="text-xs font-semibold text-slate-700 dark:text-slate-200">{label}</div>
+      ) : null}
       <svg
         width={80}
         height={80}
         viewBox="0 0 80 80"
         className="drop-shadow-sm"
-        aria-label={isExpired ? 'Voting closed' : `Voting closes in ${minutes} minutes and ${seconds} seconds`}
+        aria-label={isExpired ? 'Voting closed' : `${label ?? 'Voting closes in'} ${minutes} minutes and ${seconds} seconds`}
       >
         <circle
           cx="40"
@@ -92,7 +98,7 @@ export default function CountdownTimer({ expiresAt, createdAt }: CountdownTimerP
       </svg>
       <div className="text-[11px] text-slate-500 dark:text-slate-400 leading-tight">
         <div>{timeLabel}</div>
-        <div className="text-[10px]">Voting closes automatically</div>
+        {resolvedHelperText ? <div className="text-[10px]">{resolvedHelperText}</div> : null}
       </div>
     </div>
   );

--- a/src/app/voting/components/Vote.tsx
+++ b/src/app/voting/components/Vote.tsx
@@ -8,15 +8,32 @@ import { auth, db } from '@/lib/firebase';
 import { Question, Vote } from '../types';
 import { Button } from './ui/Button';
 import { Input } from './ui/Input';
-import { ArrowRight, AlertCircle, Check, Loader2 } from 'lucide-react';
+import { ArrowRight, AlertCircle, CalendarClock, Check, Loader2 } from 'lucide-react';
 import { getVoteStatus } from '@/lib/voteExpiry';
 import { lightHaptic } from '@/lib/haptics';
+import CountdownTimer from './CountdownTimer';
 
 const deriveFirstName = (user: User | null): string => {
   if (!user) return '';
   const base = user.displayName?.trim() || user.email?.split('@')[0] || '';
   const first = base.split(/[\s._-]+/).find(Boolean) || '';
   return first ? first.charAt(0).toUpperCase() + first.slice(1) : '';
+};
+
+const formatVotingDate = (date: Date): string => {
+  const datePart = new Intl.DateTimeFormat('en-GB', {
+    weekday: 'long',
+    day: '2-digit',
+    month: 'long',
+    year: 'numeric',
+  }).format(date).replace(',', '');
+  const timePart = new Intl.DateTimeFormat('en-GB', {
+    hour: '2-digit',
+    minute: '2-digit',
+    hour12: false,
+  }).format(date);
+
+  return `${datePart} at ${timePart}`;
 };
 
 const VotePage: React.FC = () => {
@@ -175,7 +192,7 @@ const VotePage: React.FC = () => {
       } catch (checkError) {
         if (!isActive) return;
         console.error('Failed to load existing vote', checkError);
-        setDuplicateMessage('Please confirm your flat number before submitting your vote.');
+        setDuplicateMessage('Please confirm your flat number before submitting your voting response.');
       } finally {
         if (isActive) setIsCheckingExistingVote(false);
       }
@@ -216,12 +233,12 @@ const VotePage: React.FC = () => {
     }
 
     if (!currentUser) {
-      setError('Please log in to vote.');
+      setError('Please log in to take part in voting.');
       return;
     }
 
     if (!trimmedName) {
-      setError("Please enter your name to vote.");
+      setError("Please enter your name to take part in voting.");
       return;
     }
     if (!selectedOptionId) {
@@ -229,7 +246,7 @@ const VotePage: React.FC = () => {
       return;
     }
     if (!normalizedFlat) {
-      setError("Please enter your flat number to vote.");
+      setError("Please enter your flat number to take part in voting.");
       return;
     }
 
@@ -248,11 +265,11 @@ const VotePage: React.FC = () => {
       sessionStorage.setItem('ovh_flat', normalizedFlat);
       await loadNextQuestion();
     } catch (err: unknown) {
-      let message = 'Unable to submit your vote right now. Please try again.';
+      let message = 'Unable to submit your voting response right now. Please try again.';
 
       if (err instanceof FirebaseError) {
         if (err.code === 'permission-denied') {
-          message = 'Please confirm your flat number before submitting your vote.';
+          message = 'Please confirm your flat number before submitting your voting response.';
         } else {
           message = err.message;
         }
@@ -261,7 +278,7 @@ const VotePage: React.FC = () => {
       }
 
       if (message.toLowerCase().includes('already voted')) {
-        message = 'This flat has already submitted a vote for this question.';
+        message = 'A voting response has already been recorded for this flat.';
         setDuplicateMessage(message);
       }
 
@@ -286,6 +303,15 @@ const VotePage: React.FC = () => {
         ? new Date(currentQuestion.startsAt)
         : null;
   const voteStatus = getVoteStatus(new Date(now), expiresAtDate, startsAtDate);
+  const isScheduled = voteStatus.phase === 'scheduled';
+  const isOpen = voteStatus.phase === 'open';
+  const isClosed = voteStatus.phase === 'closed';
+  const votingWindowVisible = Boolean(startsAtDate || expiresAtDate);
+  const formattedStartsAt = startsAtDate ? formatVotingDate(startsAtDate) : 'Opens immediately';
+  const formattedExpiresAt = expiresAtDate ? formatVotingDate(expiresAtDate) : null;
+  const countdownTarget = isScheduled ? startsAtDate : isOpen ? expiresAtDate : null;
+  const countdownLabel = isScheduled ? 'Voting opens in' : isOpen ? 'Voting closes in' : null;
+  const countdownHelperText = isOpen ? 'Voting will close automatically at the scheduled time.' : null;
   const canSubmit = Boolean(
     selectedOptionId &&
     trimmedName &&
@@ -293,9 +319,10 @@ const VotePage: React.FC = () => {
     normalizedFlat.length > 0 &&
     currentUser &&
     !isSubmitting &&
-    !isCheckingExistingVote,
+    !isCheckingExistingVote &&
+    isOpen,
   );
-  const isClosed = !voteStatus.isOpen;
+  const isVotingLocked = isScheduled || isClosed;
   const hasExistingVote = Boolean(existingVote);
   const hasChangedVote = hasExistingVote && selectedOptionId !== existingVote?.optionId;
 
@@ -326,24 +353,59 @@ const VotePage: React.FC = () => {
       ">
         {/* Header */}
         <div className="p-8 border-b border-slate-200 bg-gradient-to-r from-cyan-50 to-indigo-50">
-          <div className="flex justify-between items-start mb-4">
-            <span
-              className={`inline-flex px-3 py-1 text-xs font-bold tracking-wider uppercase rounded-full border shadow-[0_6px_20px_rgba(16,185,129,0.15)] ${
-                voteStatus.kind === 'closed'
-                  ? 'bg-slate-100 text-slate-700 border-slate-200 dark:bg-white/10 dark:text-white/80 dark:border-white/20'
-                  : voteStatus.kind === 'scheduled'
-                    ? 'bg-amber-50 text-amber-700 border-amber-200 dark:bg-amber-500/15 dark:text-amber-100 dark:border-amber-300/60'
-                    : 'bg-emerald-50 text-emerald-700 border-emerald-200 dark:bg-emerald-500/15 dark:text-emerald-100 dark:border-emerald-300/60'
-              }`}
+          <div className="flex flex-col gap-3 md:flex-row md:items-start md:justify-between mb-4">
+            <div className="flex">
+              <span
+                className={`inline-flex px-3 py-1 text-xs font-bold tracking-wider uppercase rounded-full border shadow-[0_6px_20px_rgba(16,185,129,0.15)] ${
+                  isClosed
+                    ? 'bg-slate-100 text-slate-700 border-slate-200 dark:bg-white/10 dark:text-white/80 dark:border-white/20'
+                    : isScheduled
+                      ? 'bg-amber-50 text-amber-700 border-amber-200 dark:bg-amber-500/15 dark:text-amber-100 dark:border-amber-300/60'
+                      : 'bg-emerald-50 text-emerald-700 border-emerald-200 dark:bg-emerald-500/15 dark:text-emerald-100 dark:border-emerald-300/60'
+                }`}
+              >
+                {isScheduled ? 'Scheduled' : isClosed ? 'Voting closed' : 'Voting open'}
+              </span>
+            </div>
+            <h2
+              className="
+                text-xl
+                md:text-2xl
+                font-bold
+                text-slate-900
+                leading-snug
+                line-clamp-2
+                md:line-clamp-none
+              "
             >
-              {voteStatus.label}
-            </span>
+              {currentQuestion.title}
+            </h2>
           </div>
-          <h2 className="text-2xl font-bold text-slate-900 mb-2 leading-tight">
-            {currentQuestion.title}
-          </h2>
+          {votingWindowVisible && (
+            <div className="mt-3 rounded-2xl border border-slate-200 bg-slate-50/80 p-4">
+              <div className="flex items-center gap-2 text-xs font-semibold uppercase tracking-wide text-slate-600">
+                <CalendarClock size={14} className="text-slate-500" />
+                Voting window
+              </div>
+              <div className="mt-2 space-y-1 text-sm text-slate-700">
+                <div>
+                  <span className="font-semibold text-slate-800">Opens:</span> {formattedStartsAt}
+                </div>
+                {formattedExpiresAt ? (
+                  <div>
+                    <span className="font-semibold text-slate-800">Closes:</span> {formattedExpiresAt}
+                  </div>
+                ) : null}
+              </div>
+            </div>
+          )}
+          {!isClosed && (
+            <p className="mt-3 text-xs text-slate-600">
+              Results will be available once voting has closed.
+            </p>
+          )}
           {currentQuestion.description && (
-            <p className="text-slate-600 text-sm leading-relaxed">
+            <p className="text-slate-600 text-sm leading-relaxed mt-1">
               {currentQuestion.description}
             </p>
           )}
@@ -351,9 +413,9 @@ const VotePage: React.FC = () => {
             <div className="mt-4 inline-flex items-center gap-2 text-sm font-semibold text-emerald-700 bg-emerald-50 border border-emerald-200 px-3 py-2 rounded-full shadow-[0_6px_20px_rgba(16,185,129,0.12)]">
               <Check size={14} />
               <span>
-                You voted: <span className="text-emerald-900">{currentQuestion.options.find(o => o.id === existingVote?.optionId)?.label ?? existingVote?.optionId}</span>
+                Your selection: <span className="text-emerald-900">{currentQuestion.options.find(o => o.id === existingVote?.optionId)?.label ?? existingVote?.optionId}</span>
               </span>
-              {!isClosed && <span className="text-emerald-700 font-medium">• Change your answer anytime</span>}
+              {isOpen && <span className="text-emerald-700 font-medium">• Change your selection anytime</span>}
             </div>
           )}
         </div>
@@ -415,32 +477,48 @@ const VotePage: React.FC = () => {
             </p>
           </div>
 
+          {isClosed ? (
+            <div className="rounded-2xl border border-slate-200 bg-white p-4 text-center text-sm font-semibold text-slate-700">
+              Voting closed
+            </div>
+          ) : countdownTarget && countdownLabel ? (
+            <div className="rounded-2xl border border-slate-200 bg-white p-4 flex justify-center">
+              <CountdownTimer
+                expiresAt={countdownTarget}
+                createdAt={isOpen ? startsAtDate ?? new Date(now) : new Date(now)}
+                label={countdownLabel}
+                helperText={countdownHelperText}
+              />
+            </div>
+          ) : null}
+
           {/* Options */}
-          <div className="space-y-3">
+          <div className={`space-y-3 ${isScheduled ? 'opacity-60' : ''}`}>
             <label className="block text-sm font-semibold text-slate-800 ml-1">Select your choice:</label>
-            {voteStatus.isScheduled && startsAtDate && (
-              <div className="flex items-center gap-3 text-sm text-amber-700 bg-amber-50 p-4 rounded-xl border border-amber-200">
-                <AlertCircle size={18} className="shrink-0" />
-                <span>
-                  Voting will open on{' '}
-                  <strong className="font-semibold">
-                    {new Intl.DateTimeFormat('en-GB', { dateStyle: 'medium', timeStyle: 'short' }).format(startsAtDate)}
-                  </strong>
-                  .
-                </span>
+            {isScheduled && (
+              <div className="flex items-start gap-3 text-sm text-slate-700 bg-slate-50 p-4 rounded-xl border border-slate-200">
+                <AlertCircle size={18} className="shrink-0 text-slate-500" />
+                <div>
+                  <p>Voting has not yet opened.</p>
+                  <p>Please check back once the scheduled start time arrives.</p>
+                </div>
               </div>
             )}
             {currentQuestion.options.map((option) => {
               const isSelected = selectedOptionId === option.id;
               const isPrevSelection = existingVote?.optionId === option.id;
+              const hoverStyles = isScheduled ? '' : 'hover:bg-slate-50 hover:border-cyan-100';
+              const hoverText = isScheduled ? '' : 'group-hover:text-slate-900';
+              const hoverRing = isScheduled ? '' : 'group-hover:border-cyan-400';
               return (
                 <label
                   key={option.id}
                   className={`
-                    relative flex items-center p-4 rounded-xl border cursor-pointer transition-all duration-200 group
+                    relative flex items-center p-4 rounded-xl border transition-all duration-200 group
+                    ${isScheduled ? 'cursor-not-allowed' : 'cursor-pointer'}
                     ${isSelected
                       ? 'border-cyan-400/70 bg-cyan-50 shadow-[0_15px_40px_rgba(6,182,212,0.18)]'
-                      : 'border-slate-200 bg-white hover:bg-slate-50 hover:border-cyan-100'
+                      : `border-slate-200 bg-white ${hoverStyles}`
                     }
                   `}
                 >
@@ -451,20 +529,20 @@ const VotePage: React.FC = () => {
                     checked={isSelected}
                     onChange={() => setSelectedOptionId(option.id)}
                     className="sr-only" 
-                    disabled={isClosed}
+                    disabled={isVotingLocked}
                   />
                   <div className={`
                     flex-shrink-0 w-5 h-5 rounded-full border flex items-center justify-center mr-4 transition-colors
-                    ${isSelected ? 'border-cyan-500 bg-cyan-500 text-white' : 'border-slate-300 group-hover:border-cyan-400'}
+                    ${isSelected ? 'border-cyan-500 bg-cyan-500 text-white' : `border-slate-300 ${hoverRing}`}
                   `}>
                     {isSelected && <Check size={12} className="text-white" />}
                   </div>
-                  <span className={`font-medium text-sm ${isSelected ? 'text-slate-900' : 'text-slate-700 group-hover:text-slate-900'}`}>
+                  <span className={`font-medium text-sm ${isSelected ? 'text-slate-900' : `text-slate-700 ${hoverText}`}`}>
                     {option.label}
                   </span>
                   {isPrevSelection && (
                     <span className="ml-auto text-xs font-semibold text-emerald-600 bg-emerald-50 border border-emerald-200 rounded-full px-3 py-1">
-                      You chose this
+                      Selected
                     </span>
                   )}
                 </label>
@@ -472,10 +550,10 @@ const VotePage: React.FC = () => {
             })}
           </div>
 
-          {hasExistingVote && hasChangedVote && !isClosed && (
+          {hasExistingVote && hasChangedVote && isOpen && (
             <div className="flex items-center gap-3 text-sm text-amber-700 bg-amber-50 p-4 rounded-xl border border-amber-200">
               <AlertCircle size={18} className="shrink-0" />
-              Your vote will be updated.
+              Your selection will be updated.
             </div>
           )}
 
@@ -485,25 +563,30 @@ const VotePage: React.FC = () => {
               {displayMessage}
             </div>
           )}
-          {!voteStatus.isOpen && (
-            <div className="flex items-center gap-3 text-sm text-slate-700 bg-slate-50 p-4 rounded-xl border border-slate-200 dark:bg-white/10 dark:text-white/80 dark:border-white/15">
-              <AlertCircle size={18} className="shrink-0 text-slate-500 dark:text-white/70" />
-              {voteStatus.kind === 'scheduled'
-                ? 'Voting has not opened yet. Please check back once the start time arrives.'
-                : hasExistingVote
-                  ? 'Voting is closed for this question. Your recorded answer is shown above.'
-                  : 'Voting is closed for this question.'}
+          {isClosed ? (
+            <div className="rounded-2xl border border-slate-200 bg-slate-50 p-6 text-center space-y-4">
+              <div>
+                <p className="text-lg font-semibold text-slate-900">Voting is now closed</p>
+                <p className="text-sm text-slate-600">Thank you for taking part.</p>
+              </div>
+              <Button
+                type="button"
+                fullWidth
+                onClick={() => navigate('/results')}
+              >
+                View results <ArrowRight size={16} className="ml-2" />
+              </Button>
             </div>
+          ) : (
+            <Button
+              type="submit"
+              fullWidth
+              isLoading={isSubmitting}
+              disabled={!canSubmit}
+            >
+              {hasExistingVote && isOpen ? 'Update vote' : 'Submit vote'} <ArrowRight size={16} className="ml-2" />
+            </Button>
           )}
-
-          <Button
-            type="submit"
-            fullWidth
-            isLoading={isSubmitting}
-            disabled={!canSubmit || isClosed}
-          >
-            {hasExistingVote ? 'Update Vote' : 'Submit Vote'} <ArrowRight size={16} className="ml-2" />
-          </Button>
         </form>
       </div>
 
@@ -512,7 +595,7 @@ const VotePage: React.FC = () => {
           onClick={() => navigate('/results')}
           className="text-sm text-slate-600 hover:text-cyan-700 transition-colors underline decoration-slate-300 underline-offset-4"
         >
-          Skip to Results
+          View results
         </button>
       </div>
     </div>

--- a/src/lib/voteExpiry.ts
+++ b/src/lib/voteExpiry.ts
@@ -44,24 +44,40 @@ export function getVoteStatus(now: Date, expiresAt?: Date | null, startsAt?: Dat
       isExpired: false,
       isOpen: false,
       isScheduled: true,
+      phase: 'scheduled' as const,
       label: 'Scheduled',
       kind: 'scheduled' as const,
     };
   }
 
   if (!expiresAt) {
-    return { isExpired: false, isOpen: true, isScheduled: false, label: "Open", kind: "open" as const };
+    return {
+      isExpired: false,
+      isOpen: true,
+      isScheduled: false,
+      phase: 'open' as const,
+      label: "Open",
+      kind: "open" as const,
+    };
   }
 
   const ms = expiresAt.getTime() - now.getTime();
   if (ms <= 0) {
-    return { isExpired: true, isOpen: false, isScheduled: false, label: "Closed", kind: "closed" as const };
+    return {
+      isExpired: true,
+      isOpen: false,
+      isScheduled: false,
+      phase: 'closed' as const,
+      label: "Closed",
+      kind: "closed" as const,
+    };
   }
 
   return {
     isExpired: false,
     isOpen: true,
     isScheduled: false,
+    phase: 'open' as const,
     label: formatTimeRemaining(ms),
     kind: "open" as const,
   };


### PR DESCRIPTION
### Motivation
- Improve mobile readability of voting questions by preventing awkward line breaks and separating status, title, and description.  
- Surface phase-aware UI (scheduled / open / closed) so the page can show appropriate countdowns, disabled state and closed CTAs without changing voting logic or Firestore rules.  

### Description
- Reworked the question header in `src/app/voting/components/Vote.tsx` to stack the status badge above the title on small screens while preserving the inline desktop layout and clamp titles to two lines using Tailwind utility classes.  
- Integrated a countdown into the vote page and added `label` and `helperText` props to `src/app/voting/components/CountdownTimer.tsx` to support phase-aware copy and accessible aria text.  
- Added `phase` to `src/lib/voteExpiry.ts` (values: `scheduled | open | closed`) and derived `isScheduled`, `isOpen`, `isClosed` in `Vote.tsx` to control UI: disable options while scheduled, show a friendly scheduled message, show a countdown while open, and replace submit UI with a `View results` CTA when closed.  
- Minor UX/copy refinements across the vote form, including tightened description spacing, clearer selected-vote labels, and more neutral user-facing error/messages.  

### Testing
- Started the dev server with `npm run dev -- --hostname 0.0.0.0 --port 3000` and the `/voting` route compiled successfully (fonts warnings/fallbacks were reported).  
- Ran a Playwright script to visit `/voting` at a mobile viewport and captured a screenshot to `artifacts/voting-mobile-title.png`.  
- Page load hit a Firebase `auth/invalid-api-key` error during server render, causing a `500` so full end-to-end data-driven validation could not be completed; no unit tests were added or run.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_696c0388e048832491b9870c836206b8)