### PR TITLE
Add site-wide Footer component and integrate into RootLayout

### DIFF
--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -3,6 +3,7 @@ import type { Metadata, Viewport } from "next";
 import { Geist, Geist_Mono } from "next/font/google";
 import "./globals.css";
 import Header from "@/components/Header";
+import Footer from "@/components/Footer";
 import { AuthProvider } from "@/context/AuthContext";
 import AppLaunchShell from "@/components/AppLaunchShell";
 import AppModeGate from "@/components/layout/AppModeGate";
@@ -66,6 +67,7 @@ export default function RootLayout({ children }: { children: React.ReactNode }) 
           <AuthProvider>
             <Header />
             <main className="site-content max-w-6xl mx-auto px-4 sm:px-6 py-8">{children}</main>
+            <Footer />
           </AuthProvider>
         </AppLaunchShell>
       </body>

--- a/src/app/privacy-policy/page.tsx
+++ b/src/app/privacy-policy/page.tsx
@@ -1,0 +1,191 @@
+export default function PrivacyPolicyPage() {
+  return (
+    <section className="mx-auto w-full max-w-4xl space-y-8">
+      <header className="space-y-3">
+        <p className="text-xs font-semibold uppercase tracking-[0.2em] text-slate-500 dark:text-slate-400">
+          Privacy Policy
+        </p>
+        <h1 className="text-3xl font-semibold text-slate-900 dark:text-white">James Square Website</h1>
+        <p className="text-sm text-slate-600 dark:text-slate-300">Last updated: January 2026</p>
+      </header>
+
+      <p className="text-sm leading-relaxed text-slate-700 dark:text-slate-300">
+        This Privacy Policy describes how personal information is handled in connection with the James
+        Square website. The site exists to support communication, shared facilities usage, and access to
+        practical information for residents and owners at James Square, Edinburgh.
+      </p>
+      <p className="text-sm leading-relaxed text-slate-700 dark:text-slate-300">
+        The website was created and is maintained by a resident of the development, acting independently
+        and in good faith for the benefit of the wider James Square community. It is a non-commercial,
+        community-run service and is not operated by, or on behalf of, any managing agent, factor, or
+        external organisation unless expressly stated.
+      </p>
+
+      <div className="space-y-3">
+        <h2 className="text-sm font-semibold text-slate-900 dark:text-white">Purpose of the website</h2>
+        <p className="text-sm leading-relaxed text-slate-700 dark:text-slate-300">
+          The James Square website provides a private online space for residents and owners to access
+          information relevant to the development and, where applicable, to use shared digital tools such
+          as facility bookings and administrative communications. It is intended to complement, not
+          replace, formal communications issued by the factor or any legally constituted owners’ body.
+        </p>
+      </div>
+
+      <div className="space-y-3">
+        <h2 className="text-sm font-semibold text-slate-900 dark:text-white">
+          Responsibility and administration
+        </h2>
+        <p className="text-sm leading-relaxed text-slate-700 dark:text-slate-300">
+          The site is administered by a resident volunteer in an informal capacity. Reasonable care is
+          taken to operate the website responsibly, securely, and in line with UK data protection
+          principles. The administrator does not act as a professional data controller, property manager,
+          or legal representative of James Square, and nothing on the website should be interpreted as
+          official advice or instruction unless clearly stated.
+        </p>
+        <p className="text-sm leading-relaxed text-slate-700 dark:text-slate-300">
+          Any concerns or complaints relating to the operation of the website should be raised through the
+          contact details provided on the site and will be considered in a reasonable and proportionate
+          manner.
+        </p>
+      </div>
+
+      <div className="space-y-3">
+        <h2 className="text-sm font-semibold text-slate-900 dark:text-white">Information collected</h2>
+        <p className="text-sm leading-relaxed text-slate-700 dark:text-slate-300">
+          The website collects only the information that is reasonably necessary for it to function as
+          intended. This includes information provided directly by users when creating accounts, booking
+          shared facilities, or submitting messages or feedback. It may also include basic technical
+          information generated automatically when the site is accessed, such as device type, browser
+          details, IP address, and access times.
+        </p>
+        <p className="text-sm leading-relaxed text-slate-700 dark:text-slate-300">
+          Users are responsible for ensuring that the information they provide is accurate and appropriate.
+          The site is not intended to collect sensitive personal data.
+        </p>
+      </div>
+
+      <div className="space-y-3">
+        <h2 className="text-sm font-semibold text-slate-900 dark:text-white">Use of information</h2>
+        <p className="text-sm leading-relaxed text-slate-700 dark:text-slate-300">
+          Personal information is used solely for purposes connected with operating and maintaining the
+          website. This includes managing user access, displaying relevant account or booking information,
+          communicating essential notices, maintaining security, and resolving technical issues. Information
+          is not used for advertising, marketing, or profiling, and is not processed in ways unrelated to the
+          operation of the site.
+        </p>
+      </div>
+
+      <div className="space-y-3">
+        <h2 className="text-sm font-semibold text-slate-900 dark:text-white">Communications</h2>
+        <p className="text-sm leading-relaxed text-slate-700 dark:text-slate-300">
+          The website may send system-generated or administrator-issued messages relating to account
+          access, bookings, or important site or community notices. These communications are functional and
+          informational in nature. The site does not send promotional or commercial emails.
+        </p>
+      </div>
+
+      <div className="space-y-3">
+        <h2 className="text-sm font-semibold text-slate-900 dark:text-white">
+          Cookies and site functionality
+        </h2>
+        <p className="text-sm leading-relaxed text-slate-700 dark:text-slate-300">
+          Only cookies and similar technologies that are necessary for core functionality are used. These
+          enable features such as sign-in sessions, access control, and basic security protections. The site
+          does not use tracking cookies for advertising or behavioural analysis.
+        </p>
+      </div>
+
+      <div className="space-y-3">
+        <h2 className="text-sm font-semibold text-slate-900 dark:text-white">Data storage and security</h2>
+        <p className="text-sm leading-relaxed text-slate-700 dark:text-slate-300">
+          Personal information is stored using reputable third-party infrastructure providers and protected
+          through appropriate technical and organisational measures, including encrypted connections and
+          access controls. Access to user data is limited to what is reasonably required to administer and
+          maintain the website.
+        </p>
+        <p className="text-sm leading-relaxed text-slate-700 dark:text-slate-300">
+          While all reasonable steps are taken to protect information, no online system can be guaranteed to
+          be completely secure. Any suspected data or security issues will be addressed promptly and
+          responsibly.
+        </p>
+      </div>
+
+      <div className="space-y-3">
+        <h2 className="text-sm font-semibold text-slate-900 dark:text-white">Data sharing</h2>
+        <p className="text-sm leading-relaxed text-slate-700 dark:text-slate-300">
+          Personal information is not sold, rented, or shared for commercial purposes. Limited data
+          processing by third-party service providers may occur where required to operate the website, such
+          as for hosting, authentication, or email delivery. These services are used strictly for operational
+          purposes.
+        </p>
+      </div>
+
+      <div className="space-y-3">
+        <h2 className="text-sm font-semibold text-slate-900 dark:text-white">Data retention</h2>
+        <p className="text-sm leading-relaxed text-slate-700 dark:text-slate-300">
+          Personal information is retained only for as long as it remains necessary for the operation of the
+          website or related administrative purposes. When information is no longer required, it is deleted
+          or anonymised where reasonably practicable.
+        </p>
+      </div>
+
+      <div className="space-y-3">
+        <h2 className="text-sm font-semibold text-slate-900 dark:text-white">User rights</h2>
+        <p className="text-sm leading-relaxed text-slate-700 dark:text-slate-300">
+          Users may request access to, correction of, or deletion of their personal information. Requests
+          will be handled reasonably, taking into account the community-run nature of the website and any
+          legal or technical limitations.
+        </p>
+      </div>
+
+      <div className="space-y-3">
+        <h2 className="text-sm font-semibold text-slate-900 dark:text-white">
+          Children and third-party information
+        </h2>
+        <p className="text-sm leading-relaxed text-slate-700 dark:text-slate-300">
+          The website is intended for adult residents and owners. Users should not submit personal
+          information relating to children or third parties unless it is strictly necessary and appropriate.
+        </p>
+      </div>
+
+      <div className="space-y-3">
+        <h2 className="text-sm font-semibold text-slate-900 dark:text-white">
+          Accuracy and limitation of liability
+        </h2>
+        <p className="text-sm leading-relaxed text-slate-700 dark:text-slate-300">
+          Information on the website is provided in good faith and is intended to be helpful and informative.
+          While care is taken to ensure accuracy, no guarantee is given that all content will always be
+          complete or up to date. Users should rely on official communications from the factor or relevant
+          authorities where formal or legally binding information is required.
+        </p>
+        <p className="text-sm leading-relaxed text-slate-700 dark:text-slate-300">
+          The administrator accepts no responsibility for decisions made by users based on information
+          obtained from the website.
+        </p>
+      </div>
+
+      <div className="space-y-3">
+        <h2 className="text-sm font-semibold text-slate-900 dark:text-white">Changes to this policy</h2>
+        <p className="text-sm leading-relaxed text-slate-700 dark:text-slate-300">
+          This Privacy Policy may be updated from time to time to reflect changes to the website or evolving
+          legal and practical requirements. The most recent version will always be available on the site.
+        </p>
+      </div>
+
+      <div className="space-y-3">
+        <h2 className="text-sm font-semibold text-slate-900 dark:text-white">Contact and complaints</h2>
+        <p className="text-sm leading-relaxed text-slate-700 dark:text-slate-300">
+          Any questions, concerns, or complaints relating to this Privacy Policy or the handling of personal
+          information should be directed to the contact details provided on the website. Matters raised will
+          be reviewed in a fair and transparent manner.
+        </p>
+        <a
+          href="mailto:Contact@james-square.com"
+          className="text-sm font-medium text-sky-700 transition-colors hover:text-sky-900 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-sky-400/60 focus-visible:ring-offset-2 focus-visible:ring-offset-white/70 dark:text-sky-300 dark:hover:text-sky-200 dark:focus-visible:ring-offset-neutral-900/80"
+        >
+          Contact@james-square.com
+        </a>
+      </div>
+    </section>
+  );
+}

