### PR TITLE
Modern app-style Footer component with animated logo glow

### DIFF
--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -206,6 +206,26 @@ body::before {
   box-shadow: 0 12px 40px rgb(0 0 0 / 0.12);
 }
 
+@keyframes footer-glow {
+  0%,
+  100% {
+    opacity: 0.35;
+  }
+  50% {
+    opacity: 0.7;
+  }
+}
+
+.animate-footer-glow {
+  animation: footer-glow 8s ease-in-out infinite;
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .animate-footer-glow {
+    animation: none;
+  }
+}
+
 /* Focus ring for accessibility */
 :focus-visible {
   outline: 2px solid hsl(var(--ring));

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -1,9 +1,9 @@
 // src/app/layout.tsx
 import type { Metadata, Viewport } from "next";
-import Link from "next/link";
 import { Geist, Geist_Mono } from "next/font/google";
 import "./globals.css";
 import Header from "@/components/Header";
+import Footer from "@/components/Footer";
 import { AuthProvider } from "@/context/AuthContext";
 import AppLaunchShell from "@/components/AppLaunchShell";
 import AppModeGate from "@/components/layout/AppModeGate";
@@ -67,19 +67,7 @@ export default function RootLayout({ children }: { children: React.ReactNode }) 
           <AuthProvider>
             <Header />
             <main className="site-content max-w-6xl mx-auto px-4 sm:px-6 py-8">{children}</main>
-            <footer className="mt-12 border-t border-slate-200/70 dark:border-slate-800/70">
-              <div className="max-w-6xl mx-auto px-4 sm:px-6 py-6 text-sm text-slate-600 dark:text-slate-400 flex flex-col gap-3 sm:flex-row sm:items-center sm:justify-between">
-                <p className="text-xs sm:text-sm">James Square community website.</p>
-                <nav aria-label="Legal" className="flex items-center gap-4">
-                  <Link href="/privacy" className="hover:text-slate-900 dark:hover:text-slate-100 transition-colors">
-                    Privacy Policy
-                  </Link>
-                  <Link href="/terms" className="hover:text-slate-900 dark:hover:text-slate-100 transition-colors">
-                    Terms of Use
-                  </Link>
-                </nav>
-              </div>
-            </footer>
+            <Footer />
           </AuthProvider>
         </AppLaunchShell>
       </body>

--- a/src/components/Footer.tsx
+++ b/src/components/Footer.tsx
@@ -1,0 +1,214 @@
+import Image from "next/image";
+import Link from "next/link";
+
+const contactEmails = [
+  "contact@james-square.com",
+  "support@james-square.com",
+  "committee@james-square.com",
+];
+
+const quickLinks = [
+  { href: "/privacy", label: "Privacy Policy", icon: ShieldIcon },
+  { href: "/terms", label: "Terms of Use", icon: FileIcon },
+  { href: "/local", label: "More Information", icon: InfoIcon },
+  { href: "/message-board", label: "Message Board", icon: MessageIcon },
+  { href: "/book", label: "Book Facilities", icon: CalendarIcon },
+];
+
+export default function Footer() {
+  return (
+    <footer className="mt-12">
+      <div className="jqs-glass rounded-t-3xl rounded-b-none border border-slate-200/60 dark:border-slate-800/60">
+        <div className="max-w-6xl mx-auto px-3 sm:px-6 py-4 md:py-8">
+          <div className="flex justify-center md:hidden mb-3">
+            <LogoMark />
+          </div>
+
+          <div className="grid grid-cols-3 gap-3 sm:gap-4 md:gap-10 text-[11px] sm:text-xs md:text-sm text-slate-600 dark:text-slate-300">
+            <section className="flex flex-col gap-2 md:gap-3">
+              <div className="hidden md:flex items-center gap-3">
+                <LogoMark />
+                <h2 className="text-[10px] font-semibold uppercase tracking-wide text-slate-500 dark:text-slate-400">
+                  About
+                </h2>
+              </div>
+              <h2 className="md:hidden text-[10px] font-semibold uppercase tracking-wide text-slate-500 dark:text-slate-400 text-center">
+                About
+              </h2>
+              <p className="leading-snug md:leading-relaxed text-slate-600 dark:text-slate-300">
+                James-Square.com is an online portal for residents and owners to manage facilities, communications, and
+                building information.
+              </p>
+            </section>
+
+            <section className="flex flex-col gap-2 md:gap-3">
+              <h2 className="text-[10px] font-semibold uppercase tracking-wide text-slate-500 dark:text-slate-400 text-center md:text-left">
+                Contact
+              </h2>
+              <ul className="space-y-2 md:space-y-3">
+                {contactEmails.map((email) => (
+                  <li key={email}>
+                    <a
+                      className="flex flex-col items-center gap-1 text-center text-slate-600 transition-colors hover:text-slate-900 dark:text-slate-300 dark:hover:text-slate-100 md:items-start md:text-left"
+                      href={`mailto:${email}`}
+                    >
+                      <MailIcon className="h-4 w-4" />
+                      <span className="text-[10px] sm:text-[11px] md:text-sm leading-snug">{email}</span>
+                    </a>
+                  </li>
+                ))}
+              </ul>
+              <p className="hidden md:block text-[11px] text-slate-500 dark:text-slate-400">
+                We respond during business hours and committee review windows.
+              </p>
+            </section>
+
+            <section className="flex flex-col gap-2 md:gap-3">
+              <h2 className="text-[10px] font-semibold uppercase tracking-wide text-slate-500 dark:text-slate-400 text-center md:text-left">
+                Links
+              </h2>
+              <ul className="space-y-2 md:space-y-3">
+                {quickLinks.map(({ href, label, icon: Icon }) => (
+                  <li key={href}>
+                    <Link
+                      href={href}
+                      className="flex flex-col items-center gap-1 rounded-lg px-1.5 py-1 text-center text-slate-600 transition-colors hover:text-slate-900 dark:text-slate-300 dark:hover:text-slate-100 md:items-start md:text-left"
+                    >
+                      <Icon className="h-4 w-4" />
+                      <span className="text-[10px] sm:text-[11px] md:text-sm leading-snug">{label}</span>
+                    </Link>
+                  </li>
+                ))}
+              </ul>
+            </section>
+          </div>
+
+          <div className="mt-4 border-t border-slate-200/70 dark:border-slate-700/60 pt-2 text-[10px] text-slate-500 dark:text-slate-400">
+            © 2025 James Square. All rights reserved.
+          </div>
+        </div>
+      </div>
+    </footer>
+  );
+}
+
+function LogoMark() {
+  return (
+    <div className="relative">
+      <span
+        className="animate-footer-glow footer-logo-glow pointer-events-none absolute -inset-6 rounded-full blur-2xl bg-[radial-gradient(circle,rgba(148,163,184,0.35),transparent_70%)] dark:bg-[radial-gradient(circle,rgba(96,165,250,0.5),transparent_70%)]"
+        aria-hidden="true"
+      />
+      <Image src="/images/logo/Logo.png" alt="James Square" width={36} height={36} className="relative h-9 w-9" />
+    </div>
+  );
+}
+
+function MailIcon({ className }: { className?: string }) {
+  return (
+    <svg
+      className={className}
+      viewBox="0 0 24 24"
+      fill="none"
+      stroke="currentColor"
+      strokeWidth={1.5}
+      strokeLinecap="round"
+      strokeLinejoin="round"
+      aria-hidden="true"
+    >
+      <path d="M4 6h16a2 2 0 0 1 2 2v8a2 2 0 0 1-2 2H4a2 2 0 0 1-2-2V8a2 2 0 0 1 2-2Z" />
+      <path d="m22 8-10 6L2 8" />
+    </svg>
+  );
+}
+
+function ShieldIcon({ className }: { className?: string }) {
+  return (
+    <svg
+      className={className}
+      viewBox="0 0 24 24"
+      fill="none"
+      stroke="currentColor"
+      strokeWidth={1.5}
+      strokeLinecap="round"
+      strokeLinejoin="round"
+      aria-hidden="true"
+    >
+      <path d="M12 3 4 6v6c0 5 3.2 8.4 8 9 4.8-.6 8-4 8-9V6l-8-3Z" />
+    </svg>
+  );
+}
+
+function FileIcon({ className }: { className?: string }) {
+  return (
+    <svg
+      className={className}
+      viewBox="0 0 24 24"
+      fill="none"
+      stroke="currentColor"
+      strokeWidth={1.5}
+      strokeLinecap="round"
+      strokeLinejoin="round"
+      aria-hidden="true"
+    >
+      <path d="M14 3H6a2 2 0 0 0-2 2v14a2 2 0 0 0 2 2h12a2 2 0 0 0 2-2V9l-6-6Z" />
+      <path d="M14 3v6h6" />
+    </svg>
+  );
+}
+
+function InfoIcon({ className }: { className?: string }) {
+  return (
+    <svg
+      className={className}
+      viewBox="0 0 24 24"
+      fill="none"
+      stroke="currentColor"
+      strokeWidth={1.5}
+      strokeLinecap="round"
+      strokeLinejoin="round"
+      aria-hidden="true"
+    >
+      <circle cx="12" cy="12" r="9" />
+      <path d="M12 16v-4" />
+      <path d="M12 8h.01" />
+    </svg>
+  );
+}
+
+function MessageIcon({ className }: { className?: string }) {
+  return (
+    <svg
+      className={className}
+      viewBox="0 0 24 24"
+      fill="none"
+      stroke="currentColor"
+      strokeWidth={1.5}
+      strokeLinecap="round"
+      strokeLinejoin="round"
+      aria-hidden="true"
+    >
+      <path d="M21 15a4 4 0 0 1-4 4H7l-4 3V7a4 4 0 0 1 4-4h10a4 4 0 0 1 4 4Z" />
+    </svg>
+  );
+}
+
+function CalendarIcon({ className }: { className?: string }) {
+  return (
+    <svg
+      className={className}
+      viewBox="0 0 24 24"
+      fill="none"
+      stroke="currentColor"
+      strokeWidth={1.5}
+      strokeLinecap="round"
+      strokeLinejoin="round"
+      aria-hidden="true"
+    >
+      <path d="M8 3v3" />
+      <path d="M16 3v3" />
+      <path d="M4 9h16" />
+      <rect x="4" y="5" width="16" height="16" rx="2" />
+    </svg>
+  );
+}


### PR DESCRIPTION
### Motivation

- Replace the previous generic inline footer with a compact, app-like footer that presents identity, contact, and navigation in vertical blocks while remaining a horizontal band on mobile.
- Ensure full, clickable email addresses and an always-visible logo with a subtle animated glow that respects `prefers-reduced-motion`.
- Integrate the new footer across the site and use the existing glass-style visual language for consistency.

### Description

- Added a new `src/components/Footer.tsx` implementing three vertical blocks (About / Contact / Links) with icon-above-text tiles, full `mailto:` addresses, and quick links including `More Information → /local`.
- Replaced the previous inline footer in `src/app/layout.tsx` by importing and rendering the new `Footer` component site-wide.
- Extended `src/app/globals.css` with a `@keyframes footer-glow` animation and an `.animate-footer-glow` helper plus a `prefers-reduced-motion` rule, and used the existing `.jqs-glass` styling for the container.
- Included a compact `LogoMark` with a subtle radial glow behind the logo and small SVG icons for the contact and link items.

### Testing

- Started the dev server with `next dev`, which compiled and served the app while falling back to local fonts after Google Fonts fetch failures, and produced Playwright screenshots at `artifacts/footer-desktop-updated.png` and `artifacts/footer-mobile-updated.png`.
- Observed server-side Firebase `auth/invalid-api-key` errors that produced HTTP 500 responses during some page renders; these errors are unrelated to the footer markup but impacted full-page rendering in the dev environment.
- No unit tests were added or run for the footer component in this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_696f644aaa7483249b386d5e463279fb)