### PR TITLE
Redesign /fior-questionnaire: owner-focused layout and wording

### DIFF
--- a/src/app/fior-questionnaire/page.tsx
+++ b/src/app/fior-questionnaire/page.tsx
@@ -1,8 +1,10 @@
 import type { Metadata } from 'next';
+import Image from 'next/image';
+import Link from 'next/link';
 
-const pageTitle = 'Fior Payment Questionnaire | James Square';
+const pageTitle = 'Fior Additional Payments Questionnaire | James Square';
 const pageDescription =
-  'Neutral information page for James Square owners completing the Fior payment questionnaire.';
+  'Information page for James Square owners completing the Fior additional payments questionnaire.';
 const formUrl = 'https://forms.office.com/r/GEk4AbGcjz';
 
 export const metadata: Metadata = {
@@ -19,69 +21,141 @@ export const metadata: Metadata = {
   },
 };
 
+function DualModeIcon() {
+  return (
+    <div className="shrink-0 rounded-2xl border border-slate-200/70 bg-white/60 p-3 shadow-sm backdrop-blur dark:border-white/10 dark:bg-white/10">
+      <Image
+        src="/images/icons/q&a-light.png"
+        alt="Questionnaire icon"
+        width={96}
+        height={96}
+        className="block h-16 w-16 object-contain dark:hidden sm:h-20 sm:w-20"
+        priority
+      />
+      <Image
+        src="/images/icons/q&a-dark.png"
+        alt="Questionnaire icon"
+        width={96}
+        height={96}
+        className="hidden h-16 w-16 object-contain dark:block sm:h-20 sm:w-20"
+        priority
+      />
+    </div>
+  );
+}
+
 export default function FiorQuestionnairePage() {
   return (
-    <main className="mx-auto w-full max-w-5xl px-4 py-8 sm:px-6 sm:py-10">
+    <main className="mx-auto w-full max-w-6xl px-4 py-8 sm:px-6 sm:py-10 lg:py-14">
       <section className="relative overflow-hidden rounded-3xl border border-slate-200/70 bg-white/80 p-6 shadow-xl backdrop-blur dark:border-slate-800/70 dark:bg-slate-900/70 sm:p-8 lg:p-10">
         <div className="pointer-events-none absolute inset-0 opacity-70" aria-hidden>
           <div className="absolute -right-10 -top-24 h-64 w-64 rounded-full bg-blue-400/20 blur-3xl" />
           <div className="absolute -bottom-10 -left-20 h-72 w-72 rounded-full bg-sky-400/20 blur-3xl" />
         </div>
 
-        <div className="relative z-10 space-y-6">
-          <header className="space-y-4">
-            <p className="text-sm font-medium uppercase tracking-[0.12em] text-slate-500 dark:text-slate-400">
-              James Square Owner Information
+        <div className="relative z-10 space-y-8">
+          <header className="space-y-5">
+            <div className="flex flex-col gap-4 sm:flex-row sm:items-start sm:justify-between">
+              <div className="space-y-3">
+                <p className="text-sm font-medium uppercase tracking-[0.12em] text-slate-500 dark:text-slate-400">
+                  Owners Information
+                </p>
+                <h1 className="text-3xl font-semibold text-slate-900 dark:text-slate-100 sm:text-4xl">
+                  Fior Additional Payments Questionnaire
+                </h1>
+              </div>
+              <DualModeIcon />
+            </div>
+
+            <p className="max-w-3xl text-base leading-relaxed text-slate-700 dark:text-slate-200">
+              This questionnaire has been created to better understand whether owners at James Square may have made
+              additional payments during the previous factoring period, or continued making payments after February
+              2026.
             </p>
-            <h1 className="text-3xl font-semibold text-slate-900 dark:text-slate-100 sm:text-4xl">
-              Fior Payment Questionnaire
-            </h1>
+            <p className="max-w-3xl text-base leading-relaxed text-slate-700 dark:text-slate-200">
+              The information collected is intended to help gauge how widespread the issue may be and whether further
+              collective discussion or advice may be worthwhile.
+            </p>
+
+            <div className="flex flex-wrap gap-2 pt-1">
+              {['Owners Information', 'Takes around 2 minutes', 'Questionnaire currently open'].map((item) => (
+                <span
+                  key={item}
+                  className="rounded-full border border-sky-200/80 bg-sky-100/70 px-3 py-1 text-xs font-medium text-sky-800 dark:border-sky-400/20 dark:bg-sky-500/10 dark:text-sky-200"
+                >
+                  {item}
+                </span>
+              ))}
+            </div>
           </header>
 
-          <div className="space-y-4 text-base leading-relaxed text-slate-700 dark:text-slate-200">
-            <p>
-              Following concerns raised by other owners, this questionnaire has been set up to assist with gathering
-              initial information to understand how many owners made payments to Fior Asset &amp; Property following
-              the transfer of factor responsibilities to Myreside Management in February 2026.
-            </p>
-            <p>
-              This is an information gathering exercise only. Owners are encouraged to retain any relevant invoices,
-              payment confirmations, bank statements or correspondence, but are not being asked to submit evidence at
-              this stage.
-            </p>
-            <p>
-              Depending on the responses received, affected owners may later wish to discuss whether independent legal
-              guidance should be sought.
-            </p>
-          </div>
+          <section className="rounded-2xl border border-slate-200/80 bg-white/75 p-4 text-sm text-slate-700 shadow-sm dark:border-white/10 dark:bg-white/5 dark:text-slate-200 sm:p-5">
+            This questionnaire is informal and for information gathering purposes only. Submitting a response does not
+            create legal action, representation, or financial claims.
+          </section>
 
-          <div>
-            <a
-              href={formUrl}
-              target="_blank"
-              rel="noopener noreferrer"
-              className="inline-flex items-center justify-center rounded-xl bg-slate-900 px-6 py-3 text-base font-semibold text-white shadow-md shadow-slate-900/20 transition hover:-translate-y-0.5 hover:bg-slate-800 focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-slate-700 dark:bg-white dark:text-slate-900 dark:hover:bg-slate-100"
+          <details className="group rounded-2xl border border-slate-200/80 bg-white/75 p-5 shadow-sm dark:border-white/10 dark:bg-white/5">
+            <summary className="cursor-pointer list-none text-base font-semibold text-slate-900 marker:content-none dark:text-slate-100">
+              Why has this questionnaire been created?
+              <span className="ml-2 text-slate-400 transition group-open:rotate-180 inline-block">⌄</span>
+            </summary>
+            <div className="pt-3 text-sm leading-relaxed text-slate-700 dark:text-slate-200">
+              <p>
+                Following the transition from Fior Asset &amp; Property to Myreside Management in February 2026, some
+                owners have reported continuing payments or making additional contributions towards maintenance or
+                roof-related works.
+              </p>
+              <p className="mt-3">
+                This questionnaire has been created simply to understand how many owners may have been affected and
+                whether there is enough shared interest to explore the matter further collectively.
+              </p>
+            </div>
+          </details>
+
+          <section className="mx-auto w-full max-w-4xl space-y-4 rounded-3xl border border-slate-200/80 bg-white/70 p-3 shadow-lg backdrop-blur dark:border-white/10 dark:bg-white/5 sm:p-5">
+            <div className="flex flex-wrap items-center justify-between gap-3 px-1 pt-1">
+              <h2 className="text-lg font-semibold text-slate-900 dark:text-slate-100">Questionnaire form</h2>
+              <a
+                href={formUrl}
+                target="_blank"
+                rel="noopener noreferrer"
+                className="inline-flex items-center justify-center rounded-xl bg-slate-900 px-4 py-2 text-sm font-semibold text-white shadow-md shadow-slate-900/20 transition hover:-translate-y-0.5 hover:bg-slate-800 dark:bg-white dark:text-slate-900 dark:hover:bg-slate-100"
+              >
+                Open in new window
+              </a>
+            </div>
+
+            <div className="overflow-hidden rounded-2xl border border-slate-200/80 bg-white/80 shadow-sm dark:border-white/10 dark:bg-white/5">
+              <iframe
+                title="Fior additional payments questionnaire"
+                src="https://forms.office.com/r/GEk4AbGcjz?embed=true"
+                className="h-[760px] w-full md:h-[820px]"
+                frameBorder="0"
+                marginWidth={0}
+                marginHeight={0}
+                style={{ border: 'none', maxWidth: '100%' }}
+                allowFullScreen
+              />
+            </div>
+            <p className="px-1 text-sm text-slate-600 dark:text-slate-300">
+              If the embedded form does not load on your device, please use “Open in new window”.
+            </p>
+          </section>
+
+          <section className="rounded-2xl border border-slate-200/80 bg-slate-50/80 p-4 text-sm leading-relaxed text-slate-700 shadow-sm dark:border-white/10 dark:bg-white/5 dark:text-slate-200">
+            Responses are intended to be reviewed by the James Square committee/admin team for the purpose of
+            understanding owner concerns. Information will not be published publicly. You may only be contacted if
+            further clarification is needed.
+          </section>
+
+          <div className="pt-1">
+            <Link
+              href="/"
+              className="inline-flex items-center text-sm font-medium text-slate-700 underline-offset-4 hover:underline dark:text-slate-300"
             >
-              Complete questionnaire
-            </a>
+              ← Back to homepage
+            </Link>
           </div>
-
-          <div className="overflow-hidden rounded-2xl border border-slate-200/80 bg-white/70 p-2 shadow-sm dark:border-white/10 dark:bg-white/5">
-            <iframe
-              title="Fior payment questionnaire"
-              src="https://forms.office.com/r/GEk4AbGcjz?embed=true"
-              className="h-[720px] w-full rounded-xl sm:h-[780px]"
-              frameBorder="0"
-              marginWidth={0}
-              marginHeight={0}
-              style={{ border: 'none', maxWidth: '100%', maxHeight: '100vh' }}
-              allowFullScreen
-            />
-          </div>
-
-          <p className="text-sm text-slate-600 dark:text-slate-300">
-            If the form does not load, please use the button above to open it in a new window.
-          </p>
         </div>
       </section>
     </main>


### PR DESCRIPTION
### Motivation
- Make the Fior questionnaire page feel calm, factual and owner-focused while matching the James Square site style. 
- Improve mobile usability and trust so more owners will complete the questionnaire.

### Description
- Rewrote the page at `src/app/fior-questionnaire/page.tsx` to introduce a polished glass-style hero and updated title copy (`Fior Additional Payments Questionnaire`).
- Added a dual-mode Q&A icon using existing assets (`/images/icons/q&a-light.png` and `/images/icons/q&a-dark.png`) and supportive status chips (`Owners Information`, `Takes around 2 minutes`, `Questionnaire currently open`).
- Included a neutral disclaimer card immediately under the hero and an expandable `Why has this questionnaire been created?` section with concise factual background about the Feb 2026 transition.
- Restyled the embedded form into a soft glass-style card (`max-w-4xl`), improved iframe sizing for mobile, added an `Open in new window` fallback, a privacy reassurance card, and a `← Back to homepage` link.

### Testing
- Ran `npm run lint`; lint completes successfully although unrelated warnings remain elsewhere in the repo.
- Ran `npm run build`; build failed in this environment due to external font fetch errors from Google Fonts (`Geist` / `Geist Mono`) used in `src/app/layout.tsx`, which are unrelated to the questionnaire page changes.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f5fdccfda88324a275644c50530f2e)