### PR TITLE
Fix admin email API auth and Resend payload handling

### DIFF
--- a/src/app/api/admin/send-email/route.ts
+++ b/src/app/api/admin/send-email/route.ts
@@ -55,12 +55,21 @@ const parseBearerToken = (request: NextRequest) => {
   return match?.[1];
 };
 
-const resolveSender = (sender?: string) => {
-  const candidate = sender?.trim() || DEFAULT_SENDER;
-  if (!ALLOWED_SENDERS.has(candidate)) {
+const resolveSender = (sender?: unknown) => {
+  if (sender === undefined || sender === null) {
+    return DEFAULT_SENDER;
+  }
+
+  if (typeof sender !== "string") {
     return null;
   }
-  return candidate;
+
+  const candidate = sender.trim();
+  if (!candidate) {
+    return DEFAULT_SENDER;
+  }
+
+  return ALLOWED_SENDERS.has(candidate) ? candidate : null;
 };
 
 export async function POST(req: NextRequest) {
@@ -140,8 +149,8 @@ export async function POST(req: NextRequest) {
 
     for (const batch of batches) {
       const { error, data } = await resend.emails.send({
-        from: `${sender}`,
-        to: isBulkSend ? sender : batch,
+        from: sender,
+        to: isBulkSend ? sender : batch[0],
         bcc: isBulkSend ? batch : undefined,
         subject,
         html,

--- a/src/lib/client/sendAdminEmailRequest.ts
+++ b/src/lib/client/sendAdminEmailRequest.ts
@@ -15,7 +15,7 @@ export async function sendAdminEmailRequest(
     };
   },
 ) {
-  const token = await user.getIdToken(true);
+  const token = await user.getIdToken();
 
   const res = await fetch("/api/admin/send-email", {
     method: "POST",


### PR DESCRIPTION
### Motivation
- Fix false “Session invalid or expired” behavior and payload errors in the admin email API route.
- Ensure Resend send payloads use a single `to` with optional `bcc` for bulk sends and avoid duplicate address fields.
- Prevent client-side forced token refresh loops by removing `getIdToken(true)` usage where it caused invalid token refreshes.

### Description
- Hardened sender resolution by updating `resolveSender` to accept `unknown`, validate type, return `DEFAULT_SENDER` for empty/missing values, and only return allowed senders or `null` for invalid input.
- Fixed Resend payload to use a single `to` address and `bcc` for bulk sends by setting `to: isBulkSend ? sender : batch[0]` and `bcc: isBulkSend ? batch : undefined` and leaving `from` as the validated `sender` string.
- Preserved Firebase Admin token verification and admin checks (`adminAuth.verifyIdToken` and role checks) to keep server-side security unchanged.
- Updated the client call to use `getIdToken()` instead of `getIdToken(true)` in `sendAdminEmailRequest` to avoid forced token refresh loops.

### Testing
- No automated tests were executed as part of this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_696fb1adc7d48324ae71140b1ef11232)