### PR TITLE
Allow admins to change a user’s resident type (Owner ↔ Renter)

### DIFF
--- a/src/app/admin/page.tsx
+++ b/src/app/admin/page.tsx
@@ -33,6 +33,7 @@ interface UserRegistration {
   lastLoginAt?: string | Date | { toDate: () => Date };
   residentType?: string;
   residentTypeLabel?: string;
+  userRole?: string;
   isFlagged?: boolean;
   isAdmin?: boolean;
   disabled?: boolean;
@@ -65,7 +66,8 @@ type AdminAction =
   | 'TOGGLE_ADMIN'
   | 'TOGGLE_FLAG'
   | 'TOGGLE_DISABLED'
-  | 'REQUIRE_RESIDENT_TYPE_CONFIRMATION';
+  | 'REQUIRE_RESIDENT_TYPE_CONFIRMATION'
+  | 'UPDATE_RESIDENT_TYPE';
 
 interface PendingAdminAction {
   action: AdminAction;
@@ -467,6 +469,16 @@ export default function AdminDashboard() {
           confirmLabel: 'Require confirmation',
           successMessage: `Required resident type confirmation for ${displayName}.`,
         };
+      case 'UPDATE_RESIDENT_TYPE': {
+        const nextType = action.payload?.residentType === 'owner' ? 'Owner' : 'Renter';
+        return {
+          title: 'Confirm resident status change',
+          description: `Are you sure you want to change ${displayName} to ${nextType}?`,
+          warning: 'This updates how the user is classified across the system.',
+          confirmLabel: `Set as ${nextType}`,
+          successMessage: `Updated ${displayName} to ${nextType}.`,
+        };
+      }
       default:
         return {
           title: 'Confirm admin action',
@@ -568,6 +580,27 @@ export default function AdminDashboard() {
           );
           await addDoc(collection(db, 'activityLogs'), {
             action: 'Flagged resident type confirmation requirement',
+            admin: auth.currentUser?.email || 'unknown',
+            timestamp: new Date(),
+          });
+          break;
+        }
+        case 'UPDATE_RESIDENT_TYPE': {
+          const residentType =
+            pendingAction.payload?.residentType === 'renter' ? 'renter' : 'owner';
+          const updates = {
+            residentType,
+            residentTypeLabel: residentType === 'owner' ? 'Owner' : 'Renter',
+            userRole: residentType === 'owner' ? 'Owner' : 'Renter',
+          };
+          await updateDoc(userRef, updates);
+          setUsers((prev) =>
+            prev.map((user) =>
+              user.id === pendingAction.userId ? { ...user, ...updates } : user
+            )
+          );
+          await addDoc(collection(db, 'activityLogs'), {
+            action: `Updated resident type to ${updates.residentTypeLabel}`,
             admin: auth.currentUser?.email || 'unknown',
             timestamp: new Date(),
           });
@@ -1445,6 +1478,24 @@ export default function AdminDashboard() {
                                 Require confirmation
                               </button>
                             )}
+                            {isAdmin && (
+                              <button
+                                onClick={() =>
+                                  openConfirmation({
+                                    action: 'UPDATE_RESIDENT_TYPE',
+                                    userId: user.id,
+                                    payload: {
+                                      residentType:
+                                        user.residentType === 'owner' ? 'renter' : 'owner',
+                                    },
+                                  })
+                                }
+                                disabled={isUserActionLocked}
+                                className="rounded-full px-3 py-1 text-xs bg-slate-700 text-white disabled:opacity-60 disabled:cursor-not-allowed"
+                              >
+                                Change resident type
+                              </button>
+                            )}
                             <button
                               onClick={() =>
                                 openConfirmation({ action: 'DELETE_USER', userId: user.id })
@@ -1554,6 +1605,24 @@ export default function AdminDashboard() {
                                 className="rounded-full px-3 py-1 text-xs bg-slate-700 text-white disabled:opacity-60 disabled:cursor-not-allowed"
                               >
                                 Require confirmation
+                              </button>
+                            )}
+                            {isAdmin && (
+                              <button
+                                onClick={() =>
+                                  openConfirmation({
+                                    action: 'UPDATE_RESIDENT_TYPE',
+                                    userId: user.id,
+                                    payload: {
+                                      residentType:
+                                        user.residentType === 'owner' ? 'renter' : 'owner',
+                                    },
+                                  })
+                                }
+                                disabled={isUserActionLocked}
+                                className="rounded-full px-3 py-1 text-xs bg-slate-700 text-white disabled:opacity-60 disabled:cursor-not-allowed"
+                              >
+                                Change resident type
                               </button>
                             )}
                             <button
@@ -1685,6 +1754,24 @@ export default function AdminDashboard() {
                                 Require confirmation
                               </button>
                             )}
+                            {isAdmin && (
+                              <button
+                                onClick={() =>
+                                  openConfirmation({
+                                    action: 'UPDATE_RESIDENT_TYPE',
+                                    userId: user.id,
+                                    payload: {
+                                      residentType:
+                                        user.residentType === 'owner' ? 'renter' : 'owner',
+                                    },
+                                  })
+                                }
+                                disabled={isUserActionLocked}
+                                className="px-4 py-2 rounded-full text-xs font-semibold bg-slate-700 text-white disabled:opacity-60 disabled:cursor-not-allowed"
+                              >
+                                Change resident type
+                              </button>
+                            )}
                             <button
                               onClick={() =>
                                 openConfirmation({ action: 'DELETE_USER', userId: user.id })
@@ -1756,6 +1843,24 @@ export default function AdminDashboard() {
                                 className="px-4 py-2 rounded-full text-xs font-semibold bg-slate-700 text-white disabled:opacity-60 disabled:cursor-not-allowed"
                               >
                                 Require confirmation
+                              </button>
+                            )}
+                            {isAdmin && (
+                              <button
+                                onClick={() =>
+                                  openConfirmation({
+                                    action: 'UPDATE_RESIDENT_TYPE',
+                                    userId: user.id,
+                                    payload: {
+                                      residentType:
+                                        user.residentType === 'owner' ? 'renter' : 'owner',
+                                    },
+                                  })
+                                }
+                                disabled={isUserActionLocked}
+                                className="px-4 py-2 rounded-full text-xs font-semibold bg-slate-700 text-white disabled:opacity-60 disabled:cursor-not-allowed"
+                              >
+                                Change resident type
                               </button>
                             )}
                             <button

--- a/src/app/admin/page.tsx
+++ b/src/app/admin/page.tsx
@@ -1378,8 +1378,9 @@ export default function AdminDashboard() {
                 )}
               </div>
               {/* Desktop Table */}
