### PR TITLE
Add questionnaire callout to owners secure page

### DIFF
--- a/src/app/owners/secure/page.tsx
+++ b/src/app/owners/secure/page.tsx
@@ -81,6 +81,21 @@ const OwnersSecurePage = () => {
           </p>
         </motion.header>
 
+        <motion.div variants={itemVariants}>
+          <div className="rounded-2xl border border-cyan-500/30 bg-cyan-500/10 p-4 md:p-5 text-sm md:text-base text-slate-800 dark:text-slate-100">
+            <p>
+              Help the owners committee by sharing your views through our questionnaire.{' '}
+              <Link
+                href="/fior-questionnaire"
+                className="font-semibold text-cyan-700 underline decoration-cyan-400/70 underline-offset-2 transition-colors hover:text-cyan-600 dark:text-cyan-300 dark:hover:text-cyan-200"
+              >
+                Complete the questionnaire
+              </Link>
+              .
+            </p>
+          </div>
+        </motion.div>
+
         <motion.div variants={itemVariants} className="mt-8">
           <div
             className="flex items-start gap-4 p-6 rounded-2xl


### PR DESCRIPTION
### Motivation
- Encourage James Square owners to provide feedback by surfacing a prominent link to the questionnaire near the top of the secure owners area.

### Description
- Inserted a new `motion.div` callout directly below the page intro in `src/app/owners/secure/page.tsx` that prompts owners to “Complete the questionnaire” and links to the questionnaire route at `/fior-questionnaire`.
- The callout uses the existing UI conventions and classes (including dark mode-friendly styles) and reuses the page's `itemVariants` animation settings for a consistent appearance.

### Testing
- No automated tests were run for this content/UI-only change.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f51fe465dc8324832de0d925e18e7b)