### PR TITLE
Add animated "How voting works" info box to Ask/Vote/Results pages

### DIFF
--- a/src/app/voting/components/AskQuestion.tsx
+++ b/src/app/voting/components/AskQuestion.tsx
@@ -5,6 +5,7 @@ import { Input } from './ui/Input';
 import { addQuestion } from '../services/storageService';
 import { useNavigate } from 'react-router-dom';
 import { DURATION_PRESETS, DurationPreset } from '@/lib/voteExpiry';
+import VotingInfoBox from './VotingInfoBox';
 
 const AskQuestion: React.FC = () => {
   const navigate = useNavigate();
@@ -142,17 +143,22 @@ const AskQuestion: React.FC = () => {
 
   if (success) {
     return (
-      <div className="flex flex-col items-center justify-center py-16 px-6 text-center animate-fade-in h-full">
-        <div className="bg-emerald-50 p-5 rounded-full mb-6 border border-emerald-200 shadow-[0_16px_40px_rgba(16,185,129,0.18)]">
-          <CheckCircle2 className="w-12 h-12 text-emerald-600" />
+      <div className="max-w-xl mx-auto py-8 px-6">
+        <div className="flex flex-col items-center justify-center py-16 text-center animate-fade-in">
+          <div className="bg-emerald-50 p-5 rounded-full mb-6 border border-emerald-200 shadow-[0_16px_40px_rgba(16,185,129,0.18)]">
+            <CheckCircle2 className="w-12 h-12 text-emerald-600" />
+          </div>
+          <h2 className="text-3xl font-bold text-slate-900 mb-3 tracking-tight">Question Published!</h2>
+          <p className="text-slate-600 mb-10 max-w-sm leading-relaxed">
+            Your question is now live. Users can find it immediately in the &quot;Vote&quot; tab.
+          </p>
+          <div className="flex flex-col sm:flex-row gap-4 w-full max-w-xs">
+            <Button variant="outline" fullWidth onClick={() => setSuccess(false)}>Ask Another</Button>
+            <Button fullWidth onClick={() => navigate('/vote')}>Go to Voting</Button>
+          </div>
         </div>
-        <h2 className="text-3xl font-bold text-slate-900 mb-3 tracking-tight">Question Published!</h2>
-        <p className="text-slate-600 mb-10 max-w-sm leading-relaxed">
-          Your question is now live. Users can find it immediately in the &quot;Vote&quot; tab.
-        </p>
-        <div className="flex flex-col sm:flex-row gap-4 w-full max-w-xs">
-          <Button variant="outline" fullWidth onClick={() => setSuccess(false)}>Ask Another</Button>
-          <Button fullWidth onClick={() => navigate('/vote')}>Go to Voting</Button>
+        <div className="mt-10">
+          <VotingInfoBox />
         </div>
       </div>
     );
@@ -327,6 +333,9 @@ const AskQuestion: React.FC = () => {
             </Button>
           </div>
         </form>
+      </div>
+      <div className="mt-10">
+        <VotingInfoBox />
       </div>
     </div>
   );

--- a/src/app/voting/components/Results.tsx
+++ b/src/app/voting/components/Results.tsx
@@ -7,6 +7,7 @@ import { Loader2 } from 'lucide-react';
 import { db } from '@/lib/firebase';
 import { getVoteStatus } from '@/lib/voteExpiry';
 import CountdownTimer from './CountdownTimer';
+import VotingInfoBox from './VotingInfoBox';
 
 const Results: React.FC = () => {
   const [stats, setStats] = useState<QuestionStats[]>([]);
@@ -348,6 +349,7 @@ const Results: React.FC = () => {
         );
         })}
       </div>
+      <VotingInfoBox />
     </div>
   );
 };

--- a/src/app/voting/components/Vote.tsx
+++ b/src/app/voting/components/Vote.tsx
@@ -12,6 +12,7 @@ import { ArrowRight, AlertCircle, CalendarClock, Check, Loader2 } from 'lucide-r
 import { getVoteStatus } from '@/lib/voteExpiry';
 import { lightHaptic } from '@/lib/haptics';
 import CountdownTimer from './CountdownTimer';
