### PR TITLE
Update homepage pool & facilities notice with latest surveyor details

### DIFF
--- a/src/app/HomePageClient.tsx
+++ b/src/app/HomePageClient.tsx
@@ -488,9 +488,10 @@ function PoolNotice() {
 
       <div className="mt-3 text-sm leading-relaxed text-neutral-800 dark:text-neutral-200">
         <p>
-          The pool area is currently closed following a plant room leak which caused an electrical
-          fault and dehumidifier failure. The dehumidifier has now been repaired and is back up
-          and running.
+          The pool, gym and sauna facilities remain temporarily closed following the earlier plant
+          room leak which caused an electrical fault and dehumidifier failure. The dehumidifier
+          has now been repaired and is back up and running, however further damage caused by
+          elevated humidity levels within the pool area is currently being assessed.
         </p>
 
         <AnimatePresence initial={false}>
@@ -528,20 +529,25 @@ function PoolNotice() {
                   affected areas are properly assessed.
                 </p>
                 <p>
-                  Myreside Management have arranged for a surveyor to attend during the first week
-                  of May to carry out a full inspection of the affected ceiling areas and
-                  surrounding structure. The aim of this inspection is to determine whether the
-                  facilities can safely reopen, or identify any essential works required before
-                  reopening can take place.
+                  F3 Surveyors have now attended the development to carry out an inspection of the
+                  pool area and surrounding structure. Pending their full report, they have advised
+                  that the facilities should remain closed as a precaution. Initial findings
+                  identified sections of cornicing requiring to be secured, along with some
+                  movement and slight sagging within the main ceiling above the pool area.
                 </p>
                 <p>
-                  Now that the dehumidifier system has been restored, conditions within the pool area
-                  can begin to stabilise. Further repairs and next steps will follow based on the
-                  surveyor&apos;s findings.
+                  Myreside Management are currently awaiting the full survey report and will then
+                  begin obtaining quotes for any necessary remedial works and repairs required
+                  before reopening can safely take place.
                 </p>
                 <p>
-                  The facilities will reopen once the area has been confirmed safe for residents to use.
-                  Further updates to follow.
+                  Now that the dehumidifier system has been restored, environmental conditions
+                  within the pool area can begin to stabilise. Further repairs and next steps will
+                  follow based on the surveyor&apos;s findings.
+                </p>
+                <p>
+                  The facilities will reopen once the area has been confirmed safe for residents to
+                  use. Further updates will follow once additional information becomes available.
                 </p>
               </div>
             </motion.div>


### PR DESCRIPTION
### Motivation
- Reflect the latest Myreside / F3 surveyor update and clarify that the pool, gym and sauna remain temporarily closed while humidity-related damage is assessed.

### Description
- Updated the short notice and the expanded “Full Update – Pool & Facilities” copy in `src/app/HomePageClient.tsx` to include F3 Surveyors attendance, their precautionary advice, initial findings about cornicing and slight ceiling sagging, that Myreside are awaiting the full report and will obtain remedial quotes, and minor wording refinements about environmental stabilisation and future updates.
- This is a content-only change and does not alter the existing UI structure or component behavior (the expand/collapse animation and button remain unchanged).

### Testing
- No automated tests were run for this content-only update.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0450a511d88324b534228f7fa2f910)