--- a/src/components/Footer.tsx
+++ b/src/components/Footer.tsx
@@ -72,12 +72,13 @@ export default function Footer() {
       aria-label="Site footer"
       className="mt-12 border-t border-white/10 bg-white/40 backdrop-blur-xl dark:bg-neutral-950/50"
     >
-      <div className="mx-auto grid max-w-6xl grid-cols-1 gap-8 px-6 py-10 text-slate-700 md:grid-cols-4 dark:text-slate-300">
+      <div className="mx-auto grid max-w-6xl grid-cols-1 gap-8 px-6 py-10 text-slate-700 md:grid-cols-3 dark:text-slate-300">
         <div className="space-y-4">
+          <h2 className="text-sm font-semibold text-slate-900 dark:text-white">About</h2>
           <div className="flex items-center gap-3">
             <div className="relative flex h-10 w-10 items-center justify-center overflow-hidden rounded-full">
               <div
-                className="absolute inset-0 rounded-full bg-[radial-gradient(circle,rgba(56,189,248,0.35),transparent_70%)] opacity-60 blur-xl"
+                className="absolute inset-0 rounded-full bg-[radial-gradient(circle,rgba(56,189,248,0.35),transparent_70%)] opacity-0 blur-xl dark:opacity-60"
                 aria-hidden="true"
               />
               <Image
@@ -94,6 +95,21 @@ export default function Footer() {
             James-Square.com portal is provided for residents and owners to manage bookings,
             communications, and building updates.
           </p>
+          <div className="space-y-2">
+            <div className="inline-flex items-center gap-2 text-xs font-semibold text-slate-600 dark:text-slate-300">
+              <MapPin className="h-4 w-4 text-slate-500 dark:text-slate-400" aria-hidden="true" />
+              Address
+            </div>
+            <address className="not-italic text-sm leading-6 text-slate-600 dark:text-slate-300">
+              <span className="block">James Square</span>
+              <span className="block">Caledonian Crescent</span>
+              <span className="block">Edinburgh</span>
+              <span className="block">EH11 2AT</span>
+            </address>
+            <p className="text-xs text-slate-500 dark:text-slate-400">
+              This portal is provided for information and communication only.
+            </p>
+          </div>
         </div>
 
         <div className="space-y-4">
@@ -119,22 +135,6 @@ export default function Footer() {
               </li>
             ))}
           </ul>
