### PR TITLE
Simplify AGM page document layout

### DIFF
--- a/src/app/agm/page.tsx
+++ b/src/app/agm/page.tsx
@@ -1,47 +1,66 @@
-'use client';
+"use client";
 
-import { useMemo, useState, type ReactNode } from 'react';
-import { CalendarDays, ChevronDown, Clock3, Copy, ExternalLink, FileText, Mail } from 'lucide-react';
+import { useMemo, useState, type ReactNode } from "react";
+import {
+  CalendarDays,
+  ChevronDown,
+  Clock3,
+  Copy,
+  ExternalLink,
+  FileText,
+  Mail,
+} from "lucide-react";
 
-import AGMComments from '@/components/AGMComments';
+import AGMComments from "@/components/AGMComments";
 
 const meetingLink =
-  'https://teams.live.com/meet/9324822330074?p=1OEuybKPe9fZKrF27P';
-const AGM_AGENDA_PATH = '/docs/survey/James Square-  AGM  Agenda - 2026.06.04.pdf';
-const AGM_FACTORS_REPORT_PATH = '/docs/survey/James Square-  AGM  - Factors Report - 2026.06.04.pdf';
+  "https://teams.live.com/meet/9324822330074?p=1OEuybKPe9fZKrF27P";
+const AGM_AGENDA_PATH =
+  "/docs/survey/James Square-  AGM  Agenda - 2026.06.04.pdf";
+const AGM_FACTORS_REPORT_PATH =
+  "/docs/survey/James Square-  AGM  - Factors Report - 2026.06.04.pdf";
 const AGM_AGENDA_HREF = encodeURI(AGM_AGENDA_PATH);
 const AGM_FACTORS_REPORT_HREF = encodeURI(AGM_FACTORS_REPORT_PATH);
