### PR TITLE
Group AGM 2026 content into a CurrentAgm2026Section

### DIFF
--- a/src/app/owners/secure/page.tsx
+++ b/src/app/owners/secure/page.tsx
@@ -153,15 +153,7 @@ const OwnersSecurePage = () => {
 
         <div className="space-y-6">
           <motion.div variants={itemVariants}>
-            <Agm2026InformationSection />
-          </motion.div>
-
-          <motion.div variants={itemVariants}>
-            <FiorQuestionnaireCallout />
-          </motion.div>
-
-          <motion.div variants={itemVariants}>
-            <FiorPaymentsFundsUpdateSection />
+            <CurrentAgm2026Section />
           </motion.div>
 
           <motion.div variants={itemVariants}>
@@ -194,6 +186,34 @@ const OwnersSecurePage = () => {
 };
 
 export default OwnersSecurePage;
+
+function CurrentAgm2026Section() {
+  return (
+    <section
+      aria-labelledby="current-agm-2026-heading"
+      className="rounded-3xl border border-cyan-400/30 bg-cyan-500/5 p-4 shadow-sm backdrop-blur sm:p-5 md:p-6 dark:border-cyan-300/20 dark:bg-cyan-300/5"
+    >
+      <header className="mb-5 space-y-2">
+        <p className="text-xs font-semibold uppercase tracking-[0.2em] text-cyan-700 dark:text-cyan-300">
+          Current owners business
+        </p>
+        <h2 id="current-agm-2026-heading" className="text-2xl font-semibold text-slate-900 dark:text-slate-100">
+          AGM 2026
+        </h2>
+        <p className="max-w-3xl text-sm md:text-base text-slate-700 dark:text-slate-200">
+          Current AGM-related information, Fior owner questionnaire details, and funds/payment updates are grouped here
+          for easier review before the older and general owner updates below.
+        </p>
+      </header>
+
+      <div className="space-y-5">
+        <Agm2026InformationSection />
+        <FiorQuestionnaireCallout />
+        <FiorPaymentsFundsUpdateSection />
+      </div>
+    </section>
+  );
+}
 
 function Agm2026InformationSection() {
   const agmHeld = new Date() >= AGM_DATE_THRESHOLD;


### PR DESCRIPTION
### Motivation
- Improve the Owners secure page structure by grouping all current AGM‑2026 related content into a single, discoverable block for easier review. 
- Preserve all existing AGM, Fior, correspondence, statistics, and document content while clarifying the hierarchy and ordering of current vs older updates.

### Description
- Replaced the three separate top-level entries for the AGM information, Fior questionnaire callout, and Fior payments/funds update with a single `CurrentAgm2026Section` rendered in `src/app/owners/secure/page.tsx`.
- Added the `CurrentAgm2026Section` component which wraps `Agm2026InformationSection`, `FiorQuestionnaireCallout`, and `FiorPaymentsFundsUpdateSection` and provides a titled container (`AGM 2026`) and explanatory copy.
- Adjusted the ordering so the grouped AGM 2026 block appears before older/general updates and left all original sections and content intact.

### Testing
- Ran `npm run lint`, which completed successfully but emitted a small number of lint warnings unrelated to the change. 
- Verified `npx -y playwright --version` succeeded in the environment. 
- Attempted to capture a page screenshot with Playwright (`npx -y playwright screenshot ...`) and to install Playwright browsers (`npx -y playwright install chromium`), but the browser download step failed due to the Playwright CDN returning `403 Domain forbidden`, so end-to-end visual verification was blocked.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a209dad72f88324bfec1fbff87ce628)