### PR TITLE
Add admin 'Set resident type' action and enable desktop users table horizontal scroll

### DIFF
--- a/src/app/admin/page.tsx
+++ b/src/app/admin/page.tsx
@@ -98,7 +98,7 @@ const RESIDENT_TYPE_OPTIONS = [
   { value: 'owner', label: 'Owner' },
   { value: 'renter', label: 'Renter' },
   { value: 'stl', label: 'Short Term Holiday Let' },
-];
+] as const;
 
 type ResidentTypeOption = (typeof RESIDENT_TYPE_OPTIONS)[number]['value'];
 

--- a/src/app/admin/page.tsx
+++ b/src/app/admin/page.tsx
@@ -1394,6 +1394,14 @@ export default function AdminDashboard() {
                     {actionFeedback.message}
                   </div>
                 )}
+                <div className="rounded-2xl border border-amber-200/70 bg-amber-50/80 px-4 py-3 text-xs text-amber-900 dark:border-amber-400/30 dark:bg-amber-500/10 dark:text-amber-100">
+                  <p className="font-semibold">Resident information review notice</p>
+                  <p className="mt-1">
+                    Any updates made here will be reviewed by the admin team. Providing false
+                    information may result in a temporary account disablement. Please ensure all
+                    details are accurate and correct.
+                  </p>
+                </div>
               </div>
               {/* Desktop Table */}
               <div className="hidden md:block">

--- a/src/app/admin/page.tsx
+++ b/src/app/admin/page.tsx
@@ -1396,9 +1396,11 @@ export default function AdminDashboard() {
                 )}
               </div>
               {/* Desktop Table */}
-              <div className="hidden md:block w-full jqs-glass rounded-2xl">
-                <div className="relative w-full overflow-x-auto pb-2">
-                  <table className="min-w-[1400px] w-full text-sm">
+              <div className="hidden md:block">
+                <div className="w-full overflow-x-auto">
+                  <div className="w-full jqs-glass rounded-2xl">
+                    <div className="relative w-full overflow-x-auto pb-2">
+                      <table className="min-w-[1400px] w-full text-sm">
                   <thead>
                     <tr className="text-left">
                       {[
@@ -1683,7 +1685,9 @@ export default function AdminDashboard() {
                       )
                     )}
                   </tbody>
-                  </table>
+                      </table>
+                    </div>
+                  </div>
                 </div>
               </div>
 

--- a/src/app/admin/page.tsx
+++ b/src/app/admin/page.tsx
@@ -100,6 +100,8 @@ const RESIDENT_TYPE_OPTIONS = [
   { value: 'stl', label: 'Short Term Holiday Let' },
 ];
 
+type ResidentTypeOption = (typeof RESIDENT_TYPE_OPTIONS)[number]['value'];
+
 /* ---------- Small UI helpers (visual-only) ---------- */
 function Section({
   title,
@@ -1501,7 +1503,10 @@ export default function AdminDashboard() {
                               <select
                                 value=""
                                 onChange={(e) =>
-                                  requestResidentTypeUpdate(user.id, e.target.value as any)
+                                  requestResidentTypeUpdate(
+                                    user.id,
+                                    e.target.value as ResidentTypeOption
+                                  )
                                 }
                                 disabled={isUserActionLocked}
                                 className="rounded-full px-3 py-1 text-xs border border-white/30 bg-transparent jqs-glass"
@@ -1631,7 +1636,10 @@ export default function AdminDashboard() {
                               <select
                                 value=""
                                 onChange={(e) =>
-                                  requestResidentTypeUpdate(user.id, e.target.value as any)
+                                  requestResidentTypeUpdate(
+                                    user.id,
+                                    e.target.value as ResidentTypeOption
+                                  )
                                 }
                                 disabled={isUserActionLocked}
                                 className="rounded-full px-3 py-1 text-xs border border-white/30 bg-transparent jqs-glass"

--- a/src/app/admin/page.tsx
+++ b/src/app/admin/page.tsx
@@ -1396,8 +1396,8 @@ export default function AdminDashboard() {
                 )}
               </div>
               {/* Desktop Table */}
-              <div className="hidden md:block jqs-glass rounded-2xl">
-                <div className="relative overflow-x-auto">
+              <div className="hidden md:block w-full jqs-glass rounded-2xl">
+                <div className="relative w-full overflow-x-auto pb-2">
                   <table className="min-w-[1400px] w-full text-sm">
                   <thead>
                     <tr className="text-left">


### PR DESCRIPTION
### Motivation

- Improve desktop viewability of the Users table so columns don't get cut off on wide content. 
- Allow admins to resolve users with an unknown resident type into Owner, Renter or Short Term Holiday Let (additive only) while preserving existing admin flows and mobile layout.

### Description

- Added a `RESIDENT_TYPE_OPTIONS` constant with the three resident type options (`owner`, `renter`, `stl`).
- Extended the `AdminAction` union with a new value `SET_RESIDENT_TYPE` and added a helper `requestResidentTypeUpdate(userId, residentType)` that opens the existing confirmation modal for this action.
- Extended `getActionCopy` with a `SET_RESIDENT_TYPE` case that supplies confirmation title, description, warning, button label and success message.
- Extended `confirmAdminAction` with a `SET_RESIDENT_TYPE` case which updates Firestore (`residentType`, `residentTypeLabel`, `requiresResidentTypeConfirmation`), updates local `users` state and adds an `activityLogs` entry recording the admin action.
- Wrapped the existing desktop table in an extra container to enable horizontal scrolling and set the table to `min-w-[1400px] w-full` (only layout change to the existing table, no header/row/button refactors or duplicates).
- Added a small isolated UI control (a non-saving `<select>`) inside the existing Actions `<td>` rendered only when `getResidentCategory(user) === 'unknown'`, which triggers `requestResidentTypeUpdate` on change; mobile layout and existing buttons were not modified.

### Testing

- No automated tests were run for this change.
- No runtime build/test was executed in this rollout; changes were limited to additive UI helpers, a new admin action branch and a layout wrapper and committed to the codebase successfully.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69726dc55e70832498e553c148bf9793)