### PR TITLE
Hide join/agenda actions after AGM and show post-meeting messaging

### DIFF
--- a/src/app/agm/page.tsx
+++ b/src/app/agm/page.tsx
@@ -191,31 +191,43 @@ export default function AGMPage() {
             )}
           </div>
 
-          <div className="mt-4 rounded-xl border border-cyan-300/50 bg-cyan-50 p-4 dark:bg-cyan-950/20">
-            <p className="text-xs uppercase tracking-wide text-cyan-700 dark:text-cyan-200">
-              Microsoft Teams meeting link
-            </p>
-            <a
-              href={meetingLink}
-              target="_blank"
-              rel="noopener noreferrer"
-              className="mt-2 inline-flex w-full items-center justify-center gap-2 rounded-lg bg-cyan-500 px-4 py-2 text-sm font-semibold text-slate-900 shadow sm:w-auto"
-            >
-              Join AGM on Teams
-              <ExternalLink className="h-4 w-4" />
-            </a>
-            <p className="mt-3 break-all text-xs text-slate-700 dark:text-slate-200">
-              {meetingLink}
-            </p>
-            <button
-              type="button"
-              onClick={copyMeetingLink}
-              className="mt-3 inline-flex w-full items-center justify-center gap-2 rounded-lg border border-slate-300 bg-white px-3 py-1.5 text-xs font-semibold text-slate-700 hover:bg-slate-100 sm:w-auto dark:border-slate-600 dark:bg-slate-800 dark:text-slate-100 dark:hover:bg-slate-700"
-            >
-              <Copy className="h-3.5 w-3.5" />
-              {copied ? "Meeting link copied" : "Copy meeting link"}
-            </button>
-          </div>
+          {agmHeld ? (
+            <div className="mt-4 rounded-xl border border-cyan-300/50 bg-cyan-50 p-4 dark:bg-cyan-950/20">
+              <p className="text-xs uppercase tracking-wide text-cyan-700 dark:text-cyan-200">
+                AGM update
+              </p>
+              <p className="mt-2 text-sm leading-relaxed text-slate-700 dark:text-slate-200">
+                The AGM has now taken place. The full minutes will be made
+                available and shared with owners soon.
+              </p>
+            </div>
+          ) : (
+            <div className="mt-4 rounded-xl border border-cyan-300/50 bg-cyan-50 p-4 dark:bg-cyan-950/20">
+              <p className="text-xs uppercase tracking-wide text-cyan-700 dark:text-cyan-200">
+                Microsoft Teams meeting link
+              </p>
+              <a
+                href={meetingLink}
+                target="_blank"
+                rel="noopener noreferrer"
+                className="mt-2 inline-flex w-full items-center justify-center gap-2 rounded-lg bg-cyan-500 px-4 py-2 text-sm font-semibold text-slate-900 shadow sm:w-auto"
+              >
+                Join AGM on Teams
+                <ExternalLink className="h-4 w-4" />
+              </a>
+              <p className="mt-3 break-all text-xs text-slate-700 dark:text-slate-200">
+                {meetingLink}
+              </p>
+              <button
+                type="button"
+                onClick={copyMeetingLink}
+                className="mt-3 inline-flex w-full items-center justify-center gap-2 rounded-lg border border-slate-300 bg-white px-3 py-1.5 text-xs font-semibold text-slate-700 hover:bg-slate-100 sm:w-auto dark:border-slate-600 dark:bg-slate-800 dark:text-slate-100 dark:hover:bg-slate-700"
+              >
+                <Copy className="h-3.5 w-3.5" />
+                {copied ? "Meeting link copied" : "Copy meeting link"}
+              </button>
+            </div>
+          )}
         </div>
 
         <div className="rounded-2xl border border-slate-200 bg-white/90 px-4 py-5 shadow-sm sm:px-6 sm:py-6 dark:border-slate-800 dark:bg-slate-900/80">