-              <div className="hidden md:block overflow-x-auto jqs-glass rounded-2xl">
-                <table className="min-w-full text-sm">
+              <div className="hidden md:block jqs-glass rounded-2xl overflow-visible">
+                <div className="relative overflow-x-auto">
+                  <table className="min-w-[1200px] w-full text-sm">
                   <thead>
                     <tr className="text-left">
                       {[
@@ -1395,7 +1396,16 @@ export default function AdminDashboard() {
                         'Disabled',
                         'Actions',
                       ].map((h) => (
-                        <th key={h} className="px-3 py-2 border-b border-[color:var(--glass-border)]">
+                        <th
+                          key={h}
+                          className={`px-3 py-2 border-b border-[color:var(--glass-border)] whitespace-nowrap ${
+                            h === 'Email'
+                              ? 'sticky left-0 z-10 bg-white/80 dark:bg-slate-900/80 backdrop-blur'
+                              : h === 'Actions'
+                                ? 'sticky right-0 z-10 bg-white/80 dark:bg-slate-900/80 backdrop-blur'
+                                : ''
+                          }`}
+                        >
                           {h}
                         </th>
                       ))}
@@ -1405,8 +1415,10 @@ export default function AdminDashboard() {
                     {filteredUsers.map((user) =>
                       editingUser && editingUser.id === user.id ? (
                         <tr key={user.id} className="align-top">
-                          <td className="px-3 py-2">{user.email}</td>
-                          <td className="px-3 py-2">
+                          <td className="px-3 py-2 whitespace-nowrap sticky left-0 z-10 bg-white/80 dark:bg-slate-900/80 backdrop-blur">
+                            {user.email}
+                          </td>
+                          <td className="px-3 py-2 whitespace-nowrap">
                             <input
                               type="text"
                               name="fullName"
@@ -1415,7 +1427,7 @@ export default function AdminDashboard() {
                               className="w-full border rounded px-2 py-1 bg-transparent"
                             />
                           </td>
-                          <td className="px-3 py-2">
+                          <td className="px-3 py-2 whitespace-nowrap">
                             <input
                               type="text"
                               name="username"
@@ -1424,7 +1436,7 @@ export default function AdminDashboard() {
                               className="w-full border rounded px-2 py-1 bg-transparent"
                             />
                           </td>
-                          <td className="px-3 py-2">
+                          <td className="px-3 py-2 whitespace-nowrap">
                             <input
                               type="text"
                               name="property"
@@ -1433,7 +1445,7 @@ export default function AdminDashboard() {
                               className="w-full border rounded px-2 py-1 bg-transparent"
                             />
                           </td>
-                          <td className="px-3 py-2">
+                          <td className="px-3 py-2 whitespace-nowrap">
                             {(() => {
                               const status = getResidentTypeLabel(user);
                               return (
@@ -1443,10 +1455,10 @@ export default function AdminDashboard() {
                               );
                             })()}
                           </td>
-                          <td className="px-3 py-2">
+                          <td className="px-3 py-2 whitespace-nowrap">
                             {formatDate(user.createdAt)}
                           </td>
-                          <td className="px-3 py-2">
+                          <td className="px-3 py-2 whitespace-nowrap">
                             {(() => {
                               const lastLogin = getLastLoginDisplay(user);
                               return (
@@ -1462,10 +1474,16 @@ export default function AdminDashboard() {
                               );
                             })()}
                           </td>
-                          <td className="px-3 py-2">{user.isFlagged ? 'Yes' : 'No'}</td>
-                          <td className="px-3 py-2">{user.isAdmin ? 'Yes' : 'No'}</td>
-                          <td className="px-3 py-2">{user.disabled ? 'Yes' : 'No'}</td>
-                          <td className="px-3 py-2 space-x-1">
+                          <td className="px-3 py-2 whitespace-nowrap">
+                            {user.isFlagged ? 'Yes' : 'No'}
+                          </td>
+                          <td className="px-3 py-2 whitespace-nowrap">
+                            {user.isAdmin ? 'Yes' : 'No'}
+                          </td>
+                          <td className="px-3 py-2 whitespace-nowrap">
+                            {user.disabled ? 'Yes' : 'No'}
+                          </td>
+                          <td className="px-3 py-2 space-x-1 whitespace-nowrap sticky right-0 z-10 bg-white/80 dark:bg-slate-900/80 backdrop-blur">
                             <button
                               onClick={requestUserUpdate}
                               disabled={isUserActionLocked}
@@ -1526,11 +1544,13 @@ export default function AdminDashboard() {
                         </tr>
                       ) : (
                         <tr key={user.id} className="align-top">
-                          <td className="px-3 py-2">{user.email}</td>
-                          <td className="px-3 py-2">{user.fullName}</td>
-                          <td className="px-3 py-2">{user.username}</td>
-                          <td className="px-3 py-2">{user.property}</td>
-                          <td className="px-3 py-2">
+                          <td className="px-3 py-2 whitespace-nowrap sticky left-0 z-10 bg-white/80 dark:bg-slate-900/80 backdrop-blur">
+                            {user.email}
+                          </td>
+                          <td className="px-3 py-2 whitespace-nowrap">{user.fullName}</td>
+                          <td className="px-3 py-2 whitespace-nowrap">{user.username}</td>
+                          <td className="px-3 py-2 whitespace-nowrap">{user.property}</td>
+                          <td className="px-3 py-2 whitespace-nowrap">
                             {(() => {
                               const status = getResidentTypeLabel(user);
                               return (
@@ -1540,10 +1560,10 @@ export default function AdminDashboard() {
                               );
                             })()}
                           </td>
-                          <td className="px-3 py-2">
+                          <td className="px-3 py-2 whitespace-nowrap">
                             {formatDate(user.createdAt)}
                           </td>
-                          <td className="px-3 py-2">
+                          <td className="px-3 py-2 whitespace-nowrap">
                             {(() => {
                               const lastLogin = getLastLoginDisplay(user);
                               return (
@@ -1559,10 +1579,16 @@ export default function AdminDashboard() {
                               );
                             })()}
                           </td>
-                          <td className="px-3 py-2">{user.isFlagged ? 'Yes' : 'No'}</td>
-                          <td className="px-3 py-2">{user.isAdmin ? 'Yes' : 'No'}</td>
-                          <td className="px-3 py-2">{user.disabled ? 'Yes' : 'No'}</td>
-                          <td className="px-3 py-2 space-x-1">
+                          <td className="px-3 py-2 whitespace-nowrap">
+                            {user.isFlagged ? 'Yes' : 'No'}
+                          </td>
+                          <td className="px-3 py-2 whitespace-nowrap">
+                            {user.isAdmin ? 'Yes' : 'No'}
+                          </td>
+                          <td className="px-3 py-2 whitespace-nowrap">
+                            {user.disabled ? 'Yes' : 'No'}
+                          </td>
+                          <td className="px-3 py-2 space-x-1 whitespace-nowrap sticky right-0 z-10 bg-white/80 dark:bg-slate-900/80 backdrop-blur">
                             <button
                               onClick={() => startEditing(user)}
                               disabled={isUserActionLocked}
@@ -1656,7 +1682,8 @@ export default function AdminDashboard() {
                       )
                     )}
                   </tbody>
-                </table>
+                  </table>
+                </div>
               </div>
 
               {/* Mobile Cards */}


### PR DESCRIPTION
### Motivation

- Provide a safe, auditable admin workflow to change a user between Owner and Renter without implicitly changing owner permissions. 

### Description

- Added a new admin action `UPDATE_RESIDENT_TYPE` to the `AdminAction` union and extended `UserRegistration` with `userRole` in `src/app/admin/page.tsx`. 
- Added admin-only "Change resident type" buttons to the Users table on desktop and mobile that call `openConfirmation` with `action: 'UPDATE_RESIDENT_TYPE'` and the flipped `residentType`. 
- Extended `getActionCopy()` to include confirmation modal copy for `UPDATE_RESIDENT_TYPE` and updated `confirmAdminAction` to atomically update Firestore fields `residentType`, `residentTypeLabel`, and `userRole`, update local `users` state, and add an entry to `activityLogs`. 

### Testing

- Started the dev server with `npm run dev`; Next compiled the `/admin` page successfully but the request to `/admin` returned a 500 due to Firebase `auth/invalid-api-key` (environment/config issue), so end-to-end testing against a live backend was blocked. 
- Ran a Playwright script to load `/admin` and capture a screenshot artifact which completed and produced `artifacts/admin-resident-type-action.png`. 
- No unit tests or other automated test suites were executed in this rollout.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69722191304c8324b9a36f6a9e36dbb3)