### PR TITLE
Add AGM announcement banner and make owner announcements collapsible

### DIFF
--- a/src/app/HomePageClient.tsx
+++ b/src/app/HomePageClient.tsx
@@ -5,7 +5,7 @@ import Image from 'next/image';
 import { motion, AnimatePresence, useReducedMotion } from 'framer-motion';
 import { useState } from 'react';
 import MobileAppPoster from '@/components/home/MobileAppPoster';
-import EGMAnnouncementBanner from '@/components/EGMAnnouncementBanner';
+import AGMAnnouncementBanner from '@/components/AGMAnnouncementBanner';
 import AnnouncementNotice from '@/components/AnnouncementNotice';
 
 /** ------------------------------------------------
@@ -299,9 +299,6 @@ export default function HomePageClient() {
 
   return (
     <main className="px-4 py-10 sm:py-14">
-      <div className="mb-8 sm:mb-10">
-        <EGMAnnouncementBanner />
-      </div>
       {/* HERO */}
       <section className="mx-auto max-w-6xl">
         <motion.div
@@ -389,6 +386,10 @@ export default function HomePageClient() {
                   <RulePill title="Bookable Windows" detail="05:30–09:30 • 17:00–23:00" />
                   <RulePill title="Daily Limit" detail="Max 2 slots per facility" />
                   <RulePill title="Free Use" detail="11:00–17:00 (no booking)" />
+                </div>
+
+                <div className="pt-3">
+                  <AGMAnnouncementBanner />
                 </div>
               </div>
             </header>

--- a/src/components/AGMAnnouncementBanner.tsx
+++ b/src/components/AGMAnnouncementBanner.tsx
@@ -1,0 +1,61 @@
+'use client';
+
+import Link from 'next/link';
+import { useState } from 'react';
+import { ChevronDown, ExternalLink } from 'lucide-react';
+
+export default function AGMAnnouncementBanner() {
+  const [expanded, setExpanded] = useState(false);
+
+  return (
+    <div className="rounded-2xl border border-indigo-300/40 bg-indigo-50/70 p-5 text-left shadow-sm dark:border-indigo-500/30 dark:bg-indigo-950/30 sm:p-6">
+      <p className="text-xs font-semibold uppercase tracking-[0.2em] text-indigo-700 dark:text-indigo-300">
+        OWNERS ANNOUNCEMENT
+      </p>
+
+      <h3 className="mt-2 text-lg font-semibold text-indigo-950 dark:text-indigo-100 sm:text-xl">
+        AGM Thursday 4th June for owners
+      </h3>
+
+      <p className="mt-2 text-sm leading-relaxed text-indigo-950/85 dark:text-indigo-100/90 sm:text-base">
+        The James Square AGM is approaching. Owners can review updates and vote on plans for
+        improvements. If you are a tenant, please make your owner aware.
+      </p>
+
+      {expanded && (
+        <div className="mt-4 space-y-3 border-t border-indigo-300/40 pt-4 text-sm leading-relaxed text-indigo-950/85 dark:border-indigo-400/30 dark:text-indigo-100/90 sm:text-base">
+          <p>
+            The Annual General Meeting gives owners the opportunity to find out what has been
+            happening at James Square and to vote on plans for improvements going forward. This will
+            be our first AGM with Myreside Management as factors, taking place on Thursday 4th June
+            2026 via Microsoft Teams.
+          </p>
+          <p>
+            For more information, and to leave suggestions on what you would like discussed, please
+            visit the AGM page.
+          </p>
+          <Link
+            href="/AGM"
+            className="inline-flex items-center gap-2 rounded-lg border border-indigo-400/50 bg-white/80 px-3 py-2 font-medium text-indigo-800 transition hover:bg-indigo-100 dark:border-indigo-300/40 dark:bg-indigo-900/30 dark:text-indigo-100 dark:hover:bg-indigo-900/50"
+          >
+            Visit AGM page
+            <ExternalLink className="h-4 w-4" aria-hidden="true" />
+          </Link>
+        </div>
+      )}
+
+      <button
+        type="button"
+        onClick={() => setExpanded((value) => !value)}
+        aria-expanded={expanded}
+        className="mt-4 inline-flex items-center gap-1 text-sm font-semibold text-indigo-700 hover:underline dark:text-indigo-300"
+      >
+        {expanded ? 'Show less' : 'Read more'}
+        <ChevronDown
+          className={`h-4 w-4 transition-transform ${expanded ? 'rotate-180' : ''}`}
+          aria-hidden="true"
+        />
+      </button>
+    </div>
+  );
+}

--- a/src/components/AnnouncementNotice.tsx
+++ b/src/components/AnnouncementNotice.tsx
@@ -1,5 +1,7 @@
 'use client';
 
+import { useState } from 'react';
+
 const SHOW_ANNOUNCEMENT = true;
 const GATES_NOTICE_PUBLISHED_AT = new Date('2026-02-06T00:00:00Z');
 const GATES_NOTICE_EXPIRES_AT = new Date(
@@ -7,6 +9,8 @@ const GATES_NOTICE_EXPIRES_AT = new Date(
 );
 
 export default function AnnouncementNotice() {
+  const [expanded, setExpanded] = useState(false);
+
   if (!SHOW_ANNOUNCEMENT) {
     return null;
   }
@@ -16,23 +20,24 @@ export default function AnnouncementNotice() {
   return (
     <section className="mx-auto max-w-6xl mt-6 sm:mt-8">
       <div className="jqs-glass rounded-2xl border border-white/30 bg-white/60 p-6 shadow-[0_8px_30px_rgba(0,0,0,0.06)] backdrop-blur-xl dark:border-white/10 dark:bg-white/10 sm:p-8">
-        <div className="flex flex-col gap-8">
-          <div className="flex flex-col gap-4">
-            <header className="space-y-1">
-              <p className="text-xs font-semibold uppercase tracking-[0.2em] text-amber-700/80 dark:text-amber-300/90">
-                Owner Notice
-              </p>
-              <h2 className="text-xl font-semibold text-neutral-900 dark:text-neutral-100 sm:text-2xl">
-                Update – Appointment of New Factor
-              </h2>
-            </header>
+        <header className="space-y-1">
+          <p className="text-xs font-semibold uppercase tracking-[0.2em] text-amber-700/80 dark:text-amber-300/90">
+            OWNER NOTICE
+          </p>
+          <h2 className="text-xl font-semibold text-neutral-900 dark:text-neutral-100 sm:text-2xl">
+            Update – Appointment of New Factor
+          </h2>
+        </header>
 
-            <div className="space-y-3 text-sm text-neutral-700 dark:text-neutral-200 sm:text-base">
-              <p>
-                Following the conclusion of the owner vote, the factor for James Square was
-                formally changed from Fior Asset &amp; Property to Myreside Management Limited with
-                effect from 1 February 2026.
-              </p>
+        <div className="mt-4 space-y-3 text-sm text-neutral-700 dark:text-neutral-200 sm:text-base">
+          <p>
+            Following the conclusion of the owner vote, the factor for James Square was formally
+            changed from Fior Asset &amp; Property to Myreside Management Limited with effect from 1
+            February 2026.
+          </p>
+
+          {expanded && (
+            <>
               <p>
                 Owners should no longer make any payments to Fior Asset &amp; Property. If any
                 payments have been made to Fior after 1 February 2026, owners are advised to
@@ -82,30 +87,38 @@ export default function AnnouncementNotice() {
                 <br />
                 Registered Property Factor Number PF000177
               </p>
-            </div>
-          </div>
 
-          {isGatesNoticeActive && (
-            <div className="flex flex-col gap-4">
-              <header className="space-y-1">
-                <p className="text-xs font-semibold uppercase tracking-[0.2em] text-amber-700/80 dark:text-amber-300/90">
-                  Owner Notice
-                </p>
-                <h2 className="text-xl font-semibold text-neutral-900 dark:text-neutral-100 sm:text-2xl">
-                  Update – Main Gates
-                </h2>
-              </header>
-
-              <div className="space-y-3 text-sm text-neutral-700 dark:text-neutral-200 sm:text-base">
-                <p>
-                  The issue with the main entrance gates has now been resolved. Repairs were
-                  completed on Friday, and the gates are fully operational.
-                </p>
-                <p>Thank you for your patience while this was addressed.</p>
-              </div>
-            </div>
+              {isGatesNoticeActive && (
+                <div className="border-t border-amber-200/60 pt-4 dark:border-amber-300/20">
+                  <header className="space-y-1">
+                    <p className="text-xs font-semibold uppercase tracking-[0.2em] text-amber-700/80 dark:text-amber-300/90">
+                      Owner Notice
+                    </p>
+                    <h3 className="text-lg font-semibold text-neutral-900 dark:text-neutral-100">
+                      Update – Main Gates
+                    </h3>
+                  </header>
+                  <div className="mt-3 space-y-2">
+                    <p>
+                      The issue with the main entrance gates has now been resolved. Repairs were
+                      completed on Friday, and the gates are fully operational.
+                    </p>
+                    <p>Thank you for your patience while this was addressed.</p>
+                  </div>
+                </div>
+              )}
+            </>
           )}
         </div>
+
+        <button
+          type="button"
+          onClick={() => setExpanded((value) => !value)}
+          aria-expanded={expanded}
+          className="mt-4 inline-flex items-center text-sm font-semibold text-amber-700 hover:underline dark:text-amber-300"
+        >
+          {expanded ? 'Show less' : 'View more'}
+        </button>
       </div>
     </section>
   );


### PR DESCRIPTION
### Motivation

- Surface a time-sensitive AGM notice to owners and tidy up the homepage placement of announcements.  
- Improve the owner announcement area by making longer notices collapsible to reduce visual noise.

### Description

- Replace the removed `EGMAnnouncementBanner` with a new `AGMAnnouncementBanner` component and render it inside the HERO booking section in `src/app/HomePageClient.tsx`.  
- Add the new file `src/components/AGMAnnouncementBanner.tsx` which implements an expandable AGM notice with a link to the AGM page.  
- Update `src/components/AnnouncementNotice.tsx` to introduce local state with `useState`, make the detailed factor change content collapsible, reformat the gates notice into a conditional subsection, and add a toggle `View more`/`Show less` button.  
- Small presentation/layout adjustments to headings, spacing, and borders within the announcement area for a cleaner visual hierarchy.

### Testing

- Ran a TypeScript type check with `tsc --noEmit` and a development build with `pnpm build` and both completed without errors.  
- Ran the test suite with `pnpm test` and linting with `pnpm lint`, and no failures were reported.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e754b763988324a76703db3822d3dc)