### PR TITLE
Add Fior questionnaire quick link to homepage

### DIFF
--- a/src/app/HomePageClient.tsx
+++ b/src/app/HomePageClient.tsx
@@ -268,7 +268,6 @@ function IconCard({
   darkIcon,
   blurb,
   iconAlt,
-  audienceLabel,
   ctaText,
   reduceMotion,
 }: {
@@ -278,7 +277,6 @@ function IconCard({
   darkIcon: string;
   blurb: string;
   iconAlt?: string;
-  audienceLabel?: string;
   ctaText?: string;
   reduceMotion: boolean;
 }) {
@@ -304,11 +302,6 @@ function IconCard({
         </div>
         <div className="relative z-10">
           <h3 className="text-lg font-semibold">{title}</h3>
-          {audienceLabel ? (
-            <span className="mt-2 inline-flex items-center rounded-full border border-neutral-900/10 bg-white/55 px-2.5 py-0.5 text-[11px] font-semibold uppercase tracking-wide text-neutral-700 dark:border-white/10 dark:bg-white/10 dark:text-neutral-200">
-              {audienceLabel}
-            </span>
-          ) : null}
           <p className="mt-1 text-sm text-neutral-700 dark:text-neutral-300">{blurb}</p>
           <span className="mt-3 inline-flex translate-x-0 items-center gap-1 rounded-full border border-neutral-900/10 bg-white/55 px-3 py-1 text-xs font-semibold text-neutral-900/70 transition-all group-hover:translate-x-1 group-hover:bg-white/80 group-hover:text-neutral-900 dark:border-white/10 dark:bg-white/10 dark:text-neutral-100/80 dark:group-hover:bg-white/15 dark:group-hover:text-neutral-100">
             {ctaText ?? `Open ${title}`} <ArrowRight className="h-3.5 w-3.5" />
@@ -1115,8 +1108,7 @@ export default function HomePageClient() {
               href="/fior-questionnaire"
               lightIcon="/images/icons/q&a-light.png"
               darkIcon="/images/icons/q&a-dark.png"
-              blurb="Have you paid additional money towards roof or maintenance works during the Fior management period? Or continued paying Fior after February 2026. This short questionnaire helps gauge how many owners may have been affected and how much money Fior may require to give back to James Square."
-              audienceLabel="Owners"
+              blurb="Help gauge whether owners paid additional money to Fior for roof or maintenance works, or continued paying Fior after February 2026."
               ctaText="Open Questionnaire"
               reduceMotion={Boolean(reduceMotion)}
             />

--- a/src/app/HomePageClient.tsx
+++ b/src/app/HomePageClient.tsx
@@ -230,11 +230,13 @@ function DualModeIcon({
   darkSrc,
   alt,
   size = 128,
+  className = 'h-20 w-20 object-contain sm:h-24 sm:w-24',
 }: {
   lightSrc: string;
   darkSrc: string;
   alt: string;
   size?: number;
+  className?: string;
 }) {
   return (
     <>
@@ -243,7 +245,7 @@ function DualModeIcon({
         alt={alt}
         width={size}
         height={size}
-        className="block dark:hidden h-20 w-20 object-contain sm:h-24 sm:w-24"
+        className={`block dark:hidden ${className}`}
         priority
       />
       <Image
@@ -251,7 +253,7 @@ function DualModeIcon({
         alt={alt}
         width={size}
         height={size}
-        className="hidden h-20 w-20 object-contain dark:block sm:h-24 sm:w-24"
+        className={`hidden dark:block ${className}`}
         priority
       />
     </>
@@ -268,6 +270,7 @@ function IconCard({
   darkIcon,
   blurb,
   iconAlt,
+  iconClassName,
   ctaText,
   reduceMotion,
 }: {
@@ -277,6 +280,7 @@ function IconCard({
   darkIcon: string;
   blurb: string;
   iconAlt?: string;
+  iconClassName?: string;
   ctaText?: string;
   reduceMotion: boolean;
 }) {
@@ -297,8 +301,13 @@ function IconCard({
           <span className="absolute -inset-1 bg-gradient-to-tr from-white/15 to-transparent" />
         </span>
 
-        <div className="shrink-0">
-          <DualModeIcon lightSrc={lightIcon} darkSrc={darkIcon} alt={iconAlt ?? title} />
+        <div className="shrink-0 self-center">
+          <DualModeIcon
+            lightSrc={lightIcon}
+            darkSrc={darkIcon}
+            alt={iconAlt ?? title}
+            className={iconClassName}
+          />
         </div>
         <div className="relative z-10">
           <h3 className="text-lg font-semibold">{title}</h3>
@@ -1109,6 +1118,7 @@ export default function HomePageClient() {
               lightIcon="/images/icons/q&a-light.png"
               darkIcon="/images/icons/q&a-dark.png"
               blurb="Help gauge whether owners paid additional money to Fior for roof or maintenance works, or continued paying Fior after February 2026."
+              iconClassName="h-24 w-24 object-cover sm:h-28 sm:w-28"
               ctaText="Open Questionnaire"
               reduceMotion={Boolean(reduceMotion)}
             />

--- a/src/app/HomePageClient.tsx
+++ b/src/app/HomePageClient.tsx
@@ -268,6 +268,8 @@ function IconCard({
   darkIcon,
   blurb,
   iconAlt,
+  audienceLabel,
+  ctaText,
   reduceMotion,
 }: {
   title: string;
@@ -276,6 +278,8 @@ function IconCard({
   darkIcon: string;
   blurb: string;
   iconAlt?: string;
+  audienceLabel?: string;
+  ctaText?: string;
   reduceMotion: boolean;
 }) {
   return (
@@ -300,9 +304,14 @@ function IconCard({
         </div>
         <div className="relative z-10">
           <h3 className="text-lg font-semibold">{title}</h3>
+          {audienceLabel ? (
+            <span className="mt-2 inline-flex items-center rounded-full border border-neutral-900/10 bg-white/55 px-2.5 py-0.5 text-[11px] font-semibold uppercase tracking-wide text-neutral-700 dark:border-white/10 dark:bg-white/10 dark:text-neutral-200">
+              {audienceLabel}
+            </span>
+          ) : null}
           <p className="mt-1 text-sm text-neutral-700 dark:text-neutral-300">{blurb}</p>
           <span className="mt-3 inline-flex translate-x-0 items-center gap-1 rounded-full border border-neutral-900/10 bg-white/55 px-3 py-1 text-xs font-semibold text-neutral-900/70 transition-all group-hover:translate-x-1 group-hover:bg-white/80 group-hover:text-neutral-900 dark:border-white/10 dark:bg-white/10 dark:text-neutral-100/80 dark:group-hover:bg-white/15 dark:group-hover:text-neutral-100">
-            Open {title} <ArrowRight className="h-3.5 w-3.5" />
+            {ctaText ?? `Open ${title}`} <ArrowRight className="h-3.5 w-3.5" />
           </span>
         </div>
       </motion.div>
@@ -1096,6 +1105,19 @@ export default function HomePageClient() {
               lightIcon="/images/icons/info-icon-light.png"
               darkIcon="/images/icons/new-info-icon-dark.png"
               blurb="Access, bins & recycling, contacts and local picks (food, shops, coffee)."
+              reduceMotion={Boolean(reduceMotion)}
+            />
+          </motion.div>
+
+          <motion.div variants={cardRevealVariants(Boolean(reduceMotion))}>
+            <IconCard
+              title="Fior Additional Payments Survey"
+              href="/fior-questionnaire"
+              lightIcon="/images/icons/q&a-light.png"
+              darkIcon="/images/icons/q&a-dark.png"
+              blurb="Have you paid additional money towards roof or maintenance works during the Fior management period? Or continued paying Fior after February 2026. This short questionnaire helps gauge how many owners may have been affected and how much money Fior may require to give back to James Square."
+              audienceLabel="Owners"
+              ctaText="Open Questionnaire"
               reduceMotion={Boolean(reduceMotion)}
             />
           </motion.div>


### PR DESCRIPTION
### Motivation
- Provide a visible quick link on the homepage so owners can complete a short questionnaire about additional payments made to Fior during the management period.

### Description
- Updated `src/app/HomePageClient.tsx` to add optional `audienceLabel` and `ctaText` props to the `IconCard` component and its type signature to support an audience tag and custom button text.
- Render an audience label when `audienceLabel` is supplied and use `ctaText` (falling back to `Open ${title}`) for the CTA text inside the card.
- Added a new Quick Links card titled `Fior Additional Payments Survey` that links to `/fior-questionnaire` and uses the project Q&A icons at `/images/icons/q&a-light.png` and `/images/icons/q&a-dark.png`, with the provided blurb, `Owners` label, and CTA `Open Questionnaire`.

### Testing
- Ran `npm run lint`, which completed successfully with pre-existing warnings in unrelated files.
- Ran `npm run build`, which failed in this environment due to network errors fetching Google Fonts from `fonts.gstatic.com` and is unrelated to the changes in this PR.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f5f7b986748324a78c160ba49e844e)