### PR TITLE
feat(admin): allow selecting from address for admin-sent emails

### DIFF
--- a/src/app/admin/AdminEmailPanel.tsx
+++ b/src/app/admin/AdminEmailPanel.tsx
@@ -20,6 +20,7 @@ type AdminUser = {
 };
 
 type RecipientMode = 'all' | 'owners' | 'selected';
+type FromType = 'default' | 'committee' | 'support';
 
 type Status = {
   tone: 'idle' | 'loading' | 'success' | 'error';
@@ -34,6 +35,7 @@ const AdminEmailPanel = () => {
   const [subject, setSubject] = useState('');
   const [message, setMessage] = useState('');
   const [status, setStatus] = useState<Status>({ tone: 'idle', message: '' });
+  const [fromType, setFromType] = useState<FromType>('default');
 
   useEffect(() => {
     const loadUsers = async () => {
@@ -125,6 +127,7 @@ const AdminEmailPanel = () => {
       const response = await sendAdminEmailRequest(currentUser, {
         subject: subject.trim(),
         message: message.trim(),
+        fromType,
         recipients: {
           mode: recipientMode,
           emails: buildRecipientEmails(),
@@ -168,7 +171,7 @@ const AdminEmailPanel = () => {
         Emails are delivered from the official James Square admin system. Replies go to the configured Resend sender.
       </div>
 
-      <div className="grid gap-4">
+        <div className="grid gap-4">
         <div>
           <label className="block text-sm font-medium text-slate-700 dark:text-slate-200">
             Recipients
@@ -195,6 +198,39 @@ const AdminEmailPanel = () => {
                   value={option.value}
                   checked={recipientMode === option.value}
                   onChange={() => setRecipientMode(option.value)}
+                />
+                {option.label}
+              </label>
+            ))}
+          </div>
+        </div>
+
+        <div>
+          <label className="block text-sm font-medium text-slate-700 dark:text-slate-200">
+            From address
+          </label>
+          <div className="mt-2 grid gap-2 sm:grid-cols-3">
+            {(
+              [
+                { value: 'default', label: 'No-reply (no-reply@james-square.com)' },
+                { value: 'committee', label: 'Committee (committee@james-square.com)' },
+                { value: 'support', label: 'Support (support@james-square.com)' },
+              ] as const
+            ).map((option) => (
+              <label
+                key={option.value}
+                className={`flex items-center gap-2 rounded-xl border px-3 py-2 text-sm transition ${
+                  fromType === option.value
+                    ? 'border-indigo-300 bg-indigo-50 text-indigo-900 dark:border-indigo-400/40 dark:bg-indigo-900/30 dark:text-indigo-100'
+                    : 'border-white/15 bg-white/5 text-slate-700 dark:border-white/10 dark:bg-white/5 dark:text-slate-300'
+                }`}
+              >
+                <input
+                  type="radio"
+                  name="from-address"
+                  value={option.value}
+                  checked={fromType === option.value}
+                  onChange={() => setFromType(option.value)}
                 />
                 {option.label}
               </label>

--- a/src/lib/client/sendAdminEmailRequest.ts
+++ b/src/lib/client/sendAdminEmailRequest.ts
@@ -1,12 +1,14 @@
 import { User } from "firebase/auth";
 
 type RecipientMode = "all" | "owners" | "selected";
+type FromType = "default" | "committee" | "support";
 
 export async function sendAdminEmailRequest(
   user: User,
   payload: {
     subject: string;
     message: string;
+    fromType?: FromType;
     recipients: {
       mode: RecipientMode;
       userIds?: string[];


### PR DESCRIPTION
### Motivation
- Provide admins the ability to choose which approved sender address is used when sending emails from the admin UI. 
- Ensure only predefined sender options are allowed and that the server maps those options to environment-configured Resend senders with safe fallbacks.

### Description
- Add a `From address` radio selector to the admin email form and track the selection as `fromType` in the UI (`src/app/admin/AdminEmailPanel.tsx`).
- Include the optional `fromType` in client requests by extending the payload type in `src/lib/client/sendAdminEmailRequest.ts`.
- Extend the admin email API to accept `fromType` and map it to `RESEND_FROM_EMAIL`, `RESEND_FROM_EMAIL_COMMITTEE`, or `RESEND_FROM_EMAIL_SUPPORT`, falling back to `RESEND_FROM_EMAIL` for missing/invalid values; the mapping and retrieval logic is implemented in `src/app/api/admin/send-email/route.ts`.
- Preserve existing batching, subject, body, and recipient handling while substituting the resolved `from` address when calling Resend.

### Testing
- Started the dev server with `npm run dev` which compiled the `/admin` page successfully (server started). 
- Ran an automated Playwright capture using Firefox which produced a screenshot of the admin page (success). 
- A Playwright Chromium run crashed and the server returned a `500` on `GET /admin` during one run due to a Firebase configuration error (`auth/invalid-api-key`), so end-to-end email send was not executed in CI (failure).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_696f8bddf6888324a9e77f4c851cd5aa)