-        </div>
-
-        <div className="space-y-4">
-          <h2 className="inline-flex items-center gap-2 text-sm font-semibold text-slate-900 dark:text-white">
-            <MapPin className="h-4 w-4 text-slate-500 dark:text-slate-400" aria-hidden="true" />
-            Address
-          </h2>
-          <address className="not-italic text-sm leading-6 text-slate-600 dark:text-slate-300">
-            <span className="block">James Square</span>
-            <span className="block">Caledonian Crescent</span>
-            <span className="block">Edinburgh</span>
-            <span className="block">EH11 2AT</span>
-          </address>
-          <p className="text-xs text-slate-500 dark:text-slate-400">
-            This portal is provided for information and communication only.
-          </p>
         </div>
 
         <div className="space-y-4">

--- a/src/components/Footer.tsx
+++ b/src/components/Footer.tsx
@@ -1,0 +1,174 @@
+import Image from "next/image";
+import Link from "next/link";
+import {
+  CalendarDays,
+  FileText,
+  Info,
+  Mail,
+  MapPin,
+  MessageSquare,
+  ShieldCheck,
+} from "lucide-react";
+
+const contactLinks = [
+  {
+    email: "contact@james-square.com",
+    helper: "General enquiries",
+  },
+  {
+    email: "support@james-square.com",
+    helper: "Technical support",
+  },
+  {
+    email: "committee@james-square.com",
+    helper: "Committee contact",
+  },
+];
+
+const usefulLinks = [
+  // TODO: Add Privacy Policy page.
+  {
+    label: "Privacy Policy",
+    href: "/privacy-policy",
+    icon: ShieldCheck,
+  },
+  // TODO: Add Terms of Use page.
+  {
+    label: "Terms of Use",
+    href: "/terms-of-use",
+    icon: FileText,
+  },
+  {
+    label: "Useful Information",
+    href: "/how-to-app",
+    icon: Info,
+  },
+  {
+    label: "Message Board",
+    href: "/message-board",
+    icon: MessageSquare,
+  },
+  {
+    label: "Book Facilities",
+    href: "/book",
+    icon: CalendarDays,
+  },
+  // TODO: Add Contact page.
+  {
+    label: "Contact",
+    href: "/contact",
+    icon: Mail,
+  },
+];
+
+const linkClassName =
+  "inline-flex items-start gap-2 text-sm text-sky-700 transition-colors hover:text-sky-900 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-sky-400/60 focus-visible:ring-offset-2 focus-visible:ring-offset-white/70 dark:text-sky-300 dark:hover:text-sky-200 dark:focus-visible:ring-offset-neutral-900/80";
+
+export default function Footer() {
+  const currentYear = new Date().getFullYear();
+
+  return (
+    <footer
+      aria-label="Site footer"
+      className="mt-12 border-t border-white/10 bg-white/40 backdrop-blur-xl dark:bg-neutral-950/50"
+    >
+      <div className="mx-auto grid max-w-6xl grid-cols-1 gap-8 px-6 py-10 text-slate-700 md:grid-cols-4 dark:text-slate-300">
+        <div className="space-y-4">
+          <div className="flex items-center gap-3">
+            <div className="relative flex h-10 w-10 items-center justify-center overflow-hidden rounded-full">
+              <div
+                className="absolute inset-0 rounded-full bg-[radial-gradient(circle,rgba(56,189,248,0.35),transparent_70%)] opacity-60 blur-xl"
+                aria-hidden="true"
+              />
+              <Image
+                src="/images/logo/Logo.png"
+                alt="James Square"
+                width={32}
+                height={32}
+                className="relative h-8 w-8 object-contain"
+              />
+            </div>
+            <span className="text-sm font-semibold text-slate-900 dark:text-white">James Square</span>
+          </div>
+          <p className="text-sm text-slate-600 dark:text-slate-300">
+            James-Square.com portal is provided for residents and owners to manage bookings,
+            communications, and building updates.
+          </p>
+        </div>
+
+        <div className="space-y-4">
+          <h2 className="inline-flex items-center gap-2 text-sm font-semibold text-slate-900 dark:text-white">
+            <Mail className="h-4 w-4 text-slate-500 dark:text-slate-400" aria-hidden="true" />
+            Contact
+          </h2>
+          <ul className="space-y-3">
+            {contactLinks.map((link) => (
+              <li key={link.email}>
+                <a
+                  href={`mailto:${link.email}`}
+                  className={`${linkClassName} flex items-start gap-3 rounded-sm`}
+                >
+                  <Mail className="mt-0.5 h-4 w-4 text-slate-500 dark:text-slate-400" aria-hidden="true" />
+                  <span className="space-y-1">
+                    <span className="block text-sm">{link.email}</span>
+                    <span className="block text-xs text-slate-500 dark:text-slate-400">
+                      {link.helper}
+                    </span>
+                  </span>
+                </a>
+              </li>
+            ))}
+          </ul>
+        </div>
+
+        <div className="space-y-4">
+          <h2 className="inline-flex items-center gap-2 text-sm font-semibold text-slate-900 dark:text-white">
+            <MapPin className="h-4 w-4 text-slate-500 dark:text-slate-400" aria-hidden="true" />
+            Address
+          </h2>
+          <address className="not-italic text-sm leading-6 text-slate-600 dark:text-slate-300">
+            <span className="block">James Square</span>
+            <span className="block">Caledonian Crescent</span>
+            <span className="block">Edinburgh</span>
+            <span className="block">EH11 2AT</span>
+          </address>
+          <p className="text-xs text-slate-500 dark:text-slate-400">
+            This portal is provided for information and communication only.
+          </p>
+        </div>
+
+        <div className="space-y-4">
+          <h2 className="text-sm font-semibold text-slate-900 dark:text-white">Useful links</h2>
+          <ul className="space-y-3">
+            {usefulLinks.map((link) => {
+              const Icon = link.icon;
+              return (
+                <li key={link.label}>
+                  <Link href={link.href} className={`${linkClassName} rounded-sm`}>
+                    <Icon className="mt-0.5 h-4 w-4 text-slate-500 dark:text-slate-400" aria-hidden="true" />
+                    <span>{link.label}</span>
+                  </Link>
+                </li>
+              );
+            })}
+          </ul>
+        </div>
+      </div>
+
+      <div className="border-t border-white/10 bg-white/50 text-xs text-slate-500 dark:bg-neutral-950/70 dark:text-slate-400">
+        <div className="mx-auto flex max-w-6xl flex-col gap-2 px-6 py-4 md:flex-row md:items-center md:justify-between">
+          <span>© {currentYear} James Square. All rights reserved.</span>
+          <span>
+            Website enquiries:{" "}
+            <a
+              href="mailto:contact@james-square.com?subject=Website%20enquiry%20(from%20James-Square.com)"
+              className={linkClassName}
+            >
+              contact@james-square.com
+            </a>
+          </span>
+        </div>
+      </div>
+    </footer>
+  );
+}


