### PR TITLE
Add current status and Telfer Subway closure details to Dalry Road improvements page

### DIFF
--- a/src/app/local/projects/dalry-road-improvements/page.tsx
+++ b/src/app/local/projects/dalry-road-improvements/page.tsx
@@ -70,6 +70,19 @@ export default function DalryRoadImprovementsPage() {
           </div>
         </header>
 
+        <section className="rounded-3xl border border-amber-200/80 dark:border-amber-500/40 bg-amber-50/90 dark:bg-amber-950/30 p-6 sm:p-8 shadow-sm space-y-3">
+          <p className="text-sm font-semibold uppercase tracking-wide text-amber-700 dark:text-amber-300">
+            Current Status
+          </p>
+          <h2 className="text-2xl font-semibold text-slate-900 dark:text-slate-100">
+            Works continue around Dalry Road and Caledonian Crescent
+          </h2>
+          <p className="text-slate-700 dark:text-slate-300">
+            Road improvement works are continuing around Dalry Road and Caledonian Crescent. A temporary closure of
+            Telfer Subway is planned from Monday 15 June to Friday 19 June 2026 while nearby works are carried out.
+          </p>
+        </section>
+
         <section className="rounded-3xl border border-slate-200/70 dark:border-slate-800/70 bg-white/80 dark:bg-slate-900/70 p-6 sm:p-8 shadow-sm space-y-6">
           <div className="space-y-3">
             <h2 className="text-2xl font-semibold text-slate-900 dark:text-slate-100">Planned works</h2>
@@ -86,7 +99,9 @@ export default function DalryRoadImprovementsPage() {
               <p>Timescale:</p>
               <ul className="list-disc space-y-1 pl-5">
                 <li>Works began in early 2026</li>
-                <li>Estimated completion: April 2026</li>
+                <li>
+                  Original estimated completion: April 2026; works updates are continuing as the project progresses
+                </li>
               </ul>
             </div>
             <p className="text-slate-700 dark:text-slate-300">
@@ -109,6 +124,56 @@ export default function DalryRoadImprovementsPage() {
               be retained.
             </p>
           </div>
+        </section>
+
+        <section className="rounded-3xl border border-slate-200/70 dark:border-slate-800/70 bg-white/80 dark:bg-slate-900/70 p-6 sm:p-8 shadow-sm space-y-6">
+          <div className="space-y-3">
+            <h2 className="text-2xl font-semibold text-slate-900 dark:text-slate-100">
+              Temporary Telfer Subway Closure
+            </h2>
+            <p className="text-slate-700 dark:text-slate-300">
+              Telfer Subway will be fully closed to both pedestrians and cyclists from Monday 15 June to Friday 19 June
+              2026.
+            </p>
+            <p className="text-slate-700 dark:text-slate-300">
+              The closure is required for safety and space constraints while works are carried out near the Caledonian
+              Crescent entrance, including construction of a raised table and footway.
+            </p>
+            <p className="text-slate-700 dark:text-slate-300">
+              A fully signed diversion route will be in place. Residents should allow additional time, especially when
+              walking or cycling between James Square, Dalry Road, and Haymarket.
+            </p>
+          </div>
+
+          <div className="space-y-3">
+            <h3 className="text-xl font-semibold text-slate-900 dark:text-slate-100">
+              What this means for James Square residents
+            </h3>
+            <p className="text-slate-700 dark:text-slate-300">
+              If you normally use Telfer Subway to reach Dalry Road, Haymarket, or nearby bus and tram stops, plan ahead
+              and follow the signed diversion during the closure period. The route may take longer on foot or by bike,
+              so leave extra time for journeys and take care around temporary traffic management in the area.
+            </p>
+          </div>
+
+          <details className="group rounded-2xl border border-slate-200/70 dark:border-slate-800/70 bg-slate-50/80 dark:bg-slate-950/40 p-4 sm:p-5">
+            <summary className="cursor-pointer text-base font-semibold text-blue-600 hover:text-blue-700 dark:text-blue-400 dark:hover:text-blue-300">
+              View diversion map
+            </summary>
+            <div className="mt-4 space-y-4">
+              <iframe
+                src="/docs/survey/Caledonian Crescent Footpath Closure.pdf"
+                title="Caledonian Crescent footpath closure diversion map"
+                className="w-full min-h-[500px] rounded-2xl border border-slate-200/70 dark:border-slate-800/70"
+              />
+              <a
+                href="/docs/survey/Caledonian Crescent Footpath Closure.pdf"
+                className="inline-flex text-sm font-semibold text-blue-600 hover:text-blue-700 dark:text-blue-400 dark:hover:text-blue-300"
+              >
+                Open diversion map PDF
+              </a>
+            </div>
+          </details>
         </section>
 
         <section className="rounded-3xl border border-slate-200/70 dark:border-slate-800/70 bg-white/80 dark:bg-slate-900/70 p-6 sm:p-8 shadow-sm space-y-3">


### PR DESCRIPTION
### Motivation
- Clarify ongoing works around Dalry Road / Caledonian Crescent and provide timely resident guidance about a planned temporary Telfer Subway closure in June 2026.
- Give residents a clear diversion map and actionable guidance while keeping the existing project content intact.

### Description
- Insert a rounded “Current Status” notice near the top of `src/app/local/projects/dalry-road-improvements/page.tsx` that explains works are continuing around Dalry Road and Caledonian Crescent and that a temporary Telfer Subway closure is planned for Monday 15 June to Friday 19 June 2026.
- Update the `Timescale` list item to read: `Original estimated completion: April 2026; works updates are continuing as the project progresses`.
- Add a new `Temporary Telfer Subway Closure` section that states the subway will be fully closed to pedestrians and cyclists from Monday 15 June to Friday 19 June 2026, explains the closure is required for safety/space constraints and the construction of a raised table and footway, and notes a fully signed diversion will be in place with advice to allow extra time between James Square, Dalry Road, and Haymarket.
- Add a resident-focused subsection `What this means for James Square residents` and a mobile-friendly expandable panel using native `<details>` / `<summary>` that embeds `/docs/survey/Caledonian Crescent Footpath Closure.pdf` with an iframe (classes `w-full min-h-[500px] rounded-2xl border`) and includes a fallback link `Open diversion map PDF`.
- Preserve the existing affected streets list, scope of works, and the continuous footways section unchanged except for the timescale wording.

### Testing
- Verified the PDF exists at `public/docs/survey/Caledonian Crescent Footpath Closure.pdf` (exists).
- Ran `npm run lint` which completed with existing unrelated warnings and no new errors.
- Attempted `npm run build` which failed due to environment blocking Google Fonts fetches for `Geist` / `Geist Mono` (font fetch errors during build).
- Attempted to capture a screenshot via Playwright which failed because the Playwright browser binary could not be installed in the environment (`403 Domain forbidden` during browser download).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a206cf3b658832498b7cd5fd6e8849d)