+import VotingInfoBox from './VotingInfoBox';
 
 const deriveFirstName = (user: User | null): string => {
   if (!user) return '';
@@ -606,6 +607,9 @@ const VotePage: React.FC = () => {
         >
           View results
         </button>
+      </div>
+      <div className="mt-10">
+        <VotingInfoBox />
       </div>
     </div>
   );

--- a/src/app/voting/components/VotingInfoBox.tsx
+++ b/src/app/voting/components/VotingInfoBox.tsx
@@ -1,0 +1,93 @@
+import React, { useState } from 'react';
+import { AnimatePresence, motion } from 'framer-motion';
+import { ChevronDown, Info } from 'lucide-react';
+
+const transition = { duration: 0.25, ease: [0.4, 0, 0.2, 1] };
+
+const VotingInfoBox: React.FC = () => {
+  const [isOpen, setIsOpen] = useState(false);
+
+  return (
+    <div className="rounded-2xl border border-slate-200 bg-slate-50/80 shadow-[0_10px_30px_rgba(15,23,42,0.06)]">
+      <button
+        type="button"
+        onClick={() => setIsOpen((prev) => !prev)}
+        aria-expanded={isOpen}
+        aria-controls="voting-info-panel"
+        className="
+          w-full
+          flex items-center justify-between gap-4
+          px-4 py-3
+          text-left
+          rounded-2xl
+          focus-visible:outline-none
+          focus-visible:ring-2
+          focus-visible:ring-cyan-400/70
+        "
+      >
+        <span className="flex items-center gap-3">
+          <span className="w-9 h-9 rounded-xl bg-cyan-100/70 text-cyan-700 flex items-center justify-center shadow-inner">
+            <Info size={18} />
+          </span>
+          <span className="text-sm font-semibold text-slate-700">How voting works</span>
+        </span>
+        <motion.span
+          animate={{ rotate: isOpen ? 180 : 0 }}
+          transition={transition}
+          className="text-slate-500"
+        >
+          <ChevronDown size={18} />
+        </motion.span>
+      </button>
+
+      <AnimatePresence initial={false}>
+        {isOpen && (
+          <motion.div
+            id="voting-info-panel"
+            initial={{ height: 0, opacity: 0 }}
+            animate={{ height: 'auto', opacity: 1 }}
+            exit={{ height: 0, opacity: 0 }}
+            transition={transition}
+            className="overflow-hidden"
+          >
+            <div className="px-5 pb-5 pt-1">
+              <div className="rounded-2xl border border-slate-200/80 bg-gradient-to-br from-white via-slate-50 to-cyan-50/60 p-4 text-xs sm:text-sm text-slate-600 shadow-[0_8px_24px_rgba(15,23,42,0.08)]">
+                <h3 className="text-sm font-semibold text-slate-800 mb-3">How voting works</h3>
+                <ul className="space-y-2">
+                  <li className="flex gap-2">
+                    <span className="mt-1 h-1.5 w-1.5 rounded-full bg-cyan-500/70" />
+                    <span>Each property (flat) can cast one vote per question</span>
+                  </li>
+                  <li className="flex gap-2">
+                    <span className="mt-1 h-1.5 w-1.5 rounded-full bg-cyan-500/70" />
+                    <span>
+                      If more than one person from the same flat is registered, the flat still counts as a single vote
+                    </span>
+                  </li>
+                  <li className="flex gap-2">
+                    <span className="mt-1 h-1.5 w-1.5 rounded-full bg-cyan-500/70" />
+                    <span>While voting is open, you may change your selection</span>
+                  </li>
+                  <li className="flex gap-2">
+                    <span className="mt-1 h-1.5 w-1.5 rounded-full bg-cyan-500/70" />
+                    <span>The most recent choice before voting closes is the one that counts</span>
+                  </li>
+                  <li className="flex gap-2">
+                    <span className="mt-1 h-1.5 w-1.5 rounded-full bg-cyan-500/70" />
+                    <span>Once voting closes, no further changes can be made</span>
+                  </li>
+                  <li className="flex gap-2">
+                    <span className="mt-1 h-1.5 w-1.5 rounded-full bg-cyan-500/70" />
+                    <span>All votes are securely logged for audit purposes</span>
+                  </li>
+                </ul>
+              </div>
+            </div>
+          </motion.div>
+        )}
+      </AnimatePresence>
+    </div>
+  );
+};
+
+export default VotingInfoBox;

--- a/src/app/voting/components/VotingInfoBox.tsx
+++ b/src/app/voting/components/VotingInfoBox.tsx
@@ -2,8 +2,6 @@ import React, { useState } from 'react';
 import { AnimatePresence, motion } from 'framer-motion';
 import { ChevronDown, Info } from 'lucide-react';
 
-const transition = { duration: 0.25, ease: [0.4, 0, 0.2, 1] };
-
 const VotingInfoBox: React.FC = () => {
   const [isOpen, setIsOpen] = useState(false);
 
@@ -33,7 +31,7 @@ const VotingInfoBox: React.FC = () => {
         </span>
         <motion.span
           animate={{ rotate: isOpen ? 180 : 0 }}
-          transition={transition}
+          transition={{ duration: 0.25, ease: 'easeInOut' }}
           className="text-slate-500"
         >
           <ChevronDown size={18} />
@@ -47,7 +45,7 @@ const VotingInfoBox: React.FC = () => {
             initial={{ height: 0, opacity: 0 }}
             animate={{ height: 'auto', opacity: 1 }}
             exit={{ height: 0, opacity: 0 }}
-            transition={transition}
+            transition={{ duration: 0.25, ease: 'easeInOut' }}
             className="overflow-hidden"
           >
             <div className="px-5 pb-5 pt-1">


### PR DESCRIPTION
### Motivation
- Provide an on-page, discoverable help card that explains the voting rules without changing navigation or voting logic. 
- Keep the UI lightweight, mobile-friendly and visually consistent with existing cards.

### Description
- Added a reusable component `src/app/voting/components/VotingInfoBox.tsx` that implements an expandable info card matching the requested copy and style. 
- The component uses `framer-motion` for smooth height/opacity animation and chevron rotation (200–300ms timing), and implements an accessible, keyboard-toggleable header (Enter/Space) with `aria-expanded`/`aria-controls`.
- Placed the component as page content at the bottom of the Ask, Vote and Results views by importing it into `src/app/voting/components/AskQuestion.tsx`, `src/app/voting/components/Vote.tsx`, and `src/app/voting/components/Results.tsx` and rendering it after page content (collapsed by default).
- Styling follows existing rounded card, subtle border/shadow, pale cyan tint and touch-friendly spacing; copy is verbatim inside the expanded panel.

### Testing
- Started the dev server with `npm run dev` and confirmed the site compiled and served (font download warnings only). 
- Captured a visual smoke test using Playwright which produced a screenshot of the `/voting` page showing the new info box (artifact produced). 
- The dev logs showed a Firebase `auth/invalid-api-key` in the local environment (development config), but the UI component rendered for the screenshot; no automated unit tests were added or run because this is a UI-only change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_696cb5d71cf88324b9876bced502223d)