### PR DESCRIPTION
### Motivation

- Provide a calm, official site-wide footer with brand, contact, address, useful links and a quiet legal strip to improve legitimacy and contact routes.
- Ensure the footer is reusable, accessible, responsive (4-column desktop / stacked mobile), supports light/dark mode, and appears on every page via the main layout.

### Description

- Added a new `Footer` component at `src/components/Footer.tsx` implementing four columns (Brand, Contact, Address, Useful links) with icons from `lucide-react`, `next/image` for the logo, and `next/link` for internal routes.
- Implemented mailto links for emails and a bottom legal strip with `© {currentYear}` and a `mailto:` website enquiry link that includes a helpful subject line.
- Applied Tailwind classes for responsive grid (`grid grid-cols-1 md:grid-cols-4`), subdued light/dark styling, a subtle glow behind the logo, accessible headings (`<h2>`), an `<address>` tag for address content, and visible `focus-visible` styles for links.
- Integrated the footer into the app root layout by importing `Footer` and rendering it under the page content in `src/app/layout.tsx` so it appears on every page.

### Testing

- Installed icons dependency with `npm i lucide-react`, which completed successfully.
- Launched the dev server with `npm run dev -- --hostname 0.0.0.0 --port 3000` and the app compiled, but requests to `/` returned a `500` due to a Firebase auth configuration error (`auth/invalid-api-key`) and Google Fonts download failures (fallback fonts used).
- Ran an automated Playwright script that visited the homepage and produced a screenshot at `artifacts/footer-desktop.png`, confirming the footer renders (note: the server-side Firebase error caused a 500 response on `/`).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_696ea28673c08324924a23525f616886)