-const AGM_DATE_THRESHOLD = new Date('2026-06-05T00:00:00');
+const AGM_DATE_THRESHOLD = new Date("2026-06-05T00:00:00");
 const documentLinks = [
-  { label: 'AGM Agenda', href: AGM_AGENDA_HREF },
-  { label: 'Factors Report', href: AGM_FACTORS_REPORT_HREF },
+  {
+    label: "AGM Agenda",
+    description: "Formal meeting agenda and discussion items.",
+    href: AGM_AGENDA_HREF,
+  },
+  {
+    label: "Factors Report",
+    description:
+      "Myreside Management update on finances, repairs and current priorities.",
+    href: AGM_FACTORS_REPORT_HREF,
+  },
 ];
 const agendaSummaryItems = [
-  'Previous factor update',
-  'Development finances',
-  'Sinking fund balance',
-  'Outstanding debts',
-  'Committee members and block representatives',
-  'Swimming pool repairs and refurbishment',
-  'Building condition report',
-  'Building repair fund restart',
-  'Tree pruning',
-  'Caretaker salary',
-  'Council tax banding',
+  "Previous factor update",
+  "Development finances",
+  "Sinking fund balance",
+  "Outstanding debts",
+  "Committee members and block representatives",
+  "Swimming pool repairs and refurbishment",
+  "Building condition report",
+  "Building repair fund restart",
+  "Tree pruning",
+  "Caretaker salary",
+  "Council tax banding",
 ];
 const factorsReportHighlights = [
-  'Myreside Management taking over management on 1 February 2026',
-  'Building insurance and claims process',
-  'Myreside owner portal',
-  'Electricity account transition and meter readings',
-  'Roof, gutter and downpipe works',
-  'Proposed updated external building condition survey',
-  'Pool closure, safety review and repair options',
-  'Confirmation that RAAC was not found in the pool structure',
-  'Communal repairs, cleaning and grounds maintenance',
-  'Fire safety inspections',
-  'Development debt position',
-  'Sinking fund position, including Trinity transferring £25,661.81 on 7 May 2026',
+  "Myreside Management taking over management on 1 February 2026",
+  "Building insurance and claims process",
+  "Myreside owner portal",
+  "Electricity account transition and meter readings",
+  "Roof, gutter and downpipe works",
+  "Proposed updated external building condition survey",
+  "Pool closure, safety review and repair options",
+  "Confirmation that RAAC was not found in the pool structure",
+  "Communal repairs, cleaning and grounds maintenance",
+  "Fire safety inspections",
+  "Development debt position",
+  "Sinking fund position, including Trinity transferring £25,661.81 on 7 May 2026",
 ];
 
 const emailBody = `I would like to acknowledge receipt of the information about the AGM in June 2026.
@@ -57,7 +76,7 @@ Contact Number:
 Property / Flat:`;
 
 function encodeMailBody(body: string) {
-  return encodeURIComponent(body).replace(/%0A/g, '%0D%0A');
+  return encodeURIComponent(body).replace(/%0A/g, "%0D%0A");
 }
 
 export default function AGMPage() {
@@ -65,8 +84,10 @@ export default function AGMPage() {
   const agmHeld = new Date() >= AGM_DATE_THRESHOLD;
 
   const agendaMailtoHref = useMemo(() => {
-    const cc = encodeURIComponent('committee@james-square.com');
-    const subject = encodeURIComponent('James Square AGM 2026 – Agenda Request');
+    const cc = encodeURIComponent("committee@james-square.com");
+    const subject = encodeURIComponent(
+      "James Square AGM 2026 – Agenda Request",
+    );
     const body = encodeMailBody(emailBody);
 
     return `mailto:ania@myreside-management.co.uk?cc=${cc}&subject=${subject}&body=${body}`;
@@ -78,7 +99,7 @@ export default function AGMPage() {
       setCopied(true);
       window.setTimeout(() => setCopied(false), 2200);
     } catch (error) {
-      console.error('Copy meeting link failed', error);
+      console.error("Copy meeting link failed", error);
     }
   };
 
@@ -90,44 +111,33 @@ export default function AGMPage() {
             James Square AGM 2026
           </h1>
           <span className="rounded-full border border-cyan-300/50 bg-cyan-50 px-2.5 py-1 text-xs font-semibold text-cyan-700 dark:border-cyan-500/30 dark:bg-cyan-950/30 dark:text-cyan-200">
-            Documents available
+            {agmHeld ? "Meeting held" : "Upcoming meeting"}
           </span>
         </div>
         <div className="mt-4 max-w-3xl space-y-3 text-sm leading-relaxed text-slate-700 sm:text-base dark:text-slate-200">
           {agmHeld ? (
             <>
-              <p>The James Square Annual General Meeting was held on Thursday 4 June 2026.</p>
               <p>
-                This page provides access to the agenda and factors report circulated ahead of the meeting. A further
-                update, including the official minutes, will be added once available.
+                The James Square Annual General Meeting was held on Thursday 4
+                June 2026 at 7:00pm via Microsoft Teams.
+              </p>
+              <p>
+                Use this page to review the meeting documents and check for
+                updates. Official minutes will be added once available.
               </p>
             </>
           ) : (
             <>
               <p>
-                The James Square Annual General Meeting will take place on Thursday 4 June 2026 at 7:00pm via Microsoft
-                Teams.
+                The James Square Annual General Meeting will take place on
+                Thursday 4 June 2026 at 7:00pm via Microsoft Teams.
               </p>
               <p>
-                This page provides quick access to the meeting documents, agenda summary and factors report highlights.
+                Review the documents, join details and discussion topics from
+                one place without duplicate document links.
               </p>
             </>
           )}
-        </div>
-
-        <div className="mt-5 grid gap-3 sm:grid-cols-2">
-          {documentLinks.map((doc) => (
-            <a
-              key={doc.href}
-              href={doc.href}
-              target="_blank"
-              rel="noopener noreferrer"
-              className="inline-flex min-h-12 items-center justify-center gap-2 rounded-xl bg-slate-900 px-4 py-3 text-sm font-semibold text-white shadow-sm transition hover:bg-slate-800 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-cyan-500/50 dark:bg-white dark:text-slate-900 dark:hover:bg-slate-100"
-            >
-              <FileText className="h-4 w-4" aria-hidden="true" />
-              {doc.label}
-            </a>
-          ))}
         </div>
         <a
           href="https://www.james-square.com/agm"
@@ -140,99 +150,121 @@ export default function AGMPage() {
         </a>
       </section>
 
-      <section className="mt-6 rounded-2xl border border-slate-200 bg-white/90 px-4 py-5 shadow-sm sm:px-6 sm:py-6 dark:border-slate-800 dark:bg-slate-900/80">
-        <h2 className="text-2xl font-semibold text-slate-900 dark:text-white">
-          {agmHeld ? 'AGM Held – 4 June 2026' : 'Upcoming AGM – 4 June 2026'}
-        </h2>
-        <div className="mt-4 grid gap-3 sm:grid-cols-2">
-          <div className="rounded-xl border border-slate-200 bg-slate-50 p-4 dark:border-slate-700 dark:bg-slate-800/70">
-            <div className="flex items-center gap-2 text-sm font-semibold text-slate-800 dark:text-slate-100">
-              <CalendarDays className="h-4 w-4 text-cyan-300" />
-              Date
-            </div>
-            <p className="mt-2 text-sm text-slate-700 dark:text-slate-200">Thursday 4 June 2026</p>
-          </div>
-          <div className="rounded-xl border border-slate-200 bg-slate-50 p-4 dark:border-slate-700 dark:bg-slate-800/70">
-            <div className="flex items-center gap-2 text-sm font-semibold text-slate-800 dark:text-slate-100">
-              <Clock3 className="h-4 w-4 text-cyan-300" />
-              Time
-            </div>
-            <p className="mt-2 text-sm text-slate-700 dark:text-slate-200">7:00pm via Microsoft Teams</p>
-          </div>
-        </div>
-
-        <div className="mt-4 space-y-3 text-sm leading-relaxed text-slate-700 sm:text-base dark:text-slate-200">
-          {agmHeld ? (
-            <>
-              <p>The James Square Annual General Meeting was held on Thursday 4 June 2026.</p>
-              <p>
-                Owners can review the AGM page, agenda and factors report using the links below. A further update
-                summarising the discussions, decisions and any agreed actions will be published once the official
-                minutes have been prepared and circulated.
+      <section className="mt-6 grid gap-4 lg:grid-cols-[minmax(0,1.15fr)_minmax(280px,0.85fr)]">
+        <div className="rounded-2xl border border-slate-200 bg-white/90 px-4 py-5 shadow-sm sm:px-6 sm:py-6 dark:border-slate-800 dark:bg-slate-900/80">
+          <h2 className="text-2xl font-semibold text-slate-900 dark:text-white">
+            Meeting details
+          </h2>
+          <div className="mt-4 grid gap-3 sm:grid-cols-2">
+            <div className="rounded-xl border border-slate-200 bg-slate-50 p-4 dark:border-slate-700 dark:bg-slate-800/70">
+              <div className="flex items-center gap-2 text-sm font-semibold text-slate-800 dark:text-slate-100">
+                <CalendarDays className="h-4 w-4 text-cyan-300" />
+                Date
+              </div>
+              <p className="mt-2 text-sm text-slate-700 dark:text-slate-200">
+                Thursday 4 June 2026
               </p>
-            </>
-          ) : (
-            <>
-              <p>
-                Owners are encouraged to attend where possible. The AGM will include updates on the management of the
-                development, finances, sinking fund, pool repairs, building condition report, committee appointments,
-                and priorities for the year ahead.
+            </div>
+            <div className="rounded-xl border border-slate-200 bg-slate-50 p-4 dark:border-slate-700 dark:bg-slate-800/70">
+              <div className="flex items-center gap-2 text-sm font-semibold text-slate-800 dark:text-slate-100">
+                <Clock3 className="h-4 w-4 text-cyan-300" />
+                Time and format
+              </div>
+              <p className="mt-2 text-sm text-slate-700 dark:text-slate-200">
+                7:00pm via Microsoft Teams
               </p>
-              <p>The AGM page, agenda and factors report are available using the links below.</p>
-            </>
-          )}
-        </div>
+            </div>
+          </div>
 
-        <div className="mt-4 rounded-xl border border-cyan-300/50 bg-cyan-50 p-4 dark:bg-cyan-950/20">
-          <p className="text-xs uppercase tracking-wide text-cyan-700 dark:text-cyan-200">Meeting link</p>
-          <a
-            href={meetingLink}
-            target="_blank"
-            rel="noopener noreferrer"
-            className="mt-2 inline-flex w-full items-center justify-center gap-2 rounded-lg bg-cyan-500 px-4 py-2 text-sm font-semibold text-slate-900 shadow sm:w-auto"
-          >
-            Join AGM on Teams
-            <ExternalLink className="h-4 w-4" />
-          </a>
-          <p className="mt-3 break-all text-xs text-slate-700 dark:text-slate-200">{meetingLink}</p>
-          <button
-            type="button"
-            onClick={copyMeetingLink}
-            className="mt-3 inline-flex w-full items-center justify-center gap-2 rounded-lg border border-slate-300 bg-white px-3 py-1.5 text-xs font-semibold text-slate-700 hover:bg-slate-100 sm:w-auto dark:border-slate-600 dark:bg-slate-800 dark:text-slate-100 dark:hover:bg-slate-700"
-          >
-            <Copy className="h-3.5 w-3.5" />
-            {copied ? 'Meeting link copied' : 'Copy meeting link'}
-          </button>
-        </div>
-      </section>
+          <div className="mt-4 space-y-3 text-sm leading-relaxed text-slate-700 sm:text-base dark:text-slate-200">
+            {agmHeld ? (
+              <p>
+                A further update summarising the discussions, decisions and any
+                agreed actions will be published once the official minutes have
+                been prepared and circulated.
+              </p>
+            ) : (
+              <p>
+                The meeting will cover development management, finances, sinking
+                fund, pool repairs, building condition reporting, committee
+                appointments and priorities for the year ahead.
+              </p>
+            )}
+          </div>
 
-      <section className="mt-6 rounded-2xl border border-slate-200 bg-white/90 px-4 py-5 shadow-sm sm:px-6 sm:py-6 dark:border-slate-800 dark:bg-slate-900/80">
-        <h2 className="text-2xl font-semibold text-slate-900 dark:text-white">Documents</h2>
-        <p className="mt-2 text-sm text-slate-700 dark:text-slate-200">
-          Download or open the AGM agenda and factors report in a new tab.
-        </p>
-        <div className="mt-4 grid gap-3 sm:grid-cols-2">
-          {documentLinks.map((doc) => (
+          <div className="mt-4 rounded-xl border border-cyan-300/50 bg-cyan-50 p-4 dark:bg-cyan-950/20">
+            <p className="text-xs uppercase tracking-wide text-cyan-700 dark:text-cyan-200">
+              Microsoft Teams meeting link
+            </p>
             <a
-              key={`card-${doc.href}`}
-              href={doc.href}
+              href={meetingLink}
               target="_blank"
               rel="noopener noreferrer"
-              className="flex min-h-20 items-center justify-between gap-3 rounded-xl border border-slate-200 bg-slate-50 px-4 py-3 text-sm font-semibold text-slate-900 transition hover:bg-white hover:shadow-sm dark:border-slate-700 dark:bg-slate-800/70 dark:text-white dark:hover:bg-slate-800"
+              className="mt-2 inline-flex w-full items-center justify-center gap-2 rounded-lg bg-cyan-500 px-4 py-2 text-sm font-semibold text-slate-900 shadow sm:w-auto"
             >
-              <span className="inline-flex items-center gap-2">
-                <FileText className="h-4 w-4 text-cyan-500" aria-hidden="true" />
-                {doc.label}
-              </span>
-              <ExternalLink className="h-4 w-4 text-slate-400" aria-hidden="true" />
+              Join AGM on Teams
+              <ExternalLink className="h-4 w-4" />
             </a>
-          ))}
+            <p className="mt-3 break-all text-xs text-slate-700 dark:text-slate-200">
+              {meetingLink}
+            </p>
+            <button
+              type="button"
+              onClick={copyMeetingLink}
+              className="mt-3 inline-flex w-full items-center justify-center gap-2 rounded-lg border border-slate-300 bg-white px-3 py-1.5 text-xs font-semibold text-slate-700 hover:bg-slate-100 sm:w-auto dark:border-slate-600 dark:bg-slate-800 dark:text-slate-100 dark:hover:bg-slate-700"
+            >
+              <Copy className="h-3.5 w-3.5" />
+              {copied ? "Meeting link copied" : "Copy meeting link"}
+            </button>
+          </div>
+        </div>
+
+        <div className="rounded-2xl border border-slate-200 bg-white/90 px-4 py-5 shadow-sm sm:px-6 sm:py-6 dark:border-slate-800 dark:bg-slate-900/80">
+          <h2 className="text-2xl font-semibold text-slate-900 dark:text-white">
+            Documents
+          </h2>
+          <p className="mt-2 text-sm text-slate-700 dark:text-slate-200">
+            Open the two AGM documents below. These links are shown once here to
+            keep the page uncluttered.
+          </p>
+          <div className="mt-4 space-y-3">
+            {documentLinks.map((doc) => (
+              <a
+                key={doc.href}
+                href={doc.href}
+                target="_blank"
+                rel="noopener noreferrer"
+                className="flex items-start justify-between gap-3 rounded-xl border border-slate-200 bg-slate-50 px-4 py-3 text-sm text-slate-900 transition hover:bg-white hover:shadow-sm dark:border-slate-700 dark:bg-slate-800/70 dark:text-white dark:hover:bg-slate-800"
+              >
+                <span className="flex gap-3">
+                  <FileText
+                    className="mt-0.5 h-4 w-4 shrink-0 text-cyan-500"
+                    aria-hidden="true"
+                  />
+                  <span>
+                    <span className="block font-semibold">{doc.label}</span>
+                    <span className="mt-1 block text-xs font-normal leading-relaxed text-slate-600 dark:text-slate-300">
+                      {doc.description}
+                    </span>
+                  </span>
+                </span>
+                <ExternalLink
+                  className="mt-0.5 h-4 w-4 shrink-0 text-slate-400"
+                  aria-hidden="true"
+                />
+              </a>
+            ))}
+          </div>
         </div>
       </section>
 
       <section className="mt-6 space-y-3">
         <AgmAccordion title="Agenda Summary">
-          <p>{agmHeld ? 'Key items listed for discussion included:' : 'Key items due to be discussed include:'}</p>
+          <p>
+            {agmHeld
+              ? "Key items listed for discussion included:"
+              : "Key items due to be discussed include:"}
+          </p>
           <ul className="list-disc ms-5 space-y-1">
             {agendaSummaryItems.map((item) => (
               <li key={item}>{item}</li>
@@ -241,29 +273,16 @@ export default function AGMPage() {
         </AgmAccordion>
 
         <AgmAccordion title="Factors Report Highlights">
-          <p>{agmHeld ? 'The factors report included updates on:' : 'The factors report includes updates on:'}</p>
+          <p>
+            {agmHeld
+              ? "The factors report included updates on:"
+              : "The factors report includes updates on:"}
+          </p>
           <ul className="list-disc ms-5 space-y-1">
             {factorsReportHighlights.map((item) => (
               <li key={item}>{item}</li>
             ))}
           </ul>
-        </AgmAccordion>
-
-        <AgmAccordion title="Documents">
-          <div className="grid gap-3 sm:grid-cols-2">
-            {documentLinks.map((doc) => (
-              <a
-                key={`accordion-${doc.href}`}
-                href={doc.href}
-                target="_blank"
-                rel="noopener noreferrer"
-                className="inline-flex items-center justify-center gap-2 rounded-xl border border-slate-200 bg-slate-50 px-4 py-3 text-sm font-semibold text-slate-900 transition hover:bg-white dark:border-slate-700 dark:bg-slate-800/70 dark:text-white dark:hover:bg-slate-800"
-              >
-                <FileText className="h-4 w-4" aria-hidden="true" />
-                {doc.label}
-              </a>
-            ))}
-          </div>
         </AgmAccordion>
       </section>
 
@@ -272,9 +291,12 @@ export default function AGMPage() {
       </section>
 
       <section className="mt-6 rounded-2xl border border-slate-200 bg-white/90 px-4 py-5 shadow-sm sm:px-6 sm:py-6 dark:border-slate-800 dark:bg-slate-900/80">
-        <h2 className="text-2xl font-semibold text-slate-900 dark:text-white">Submit an agenda item</h2>
+        <h2 className="text-2xl font-semibold text-slate-900 dark:text-white">
+          Submit an agenda item
+        </h2>
         <p className="mt-2 text-sm leading-relaxed text-slate-700 dark:text-slate-200">
-          Owners are encouraged to submit any topics, questions, or concerns in advance of the AGM.
+          Owners are encouraged to submit any topics, questions, or concerns in
+          advance of the AGM.
         </p>
 
         <a
@@ -285,7 +307,8 @@ export default function AGMPage() {
           Email your agenda request
         </a>
         <p className="mt-2 text-xs text-slate-500 dark:text-slate-300">
-          This opens your default mail app with the recipient, CC, subject, and message pre-filled.
+          This opens your default mail app with the recipient, CC, subject, and
+          message pre-filled.
         </p>
       </section>
 
@@ -296,12 +319,21 @@ export default function AGMPage() {
   );
 }
 
-function AgmAccordion({ title, children }: { title: string; children: ReactNode }) {
+function AgmAccordion({
+  title,
+  children,
+}: {
+  title: string;
+  children: ReactNode;
+}) {
   return (
     <details className="group rounded-2xl border border-slate-200 bg-white/90 shadow-sm dark:border-slate-800 dark:bg-slate-900/80">
       <summary className="flex cursor-pointer list-none items-center justify-between gap-3 px-4 py-4 text-left text-base font-semibold text-slate-900 marker:hidden sm:px-6 dark:text-white">
         <span>{title}</span>
-        <ChevronDown className="h-4 w-4 shrink-0 text-slate-400 transition group-open:rotate-180" aria-hidden="true" />
+        <ChevronDown
+          className="h-4 w-4 shrink-0 text-slate-400 transition group-open:rotate-180"
+          aria-hidden="true"
+        />
       </summary>
       <div className="space-y-3 border-t border-slate-200 px-4 py-4 text-sm leading-relaxed text-slate-700 sm:px-6 sm:text-base dark:border-slate-800 dark:text-slate-200">
         {children}


### PR DESCRIPTION
### Motivation
- Reduce repeated document links and declutter the AGM page so owners can find meeting details, documents and discussion items in one place.
- Make the meeting status, date/time and Teams joining link clearer while preserving the official Teams meeting URL and copy behavior.
- Improve readability by grouping related information (meeting details, documents, summaries) into a compact layout.

### Description
- Reworked `src/app/agm/page.tsx` to replace multiple duplicated document buttons with a single dedicated `Documents` card that shows each file once with a short description and a single target link to open the PDFs.
- Moved the hero copy and the meeting metadata into a clearer two-column `Meeting details` section and updated copy to avoid repetition while keeping the Microsoft Teams link unchanged (`meetingLink` and the copy-to-clipboard button remain functional).
- Removed the redundant `Documents` accordion from the expandable list, keeping only the `Agenda Summary` and `Factors Report Highlights` accordions.
- Minor formatting and string normalisations for readability (consistent quoting/spacing) in the same file.

### Testing
- Ran code formatting with `npx prettier --write src/app/agm/page.tsx` successfully.
- Ran linting via `npm run lint`, which completed (existing unrelated warnings remain in other files).
- Attempted production build with `npm run build`, which failed in this environment due to Google Fonts fetch errors and is not related to these layout changes.
- Verified the dev server responded for the page with `curl -I http://localhost:3000/agm` (HTTP 200 observed) after starting the dev server.
- Tried `npx playwright install chromium` to capture a screenshot, but browser download was blocked by the environment (`403 Domain forbidden`), so no headless screenshot was produced.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a20a389a5f88324ae9572a10357cc76)