@@ -288,31 +300,46 @@ export default function AGMPage() {
         Meeting minutes will be published once available.
       </section>
 
-      <section className="mt-6 rounded-2xl border border-slate-200 bg-white/90 px-4 py-5 shadow-sm sm:px-6 sm:py-6 dark:border-slate-800 dark:bg-slate-900/80">
-        <h2 className="text-2xl font-semibold text-slate-900 dark:text-white">
-          Submit an agenda item
-        </h2>
-        <p className="mt-2 text-sm leading-relaxed text-slate-700 dark:text-slate-200">
-          Owners may submit topics, questions or concerns for consideration before
-          the AGM.
-        </p>
+      {agmHeld ? (
+        <section className="mt-6 rounded-2xl border border-slate-200 bg-white/90 px-4 py-5 shadow-sm sm:px-6 sm:py-6 dark:border-slate-800 dark:bg-slate-900/80">
+          <h2 className="text-2xl font-semibold text-slate-900 dark:text-white">
+            Future consultation
+          </h2>
+          <p className="mt-2 text-sm leading-relaxed text-slate-700 dark:text-slate-200">
+            Owners will be consulted on pool facilities, the updated building
+            survey, repair funds and significant projects once further
+            information is available.
+          </p>
+        </section>
+      ) : (
+        <>
+          <section className="mt-6 rounded-2xl border border-slate-200 bg-white/90 px-4 py-5 shadow-sm sm:px-6 sm:py-6 dark:border-slate-800 dark:bg-slate-900/80">
+            <h2 className="text-2xl font-semibold text-slate-900 dark:text-white">
+              Submit an agenda item
+            </h2>
+            <p className="mt-2 text-sm leading-relaxed text-slate-700 dark:text-slate-200">
+              Owners may submit topics, questions or concerns for consideration
+              before the AGM.
+            </p>
 
-        <a
-          href={agendaMailtoHref}
-          className="mt-4 inline-flex w-full items-center justify-center gap-2 rounded-xl bg-slate-900 px-5 py-3 text-sm font-semibold text-white shadow hover:bg-slate-800 sm:w-auto dark:bg-white dark:text-slate-900 dark:hover:bg-slate-100"
-        >
-          <Mail className="h-4 w-4" />
-          Email your agenda request
-        </a>
-        <p className="mt-2 text-xs text-slate-500 dark:text-slate-300">
-          This opens your default mail app with the recipient, CC, subject, and
-          message pre-filled.
-        </p>
-      </section>
+            <a
+              href={agendaMailtoHref}
+              className="mt-4 inline-flex w-full items-center justify-center gap-2 rounded-xl bg-slate-900 px-5 py-3 text-sm font-semibold text-white shadow hover:bg-slate-800 sm:w-auto dark:bg-white dark:text-slate-900 dark:hover:bg-slate-100"
+            >
+              <Mail className="h-4 w-4" />
+              Email your agenda request
+            </a>
+            <p className="mt-2 text-xs text-slate-500 dark:text-slate-300">
+              This opens your default mail app with the recipient, CC, subject,
+              and message pre-filled.
+            </p>
+          </section>
 
-      <div className="mt-6">
-        <AGMComments />
-      </div>
+          <div className="mt-6">
+            <AGMComments />
+          </div>
+        </>
+      )}
     </main>
   );
 }


### PR DESCRIPTION
### Motivation
- Ensure the UI reflects that the AGM has taken place by hiding join/copy controls and pre-meeting actions once `agmHeld` is true. 
- Replace the meeting join panel with a short post-AGM notice about minutes being published. 
- Replace the pre-AGM agenda submission area with a “Future consultation” message and stop showing the live `AGMComments` area after the meeting.

### Description
- Updated `src/app/agm/page.tsx` to conditionally render the Teams join/copy panel only when `!agmHeld` and show an `AGM update` message when `agmHeld` is true. 
- Replaced the pre-AGM “Submit an agenda item” section with a `Future consultation` section after the AGM by switching rendering based on `agmHeld`. 
- Moved `AGMComments` inside the pre-AGM branch so comments are not shown after the meeting. 
- Kept all existing links, copy behavior and utilities (e.g. `copyMeetingLink`, `agendaMailtoHref`) unchanged except for the conditional rendering and copy text updates.

### Testing
- Ran `npm run lint` which completed successfully but reported unrelated warnings in other files. 
- Verified page output by requesting the running dev server and checking content with `curl -s http://localhost:3000/agm | rg -o "AGM update|Microsoft Teams meeting link|Future consultation|Submit an agenda item|The AGM has now taken place|AGMComments"`, which confirmed the expected post-AGM strings are rendered. 
- Attempted to capture a Playwright screenshot, but `npx playwright install chromium` failed because the environment blocked browser downloads (403), so headless browser screenshotting could not be completed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a2481f06d58832497868c67b55f968c)