### PR TITLE
Refine admin dark mode styling

### DIFF
--- a/src/app/admin/AdminEmailPanel.tsx
+++ b/src/app/admin/AdminEmailPanel.tsx
@@ -7,7 +7,7 @@ import { auth, db } from '@/lib/firebase';
 import { sendAdminEmailRequest } from '@/lib/client/sendAdminEmailRequest';
 
 const baseCardClasses =
-  'rounded-2xl border border-white/20 bg-white/10 dark:border-white/10 dark:bg-white/5 backdrop-blur px-6 py-6 shadow-md space-y-5';
+  'rounded-2xl border border-white/10 bg-white/5 backdrop-blur px-6 py-6 shadow-[0_18px_40px_rgba(0,0,0,0.4)] space-y-5';
 
 type AdminUser = {
   id: string;
@@ -243,23 +243,23 @@ const AdminEmailPanel = () => {
     <section className={baseCardClasses}>
       <header className="flex flex-wrap items-start justify-between gap-3">
         <div>
-          <h2 className="text-lg font-semibold text-slate-900 dark:text-white">Email Residents</h2>
-          <p className="text-sm text-slate-600 dark:text-slate-300">
+          <h2 className="text-lg font-semibold text-white">Email Residents</h2>
+          <p className="text-sm text-slate-300">
             Compose and send an announcement using the official James Square admin system.
           </p>
         </div>
-        <div className="rounded-xl border border-white/15 bg-white/5 px-3 py-2 text-xs text-slate-600 dark:border-white/10 dark:bg-white/5 dark:text-slate-300">
+        <div className="rounded-xl border border-white/10 bg-white/5 px-3 py-2 text-xs text-slate-300">
           Recipients: <strong>{recipientCount}</strong>
         </div>
       </header>
 
-      <div className="rounded-xl border border-indigo-200/70 bg-indigo-50 px-4 py-3 text-sm text-indigo-900 dark:border-indigo-400/20 dark:bg-indigo-900/20 dark:text-indigo-100">
+      <div className="rounded-xl border border-indigo-400/30 bg-indigo-500/10 px-4 py-3 text-sm text-indigo-100">
         Emails are delivered from the official James Square admin system. Replies go to the configured Resend sender.
       </div>
 
       <div className="grid gap-4">
         <div>
-          <label className="block text-sm font-medium text-slate-700 dark:text-slate-200">
+          <label className="block text-sm font-medium text-slate-200">
             Recipients
           </label>
           <div className="mt-2 grid gap-2 sm:grid-cols-3">
@@ -275,8 +275,8 @@ const AdminEmailPanel = () => {
                 key={option.value}
                 className={`flex items-center gap-2 rounded-xl border px-3 py-2 text-sm transition ${
                   recipientMode === option.value
-                    ? 'border-indigo-300 bg-indigo-50 text-indigo-900 dark:border-indigo-400/40 dark:bg-indigo-900/30 dark:text-indigo-100'
-                    : 'border-white/15 bg-white/5 text-slate-700 dark:border-white/10 dark:bg-white/5 dark:text-slate-300'
+                    ? 'border-indigo-400/40 bg-indigo-500/15 text-indigo-100'
+                    : 'border-white/10 bg-white/5 text-slate-300'
                 }`}
               >
                 <input
@@ -293,13 +293,13 @@ const AdminEmailPanel = () => {
         </div>
 
         <div>
-          <label className="block text-sm font-medium text-slate-700 dark:text-slate-200">
+          <label className="block text-sm font-medium text-slate-200">
             Sender address
           </label>
           <select
             value={senderEmail}
             onChange={(event) => setSenderEmail(event.target.value)}
-            className="mt-1 w-full rounded-xl border border-white/20 bg-white/5 px-3 py-2 text-sm text-slate-900 dark:border-white/10 dark:bg-white/5 dark:text-white"
+            className="mt-1 w-full rounded-xl border border-white/10 bg-white/5 px-3 py-2 text-sm text-slate-100"
           >
             {senderOptions.map((option) => (
               <option key={option.value} value={option.value} className="text-slate-900">
@@ -311,7 +311,7 @@ const AdminEmailPanel = () => {
 
         {recipientMode === 'custom' && (
           <div className="space-y-2">
-            <label className="block text-sm font-medium text-slate-700 dark:text-slate-200">
+            <label className="block text-sm font-medium text-slate-200">
               Custom recipient email
             </label>
             <input
@@ -319,10 +319,10 @@ const AdminEmailPanel = () => {
               value={customEmail}
               onChange={(event) => setCustomEmail(event.target.value)}
               onBlur={() => setCustomEmail(normalizedCustomEmail)}
-              className="w-full rounded-xl border border-white/20 bg-white/5 px-3 py-2 text-sm text-slate-900 placeholder:text-slate-400 dark:border-white/10 dark:bg-white/5 dark:text-white"
+              className="w-full rounded-xl border border-white/10 bg-white/5 px-3 py-2 text-sm text-slate-100 placeholder:text-slate-500"
               placeholder="someone@example.com"
             />
-            <p className="text-xs text-slate-500 dark:text-slate-400">
+            <p className="text-xs text-slate-400">
               This email will not be saved.
             </p>
             {!customEmailIsValid && customEmail.trim().length > 0 && (
@@ -334,21 +334,21 @@ const AdminEmailPanel = () => {
         {recipientMode === 'selected' && (
           <div>
             <div className="flex items-center justify-between">
-              <h3 className="text-sm font-medium text-slate-700 dark:text-slate-200">Select recipients</h3>
-              <span className="text-xs text-slate-500 dark:text-slate-400">
+              <h3 className="text-sm font-medium text-slate-200">Select recipients</h3>
+              <span className="text-xs text-slate-400">
                 {selectedIds.length} selected
               </span>
             </div>
-            <div className="mt-2 max-h-64 overflow-auto rounded-xl border border-white/15 bg-white/5 dark:border-white/10 dark:bg-white/5">
+            <div className="mt-2 max-h-64 overflow-auto rounded-xl border border-white/10 bg-white/5">
               {loadingUsers ? (
-                <div className="px-3 py-4 text-sm text-slate-500 dark:text-slate-400">Loading users…</div>
+                <div className="px-3 py-4 text-sm text-slate-400">Loading users…</div>
               ) : users.length === 0 ? (
-                <div className="px-3 py-4 text-sm text-slate-500 dark:text-slate-400">No users found.</div>
+                <div className="px-3 py-4 text-sm text-slate-400">No users found.</div>
               ) : (
                 users.map((user) => (
                   <label
                     key={user.id}
-                    className="flex items-center gap-3 border-b border-white/10 px-3 py-2 last:border-b-0 dark:border-white/5"
+                    className="flex items-center gap-3 border-b border-white/10 px-3 py-2 last:border-b-0"
                   >
                     <input
                       type="checkbox"
@@ -356,10 +356,10 @@ const AdminEmailPanel = () => {
                       onChange={() => handleToggleSelected(user.id)}
                     />
                     <div>
-                      <p className="text-sm text-slate-900 dark:text-white">
+                      <p className="text-sm text-slate-100">
                         {user.fullName || user.email}
                       </p>
-                      <p className="text-xs text-slate-500 dark:text-slate-400">{user.email}</p>
+                      <p className="text-xs text-slate-400">{user.email}</p>
                     </div>
                   </label>
                 ))
@@ -370,32 +370,32 @@ const AdminEmailPanel = () => {
 
         <div className="grid gap-3 sm:grid-cols-2">
           <div className="sm:col-span-2">
-            <label className="block text-sm font-medium text-slate-700 dark:text-slate-200">
+            <label className="block text-sm font-medium text-slate-200">
               Subject
             </label>
             <input
               type="text"
               value={subject}
               onChange={(event) => setSubject(event.target.value)}
-              className="mt-1 w-full rounded-xl border border-white/20 bg-white/5 px-3 py-2 text-sm text-slate-900 placeholder:text-slate-400 dark:border-white/10 dark:bg-white/5 dark:text-white"
+              className="mt-1 w-full rounded-xl border border-white/10 bg-white/5 px-3 py-2 text-sm text-slate-100 placeholder:text-slate-500"
               placeholder="Enter email subject"
             />
           </div>
           <div className="sm:col-span-2">
-            <label className="block text-sm font-medium text-slate-700 dark:text-slate-200">
+            <label className="block text-sm font-medium text-slate-200">
               Message
             </label>
             <textarea
               value={message}
               onChange={(event) => setMessage(event.target.value)}
               rows={5}
-              className="mt-1 w-full rounded-xl border border-white/20 bg-white/5 px-3 py-2 text-sm text-slate-900 placeholder:text-slate-400 dark:border-white/10 dark:bg-white/5 dark:text-white"
+              className="mt-1 w-full rounded-xl border border-white/10 bg-white/5 px-3 py-2 text-sm text-slate-100 placeholder:text-slate-500"
               placeholder="Write a clear message for residents."
             />
           </div>
         </div>
 
-        <div className="rounded-xl border border-white/15 bg-white/5 px-4 py-3 text-sm text-slate-700 dark:border-white/10 dark:bg-white/5 dark:text-slate-300">
+        <div className="rounded-xl border border-white/10 bg-white/5 px-4 py-3 text-sm text-slate-300">
           This email will be sent to <strong>{recipientCount}</strong> recipients ({recipientTypeLabel}) using{' '}
           <strong>{senderEmail}</strong>.
         </div>
@@ -408,8 +408,8 @@ const AdminEmailPanel = () => {
                 : status.tone === 'success'
                   ? 'text-sm text-emerald-400'
                   : status.tone === 'loading'
-                    ? 'text-sm text-slate-500 dark:text-slate-300'
-                    : 'text-sm text-slate-600 dark:text-slate-300'
+                    ? 'text-sm text-slate-400'
+                    : 'text-sm text-slate-300'
             }
             aria-live="polite"
           >
@@ -422,11 +422,11 @@ const AdminEmailPanel = () => {
             type="button"
             onClick={handleSubmit}
             disabled={status.tone === 'loading' || loadingUsers}
-            className="inline-flex items-center justify-center rounded-xl bg-white px-4 py-2 text-sm font-semibold text-slate-900 shadow transition hover:bg-slate-100 disabled:cursor-not-allowed disabled:opacity-60 dark:bg-white/90"
+            className="inline-flex items-center justify-center rounded-xl border border-white/10 bg-white/10 px-4 py-2 text-sm font-semibold text-white shadow transition hover:bg-white/20 disabled:cursor-not-allowed disabled:opacity-60"
           >
             {status.tone === 'loading' ? 'Sending…' : shouldConfirmSend ? 'Review and send' : 'Send email'}
           </button>
-          <span className="text-xs text-slate-500 dark:text-slate-400">
+          <span className="text-xs text-slate-400">
             Emails are sent only after you confirm the send.
           </span>
         </div>
@@ -438,21 +438,21 @@ const AdminEmailPanel = () => {
           role="dialog"
           aria-modal="true"
         >
-          <div className="w-full max-w-lg space-y-4 rounded-2xl border border-white/40 bg-white p-6 shadow-xl dark:border-white/10 dark:bg-slate-900">
+          <div className="w-full max-w-lg space-y-4 rounded-2xl border border-white/10 bg-[linear-gradient(180deg,rgba(17,24,39,0.96),rgba(15,23,42,0.95))] p-6 shadow-[0_30px_80px_rgba(0,0,0,0.6)]">
             <div className="space-y-2">
-              <h3 className="text-lg font-semibold text-slate-900 dark:text-white">
+              <h3 className="text-lg font-semibold text-white">
                 Confirm email send
               </h3>
-              <p className="text-sm text-slate-700 dark:text-slate-300">
+              <p className="text-sm text-slate-300">
                 You are about to email{' '}
                 <strong>{isAllRecipients ? 'ALL users' : `${recipientCount} recipients`}</strong>. This
                 action cannot be undone. Are you sure you want to continue?
               </p>
-              <p className="text-sm text-slate-700 dark:text-slate-300">
+              <p className="text-sm text-slate-300">
                 This email will be sent using <strong>{senderEmail}</strong>.
               </p>
               {showCommitteeWarning && (
-                <p className="text-sm font-semibold text-amber-700 dark:text-amber-400">
+                <p className="text-sm font-semibold text-amber-400">
                   Committee mail is selected for multiple recipients. Please confirm this is intended.
                 </p>
               )}
@@ -460,19 +460,19 @@ const AdminEmailPanel = () => {
 
             {isAllRecipients ? (
               <div className="space-y-2">
-                <label className="block text-sm font-medium text-slate-700 dark:text-slate-200">
+                <label className="block text-sm font-medium text-slate-200">
                   Type {confirmationPhrase} to confirm
                 </label>
                 <input
                   type="text"
                   value={confirmText}
                   onChange={(event) => setConfirmText(event.target.value)}
-                  className="w-full rounded-xl border border-white/20 bg-white/5 px-3 py-2 text-sm text-slate-900 dark:border-white/10 dark:bg-white/5 dark:text-white"
+                  className="w-full rounded-xl border border-white/10 bg-white/5 px-3 py-2 text-sm text-slate-100"
                   placeholder={confirmationPhrase}
                 />
               </div>
             ) : (
-              <label className="flex items-center gap-2 text-sm text-slate-700 dark:text-slate-300">
+              <label className="flex items-center gap-2 text-sm text-slate-300">
                 <input
                   type="checkbox"
                   checked={confirmAcknowledged}

--- a/src/app/admin/AdminVoteAuditPanel.tsx
+++ b/src/app/admin/AdminVoteAuditPanel.tsx
@@ -303,7 +303,7 @@ const AdminVoteAuditPanel = ({
                           return (
                         <div
                           key={vote.id}
-                          className="rounded-lg bg-slate-50 px-3 py-2 text-sm text-slate-900 dark:bg-white/5 dark:text-slate-100"
+                          className="rounded-lg border border-white/10 bg-white/5 px-3 py-2 text-sm text-slate-100"
                         >
                           <div className="flex flex-col gap-2 sm:flex-row sm:items-center sm:justify-between">
                             <div className="space-y-1">
@@ -312,7 +312,7 @@ const AdminVoteAuditPanel = ({
                                   <span className="font-medium">{primaryName}</span>
                                 )}
                                 {secondaryLine && (
-                                  <span className="text-slate-500 dark:text-slate-400">
+                                  <span className="text-slate-400">
                                     {secondaryLine}
                                   </span>
                                 )}
@@ -321,7 +321,7 @@ const AdminVoteAuditPanel = ({
                                 {optionMap?.get(vote.optionId) ?? '—'}
                               </div>
                             </div>
-                            <div className="text-xs text-slate-500 dark:text-slate-400">
+                            <div className="text-xs text-slate-400">
                               {formatTimestamp(vote.createdAt)}
                             </div>
                           </div>

--- a/src/app/admin/OwnersPanel.tsx
+++ b/src/app/admin/OwnersPanel.tsx
@@ -93,23 +93,23 @@ const OwnersPanel = () => {
   const ownersList = useMemo(() => {
     if (owners.length === 0) {
       return (
-        <p className="text-sm text-slate-500 dark:text-slate-400">
+        <p className="text-sm text-slate-400">
           No owners have been added yet.
         </p>
       );
     }
 
     return (
-      <ul className="divide-y divide-white/10 dark:divide-white/5 text-sm">
+      <ul className="divide-y divide-white/10 text-sm">
         {owners.map((owner) => (
           <li key={owner.id} className="flex items-center justify-between py-2">
             <div>
-              <p className="font-medium text-slate-900 dark:text-white">{owner.email}</p>
+              <p className="font-medium text-slate-100">{owner.email}</p>
               {owner.fullName && (
-                <p className="text-xs text-slate-500 dark:text-slate-400">{owner.fullName}</p>
+                <p className="text-xs text-slate-400">{owner.fullName}</p>
               )}
             </div>
-            <code className="text-xs text-slate-500 dark:text-slate-400">{owner.id}</code>
+            <code className="text-xs text-slate-400">{owner.id}</code>
           </li>
         ))}
       </ul>
@@ -117,15 +117,15 @@ const OwnersPanel = () => {
   }, [owners]);
 
   return (
-    <section className="rounded-2xl border border-white/20 bg-white/10 p-6 shadow-md backdrop-blur dark:border-white/10 dark:bg-white/5 space-y-6">
+    <section className="rounded-2xl border border-white/10 bg-white/5 p-6 shadow-[0_18px_40px_rgba(0,0,0,0.4)] backdrop-blur space-y-6">
       <header className="flex flex-wrap items-center justify-between gap-3">
         <div>
-          <h2 className="text-lg font-semibold text-slate-900 dark:text-white">Owners Control Panel</h2>
-          <p className="text-sm text-slate-600 dark:text-slate-300">
+          <h2 className="text-lg font-semibold text-white">Owners Control Panel</h2>
+          <p className="text-sm text-slate-300">
             Manage owner access by email and monitor current members.
           </p>
         </div>
-        <span className="inline-flex items-center rounded-full border border-white/30 px-3 py-1 text-xs font-medium text-slate-700 dark:text-slate-200">
+        <span className="inline-flex items-center rounded-full border border-white/10 bg-white/5 px-3 py-1 text-xs font-medium text-slate-200">
           Owners: {ownerCount}
         </span>
       </header>
@@ -139,7 +139,7 @@ const OwnersPanel = () => {
             resetStatus();
           }}
           placeholder="owner@example.com"
-          className="flex-1 rounded-xl border border-white/20 bg-white/40 px-3 py-2 text-sm text-slate-900 backdrop-blur focus:border-transparent focus:outline-none focus:ring-2 focus:ring-indigo-400/60 dark:border-white/10 dark:bg-white/10 dark:text-white"
+          className="flex-1 rounded-xl border border-white/10 bg-white/5 px-3 py-2 text-sm text-slate-100 backdrop-blur focus:border-transparent focus:outline-none focus:ring-2 focus:ring-indigo-400/60"
           autoComplete="email"
           aria-label="Owner email"
           disabled={isProcessing}
@@ -157,7 +157,7 @@ const OwnersPanel = () => {
             type="button"
             onClick={() => handleOwnerToggle(false)}
             disabled={isProcessing}
-            className="inline-flex items-center justify-center rounded-xl border border-white/25 px-4 py-2 text-sm font-medium text-white/90 shadow transition hover:bg-white/10 disabled:cursor-not-allowed disabled:opacity-60"
+            className="inline-flex items-center justify-center rounded-xl border border-white/15 bg-white/5 px-4 py-2 text-sm font-medium text-white/90 shadow transition hover:bg-white/10 disabled:cursor-not-allowed disabled:opacity-60"
           >
             Revoke owner
           </button>
@@ -171,7 +171,7 @@ const OwnersPanel = () => {
               ? 'text-sm text-rose-400'
               : status.tone === 'success'
                 ? 'text-sm text-emerald-400'
-                : 'text-sm text-slate-600 dark:text-slate-300'
+                : 'text-sm text-slate-300'
           }
           aria-live="polite"
         >
@@ -180,8 +180,8 @@ const OwnersPanel = () => {
       )}
 
       <div>
-        <h3 className="text-sm font-medium text-slate-700 dark:text-slate-200">Current owners</h3>
-        <div className="mt-2 rounded-xl border border-white/15 bg-white/5 p-3 shadow-inner dark:border-white/10 dark:bg-white/5">
+        <h3 className="text-sm font-medium text-slate-200">Current owners</h3>
+        <div className="mt-2 rounded-xl border border-white/10 bg-white/5 p-3 shadow-inner">
           {ownersList}
         </div>
       </div>

--- a/src/app/admin/page.tsx
+++ b/src/app/admin/page.tsx
@@ -113,21 +113,21 @@ function Section({
 }) {
   const [open, setOpen] = useState(defaultOpen);
   return (
-    <section className="jqs-glass rounded-3xl p-6 border border-white/40 dark:border-white/10 bg-white/60 dark:bg-white/5 backdrop-blur-xl shadow-sm">
+    <section className="jqs-glass rounded-3xl p-6 border border-white/10 bg-[linear-gradient(180deg,rgba(20,25,35,0.85),rgba(15,18,28,0.9))] backdrop-blur-xl shadow-[0_20px_60px_rgba(0,0,0,0.45)]">
       <button
         className="w-full flex items-start justify-between gap-4 text-left"
         onClick={() => setOpen((v) => !v)}
         aria-expanded={open}
       >
         <div>
-          <h2 className="text-xl font-semibold text-slate-900 dark:text-slate-100">{title}</h2>
+          <h2 className="text-xl font-semibold text-slate-100">{title}</h2>
           {subtitle && (
-            <p className="text-sm text-slate-600 dark:text-slate-300 mt-0.5">{subtitle}</p>
+            <p className="text-sm text-slate-300 mt-0.5">{subtitle}</p>
           )}
         </div>
         <div className="flex items-center gap-3">
           {typeof count === 'number' && (
-            <span className="px-2 py-0.5 rounded-full text-xs font-semibold bg-white/60 dark:bg-white/10 text-slate-700 dark:text-slate-200 border border-white/40 dark:border-white/10">
+            <span className="px-2 py-0.5 rounded-full text-xs font-semibold bg-white/10 text-slate-100 border border-white/10">
               {count}
             </span>
           )}
@@ -156,9 +156,9 @@ function Section({
 /* Badge “pills” for quick KPIs */
 function StatPill({ label, value }: { label: string; value: string | number }) {
   return (
-    <div className="jqs-glass rounded-2xl px-4 py-3 text-sm bg-white/60 dark:bg-white/5 border border-white/30 dark:border-white/10 backdrop-blur-lg">
-      <div className="text-slate-600 dark:text-slate-300">{label}</div>
-      <div className="text-lg font-semibold text-slate-900 dark:text-slate-100">{value}</div>
+    <div className="jqs-glass rounded-2xl px-4 py-3 text-sm bg-white/5 border border-white/10 backdrop-blur-lg shadow-[0_8px_30px_rgba(0,0,0,0.4)]">
+      <div className="text-slate-300">{label}</div>
+      <div className="text-lg font-semibold text-slate-100">{value}</div>
     </div>
   );
 }
@@ -192,17 +192,17 @@ function ConfirmationModal({
       role="dialog"
       aria-modal="true"
     >
-      <div className="w-full max-w-lg rounded-2xl bg-white dark:bg-slate-900 border border-white/40 dark:border-white/10 shadow-xl p-6 space-y-4">
+      <div className="w-full max-w-lg rounded-2xl border border-white/10 bg-[linear-gradient(180deg,rgba(17,24,39,0.96),rgba(15,23,42,0.95))] shadow-[0_30px_80px_rgba(0,0,0,0.6)] p-6 space-y-4">
         <div className="space-y-2">
-          <h3 className="text-lg font-semibold text-slate-900 dark:text-white">{title}</h3>
-          <p className="text-sm text-slate-700 dark:text-slate-300">{description}</p>
+          <h3 className="text-lg font-semibold text-white">{title}</h3>
+          <p className="text-sm text-slate-300">{description}</p>
           {warning && (
-            <p className="text-sm font-semibold text-amber-700 dark:text-amber-400">
+            <p className="text-sm font-semibold text-amber-400">
               {warning}
             </p>
           )}
           {errorMessage && (
-            <p className="text-sm font-semibold text-red-700 dark:text-red-300">
+            <p className="text-sm font-semibold text-red-300">
               {errorMessage}
             </p>
           )}
@@ -1135,25 +1135,27 @@ export default function AdminDashboard() {
     : null;
 
   return (
-    <main className="jqs-gradient-bg min-h-screen text-slate-900 dark:text-slate-100">
-      <div className="max-w-7xl mx-auto p-6 space-y-6">
-        <header className="flex flex-wrap items-end justify-between gap-4">
-          <div>
-            <h1 className="text-3xl font-bold text-slate-900 dark:text-white">Admin Dashboard</h1>
-            <p className="text-slate-600 dark:text-slate-300 text-sm mt-1">
-              Manage users, bookings, configuration, and communications.
-            </p>
-          </div>
-          <div className="grid grid-flow-col auto-cols-max gap-3">
-            <StatPill label="Users" value={users.length} />
-            <StatPill label="Bookings" value={bookings.length} />
-            <StatPill label="Logs" value={activityLogs.length} />
-            <StatPill label="Feedback" value={feedbacks.length} />
+    <main className="jqs-gradient-bg min-h-screen text-slate-100">
+      <div className="max-w-7xl mx-auto p-6 space-y-8">
+        <header className="jqs-glass rounded-3xl border border-white/10 bg-[linear-gradient(180deg,rgba(20,25,35,0.85),rgba(15,18,28,0.92))] backdrop-blur-xl shadow-[0_20px_60px_rgba(0,0,0,0.45)] px-6 py-5">
+          <div className="flex flex-wrap items-end justify-between gap-4">
+            <div>
+              <h1 className="text-3xl font-bold text-white">Admin Dashboard</h1>
+              <p className="text-slate-300 text-sm mt-1">
+                Manage users, bookings, configuration, and communications.
+              </p>
+            </div>
+            <div className="grid grid-flow-col auto-cols-max gap-3">
+              <StatPill label="Users" value={users.length} />
+              <StatPill label="Bookings" value={bookings.length} />
+              <StatPill label="Logs" value={activityLogs.length} />
+              <StatPill label="Feedback" value={feedbacks.length} />
+            </div>
           </div>
         </header>
 
-        <div className="sticky top-0 z-20 -mx-6 px-6 py-2 md:static">
-          <div className="jqs-glass rounded-full px-2 py-2 bg-white/60 dark:bg-white/5 border border-white/40 dark:border-white/10 backdrop-blur-xl shadow-sm">
+        <div className="sticky top-0 z-20 -mx-6 px-6 py-3 md:static">
+          <div className="jqs-glass rounded-full px-2 py-2 border border-white/10 bg-white/5 backdrop-blur-xl shadow-[0_12px_30px_rgba(0,0,0,0.45)]">
             <div className="flex gap-2 overflow-x-auto whitespace-nowrap scrollbar-thin">
               {tabs.map((tab) => {
                 const isActive = activeTab === tab.id;
@@ -1164,8 +1166,8 @@ export default function AdminDashboard() {
                     onClick={() => setActiveTab(tab.id)}
                     className={`px-4 py-2 rounded-full text-xs font-semibold transition ${
                       isActive
-                        ? 'bg-indigo-600 text-white shadow'
-                        : 'text-slate-600 dark:text-slate-200 hover:bg-white/30 dark:hover:bg-white/10'
+                        ? 'bg-indigo-500/20 text-indigo-100 shadow-[0_8px_24px_rgba(79,70,229,0.45)] ring-1 ring-indigo-400/40'
+                        : 'text-slate-300 hover:bg-white/5 hover:text-white'
                     }`}
                   >
                     {tab.label}
@@ -1178,15 +1180,15 @@ export default function AdminDashboard() {
 
         {activeTab === 'overview' && (
           <>
-            <div className="jqs-glass rounded-2xl p-4">
+            <div className="jqs-glass rounded-2xl p-4 border border-white/10 bg-white/5 shadow-[0_16px_40px_rgba(0,0,0,0.35)]">
               <div className="flex flex-wrap items-center justify-between gap-2 mb-3">
                 <div>
-                  <h2 className="text-lg font-semibold">Resident Breakdown</h2>
-                  <p className="text-xs opacity-75">
+                  <h2 className="text-lg font-semibold text-slate-100">Resident Breakdown</h2>
+                  <p className="text-xs text-slate-400">
                     Admin/system accounts excluded from totals.
                   </p>
                 </div>
-                <div className="text-xs opacity-70">Matches the filtered user list.</div>
+                <div className="text-xs text-slate-400">Matches the filtered user list.</div>
               </div>
               <div className="grid grid-cols-2 md:grid-cols-5 gap-3">
                 <StatPill label="Total Residents" value={residentStats.total} />
@@ -1196,7 +1198,7 @@ export default function AdminDashboard() {
                 <StatPill label="Inactive 30+ days" value={activityStats.inactive} />
               </div>
             </div>
-            <div className="jqs-glass rounded-2xl px-4 py-3 text-xs opacity-80">
+            <div className="jqs-glass rounded-2xl px-4 py-3 text-xs text-slate-400 border border-white/10 bg-white/5">
               Some residents signed up before resident-type confirmation existed. Unknown residents will be
               asked to confirm their status later. (Admin-only notice)
             </div>
@@ -1351,7 +1353,7 @@ export default function AdminDashboard() {
               </div>
               <div className="space-y-2 mb-4">
                 {isActionProcessing && (
-                  <div className="text-xs font-semibold uppercase tracking-wide text-emerald-700 dark:text-emerald-300">
+                  <div className="text-xs font-semibold uppercase tracking-wide text-emerald-300">
                     Saving…
                   </div>
                 )}
@@ -1359,8 +1361,8 @@ export default function AdminDashboard() {
                   <div
                     className={`rounded-xl px-4 py-2 text-sm ${
                       actionFeedback.type === 'success'
-                        ? 'bg-emerald-100 text-emerald-900 dark:bg-emerald-500/20 dark:text-emerald-100'
-                        : 'bg-red-100 text-red-900 dark:bg-red-500/20 dark:text-red-100'
+                        ? 'bg-emerald-500/15 text-emerald-100 border border-emerald-400/30'
+                        : 'bg-red-500/15 text-red-100 border border-red-400/30'
                     }`}
                   >
                     {actionFeedback.message}
@@ -1373,13 +1375,13 @@ export default function AdminDashboard() {
                     <span className="font-semibold">STL residents</span>
                     <span className="text-xs opacity-70">{stlUsers.length} total</span>
                   </div>
-                  <ul className="mt-2 space-y-1 text-xs text-slate-600 dark:text-slate-300">
+                  <ul className="mt-2 space-y-1 text-xs text-slate-300">
                     {stlUsers.map((user) => (
                       <li key={user.id} className="flex flex-wrap justify-between gap-2">
-                        <span className="font-medium text-slate-900 dark:text-slate-100">
+                        <span className="font-medium text-slate-100">
                           {user.fullName || user.email}
                         </span>
-                        <span className="text-slate-500 dark:text-slate-400">{user.email}</span>
+                        <span className="text-slate-400">{user.email}</span>
                       </li>
                     ))}
                   </ul>
@@ -1471,7 +1473,7 @@ export default function AdminDashboard() {
                                     <div className="text-xs text-amber-600">Inactive 30+ days</div>
                                   )}
                                   {lastLogin.status === 'never' && (
-                                    <div className="text-xs text-slate-500">Never logged in</div>
+                                    <div className="text-xs text-slate-400">Never logged in</div>
                                   )}
                                 </div>
                               );
@@ -1571,7 +1573,7 @@ export default function AdminDashboard() {
                                     <div className="text-xs text-amber-600">Inactive 30+ days</div>
                                   )}
                                   {lastLogin.status === 'never' && (
-                                    <div className="text-xs text-slate-500">Never logged in</div>
+                                    <div className="text-xs text-slate-400">Never logged in</div>
                                   )}
                                 </div>
                               );
@@ -1751,7 +1753,7 @@ export default function AdminDashboard() {
                             <p className="text-xs text-amber-600">Inactive 30+ days</p>
                           )}
                           {getLastLoginDisplay(user).status === 'never' && (
-                            <p className="text-xs text-slate-500">Never logged in</p>
+                            <p className="text-xs text-slate-400">Never logged in</p>
                           )}
                           <p><strong>Flagged:</strong> {user.isFlagged ? 'Yes' : 'No'}</p>
                           <p><strong>Admin:</strong> {user.isAdmin ? 'Yes' : 'No'}</p>
@@ -2199,7 +2201,7 @@ export default function AdminDashboard() {
                               <span className="font-medium">{item.time}</span>
                               <span className="opacity-70">{item.total} bookings</span>
                             </div>
-                            <div className="mt-2 h-2 rounded-full bg-slate-200/40 overflow-hidden">
+                            <div className="mt-2 h-2 rounded-full bg-slate-700/40 overflow-hidden">
                               <div
                                 className={`h-full ${
                                   timeSlotBreakdown.topTimes.has(item.time)

--- a/src/app/admin/voting/page.tsx
+++ b/src/app/admin/voting/page.tsx
@@ -190,57 +190,58 @@ export default function AdminVotingAuditPage() {
   if (!isAdmin) return null;
 
   return (
-    <div className="max-w-6xl mx-auto px-4 sm:px-6 lg:px-8 py-10 space-y-8">
-      <header className="space-y-2">
-        <p className="text-xs uppercase tracking-[0.2em] text-cyan-700 font-semibold">
-          Admin view – voting audit
-        </p>
-        <div className="flex items-center gap-3">
-          <ShieldCheck className="text-cyan-600" size={20} />
-          <h1 className="text-3xl font-bold text-slate-900">Voting dashboard</h1>
-        </div>
-        <p className="text-slate-600">
-          Review ballot totals and the full audit trail. Only administrators can access voter details.
-        </p>
-      </header>
-
-      <section className="bg-white border border-slate-200 rounded-2xl shadow-sm p-5 space-y-4">
-        <div className="flex flex-col gap-3 sm:flex-row sm:items-center sm:justify-between">
-          <div>
-            <h2 className="text-lg font-semibold text-slate-900">Select a question</h2>
-            <p className="text-sm text-slate-600">
-              Switch between open and closed polls to audit their ballots.
-            </p>
+    <main className="jqs-gradient-bg min-h-screen text-slate-100">
+      <div className="max-w-6xl mx-auto px-4 sm:px-6 lg:px-8 py-10 space-y-8">
+        <header className="space-y-2">
+          <p className="text-xs uppercase tracking-[0.2em] text-cyan-300 font-semibold">
+            Admin view – voting audit
+          </p>
+          <div className="flex items-center gap-3">
+            <ShieldCheck className="text-cyan-400" size={20} />
+            <h1 className="text-3xl font-bold text-white">Voting dashboard</h1>
           </div>
-          <div className="flex items-center gap-2">
-            {loadingQuestions && <Loader2 className="w-4 h-4 animate-spin text-cyan-600" />}
-            <select
-              value={selectedQuestionId}
-              onChange={(e) => setSelectedQuestionId(e.target.value)}
-              className="border border-slate-300 rounded-xl px-3 py-2 text-sm shadow-sm focus:ring-2 focus:ring-cyan-500"
-            >
-              {questions.map((q) => (
-                <option key={q.id} value={q.id}>
-                  {q.title}
-                </option>
-              ))}
-            </select>
-          </div>
-        </div>
-        {questionError && <p className="text-sm text-red-600">{questionError}</p>}
-        {!loadingQuestions && questions.length === 0 && (
-          <p className="text-sm text-slate-600">No voting questions available yet.</p>
-        )}
-      </section>
+          <p className="text-slate-300">
+            Review ballot totals and the full audit trail. Only administrators can access voter details.
+          </p>
+        </header>
 
-      {selectedQuestion && (
-        <>
-          <section className="bg-white border border-slate-200 rounded-2xl shadow-sm p-6 space-y-4">
+        <section className="rounded-2xl border border-white/10 bg-white/5 shadow-[0_18px_40px_rgba(0,0,0,0.4)] p-5 space-y-4">
+          <div className="flex flex-col gap-3 sm:flex-row sm:items-center sm:justify-between">
+            <div>
+              <h2 className="text-lg font-semibold text-white">Select a question</h2>
+              <p className="text-sm text-slate-300">
+                Switch between open and closed polls to audit their ballots.
+              </p>
+            </div>
+            <div className="flex items-center gap-2">
+              {loadingQuestions && <Loader2 className="w-4 h-4 animate-spin text-cyan-600" />}
+              <select
+                value={selectedQuestionId}
+                onChange={(e) => setSelectedQuestionId(e.target.value)}
+                className="border border-white/10 bg-white/5 rounded-xl px-3 py-2 text-sm text-slate-100 shadow-sm focus:ring-2 focus:ring-cyan-500"
+              >
+                {questions.map((q) => (
+                  <option key={q.id} value={q.id}>
+                    {q.title}
+                  </option>
+                ))}
+              </select>
+            </div>
+          </div>
+          {questionError && <p className="text-sm text-red-300">{questionError}</p>}
+          {!loadingQuestions && questions.length === 0 && (
+            <p className="text-sm text-slate-300">No voting questions available yet.</p>
+          )}
+        </section>
+
+        {selectedQuestion && (
+          <>
+            <section className="rounded-2xl border border-white/10 bg-white/5 shadow-[0_18px_40px_rgba(0,0,0,0.4)] p-6 space-y-4">
             <div className="flex items-center gap-3">
               <BarDividerIcon />
               <div>
-                <p className="text-xs uppercase tracking-[0.2em] text-slate-600 font-semibold">Results summary</p>
-                <h3 className="text-lg font-semibold text-slate-900">{selectedQuestion.title}</h3>
+                <p className="text-xs uppercase tracking-[0.2em] text-slate-400 font-semibold">Results summary</p>
+                <h3 className="text-lg font-semibold text-white">{selectedQuestion.title}</h3>
               </div>
             </div>
 
@@ -250,11 +251,11 @@ export default function AdminVotingAuditPage() {
                 const percentage = totalVotes === 0 ? 0 : Math.round((count / Math.max(totalVotes, 1)) * 100);
                 return (
                   <div key={opt.id} className="space-y-2">
-                    <div className="flex justify-between text-sm text-slate-700">
+                    <div className="flex justify-between text-sm text-slate-300">
                       <span className="font-medium">{opt.label}</span>
-                      <span className="font-semibold text-slate-900">{count}</span>
+                      <span className="font-semibold text-white">{count}</span>
                     </div>
-                    <div className="h-2 rounded-full bg-slate-100 overflow-hidden border border-slate-200">
+                    <div className="h-2 rounded-full bg-slate-800/70 overflow-hidden border border-white/10">
                       <div
                         className="h-full bg-gradient-to-r from-cyan-500 to-indigo-500 rounded-full transition-all"
                         style={{ width: `${percentage}%` }}
@@ -264,29 +265,29 @@ export default function AdminVotingAuditPage() {
                 );
               })}
             </div>
-            <div className="text-sm text-slate-600 font-medium">
-              Total ballots recorded: <span className="text-slate-900">{totalVotes}</span>
+            <div className="text-sm text-slate-300 font-medium">
+              Total ballots recorded: <span className="text-white">{totalVotes}</span>
             </div>
-          </section>
+            </section>
 
-          <section className="bg-white border border-slate-200 rounded-2xl shadow-sm p-6 space-y-4">
+            <section className="rounded-2xl border border-white/10 bg-white/5 shadow-[0_18px_40px_rgba(0,0,0,0.4)] p-6 space-y-4">
             <div className="flex flex-col gap-3 md:flex-row md:items-center md:justify-between">
               <div className="flex items-center gap-3">
-                <Table className="text-cyan-600" size={18} />
+                <Table className="text-cyan-400" size={18} />
                 <div>
-                  <p className="text-xs uppercase tracking-[0.2em] text-slate-600 font-semibold">
+                  <p className="text-xs uppercase tracking-[0.2em] text-slate-400 font-semibold">
                     Voting audit table
                   </p>
-                  <h3 className="text-lg font-semibold text-slate-900">Ballots for this question</h3>
+                  <h3 className="text-lg font-semibold text-white">Ballots for this question</h3>
                 </div>
               </div>
               <div className="flex items-center gap-2">
-                <div className="flex items-center gap-2 border border-slate-200 rounded-xl px-3 py-2 text-sm">
-                  <Filter size={14} className="text-slate-500" />
+                <div className="flex items-center gap-2 border border-white/10 rounded-xl px-3 py-2 text-sm bg-white/5">
+                  <Filter size={14} className="text-slate-400" />
                   <select
                     value={optionFilter}
                     onChange={(e) => setOptionFilter(e.target.value)}
-                    className="bg-transparent focus:outline-none"
+                    className="bg-transparent focus:outline-none text-slate-100"
                   >
                     <option value="all">All options</option>
                     {selectedQuestion.options.map((opt) => (
@@ -324,11 +325,11 @@ export default function AdminVotingAuditPage() {
             </div>
 
             <div className="hidden md:block overflow-x-auto">
-              <table className="min-w-full divide-y divide-slate-200 text-sm">
-                <thead className="bg-slate-50">
+              <table className="min-w-full divide-y divide-white/10 text-sm">
+                <thead className="bg-white/5">
                   <tr>
-                    <th className="px-4 py-3 text-left font-semibold text-slate-700">Voter</th>
-                    <th className="px-4 py-3 text-left font-semibold text-slate-700">
+                    <th className="px-4 py-3 text-left font-semibold text-slate-200">Voter</th>
+                    <th className="px-4 py-3 text-left font-semibold text-slate-200">
                       <button
                         type="button"
                         className="flex items-center gap-1"
@@ -340,7 +341,7 @@ export default function AdminVotingAuditPage() {
                         Flat
                       </button>
                     </th>
-                    <th className="px-4 py-3 text-left font-semibold text-slate-700">
+                    <th className="px-4 py-3 text-left font-semibold text-slate-200">
                       <button
                         type="button"
                         className="flex items-center gap-1"
@@ -352,13 +353,13 @@ export default function AdminVotingAuditPage() {
                         Option
                       </button>
                     </th>
-                    <th className="px-4 py-3 text-left font-semibold text-slate-700">Cast at</th>
+                    <th className="px-4 py-3 text-left font-semibold text-slate-200">Cast at</th>
                   </tr>
                 </thead>
-                <tbody className="divide-y divide-slate-100">
+                <tbody className="divide-y divide-white/5">
                   {votesLoading ? (
                     <tr>
-                      <td colSpan={4} className="px-4 py-6 text-center text-slate-600">
+                      <td colSpan={4} className="px-4 py-6 text-center text-slate-300">
                         <span className="inline-flex items-center gap-2">
                           <Loader2 className="w-4 h-4 animate-spin text-cyan-600" /> Loading ballots…
                         </span>
@@ -366,25 +367,25 @@ export default function AdminVotingAuditPage() {
                     </tr>
                   ) : votesError ? (
                     <tr>
-                      <td colSpan={4} className="px-4 py-6 text-center text-red-600">
+                      <td colSpan={4} className="px-4 py-6 text-center text-red-300">
                         {votesError}
                       </td>
                     </tr>
                   ) : filteredVotes.length === 0 ? (
                     <tr>
-                      <td colSpan={4} className="px-4 py-6 text-center text-slate-600">
+                      <td colSpan={4} className="px-4 py-6 text-center text-slate-300">
                         No ballots recorded yet.
                       </td>
                     </tr>
                   ) : (
                     filteredVotes.map((vote) => (
-                      <tr key={vote.id} className="hover:bg-slate-50">
-                        <td className="px-4 py-3 text-slate-900 font-medium">{vote.userName}</td>
-                        <td className="px-4 py-3 text-slate-700">{vote.flat}</td>
-                        <td className="px-4 py-3 text-slate-700">
+                      <tr key={vote.id} className="hover:bg-white/5">
+                        <td className="px-4 py-3 text-slate-100 font-medium">{vote.userName}</td>
+                        <td className="px-4 py-3 text-slate-300">{vote.flat}</td>
+                        <td className="px-4 py-3 text-slate-300">
                           {optionLabelMap[vote.optionId] ?? vote.optionId}
                         </td>
-                        <td className="px-4 py-3 text-slate-700 whitespace-nowrap">
+                        <td className="px-4 py-3 text-slate-300 whitespace-nowrap">
                           {formatDateTime(vote.createdAt)}
                         </td>
                       </tr>
@@ -396,41 +397,42 @@ export default function AdminVotingAuditPage() {
 
             <div className="md:hidden space-y-3">
               {votesLoading ? (
-                <div className="rounded-xl border border-slate-200 bg-slate-50 px-4 py-3 text-sm text-slate-600">
+                <div className="rounded-xl border border-white/10 bg-white/5 px-4 py-3 text-sm text-slate-300">
                   <span className="inline-flex items-center gap-2">
                     <Loader2 className="w-4 h-4 animate-spin text-cyan-600" /> Loading ballots…
                   </span>
                 </div>
               ) : votesError ? (
-                <div className="rounded-xl border border-red-200 bg-red-50 px-4 py-3 text-sm text-red-600">
+                <div className="rounded-xl border border-red-500/30 bg-red-500/10 px-4 py-3 text-sm text-red-200">
                   {votesError}
                 </div>
               ) : filteredVotes.length === 0 ? (
-                <div className="rounded-xl border border-slate-200 bg-slate-50 px-4 py-3 text-sm text-slate-600">
+                <div className="rounded-xl border border-white/10 bg-white/5 px-4 py-3 text-sm text-slate-300">
                   No ballots recorded yet.
                 </div>
               ) : (
                 filteredVotes.map((vote) => (
-                  <div key={vote.id} className="rounded-xl border border-slate-200 bg-white p-4 shadow-sm">
+                  <div key={vote.id} className="rounded-xl border border-white/10 bg-white/5 p-4 shadow-[0_12px_30px_rgba(0,0,0,0.35)]">
                     <div className="flex flex-wrap items-center justify-between gap-2">
-                      <div className="font-semibold text-slate-900">{vote.userName}</div>
-                      <div className="text-sm text-slate-600">Flat {vote.flat}</div>
+                      <div className="font-semibold text-slate-100">{vote.userName}</div>
+                      <div className="text-sm text-slate-300">Flat {vote.flat}</div>
                     </div>
-                    <div className="mt-2 text-sm text-slate-700">
+                    <div className="mt-2 text-sm text-slate-300">
                       <span className="font-medium">Option:</span>{' '}
                       {optionLabelMap[vote.optionId] ?? vote.optionId}
                     </div>
-                    <div className="mt-1 text-xs text-slate-500">
+                    <div className="mt-1 text-xs text-slate-400">
                       Cast at {formatDateTime(vote.createdAt)}
                     </div>
                   </div>
                 ))
               )}
             </div>
-          </section>
-        </>
-      )}
-    </div>
+            </section>
+          </>
+        )}
+      </div>
+    </main>
   );
 }
 


### PR DESCRIPTION
### Motivation
- The admin dashboard contained bright/light surfaces that clash with the site’s dark theme and reduced the perceived visual hierarchy.
- Update visual styling (cards, header, tabs, section containers, stat pills) to a consistent dark, glass-like palette without changing any business logic or Firestore behavior.

### Description
- Reworked admin surface styles to a dark-first glassmorphism look by replacing light backgrounds with darker gradients, translucent panels, subtle borders, and richer shadows across the admin UI.
- Restyled stat pills, section containers, the top header and sticky tab strip to use semi-transparent dark backgrounds, muted text, and soft glow accents for active tabs.
- Converted admin subpanels (Owners, Email, Vote Audit) and mobile/desktop lists to dark glass cards with consistent 1px translucent borders and updated text colors for accessible contrast.
- Updated the voting audit page to use the same dark card language and adjusted table/list colors and progress bars to match the dark theme.
- Files changed: `src/app/admin/page.tsx`, `src/app/admin/AdminEmailPanel.tsx`, `src/app/admin/OwnersPanel.tsx`, `src/app/admin/AdminVoteAuditPanel.tsx`, `src/app/admin/voting/page.tsx`.
- No functional code, Firestore queries, permissions, or button logic were modified; changes are CSS/class-only and visual.

### Testing
- Started the dev server with `npm run dev -- --hostname 0.0.0.0 --port 3000` to compile pages; compilation completed but runtime requests to `/admin` failed due to environment issues (Firebase invalid API key and Google Fonts fetch failures).
- Captured a full-page screenshot of `/admin` using an automated Playwright script (artifact: `artifacts/admin-dark-mode.png`) to visually inspect the new dark styling.
- Note: automated dev run exposed external environment limitations (missing Firebase credentials and blocked Google Fonts) that prevented a full authenticated render; these are unrelated to the styling changes themselves.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6979237ed9808324b6e0df544a61ca57)