### PR TITLE
Add pool 3D model viewer page

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9,6 +9,7 @@
       "version": "0.1.0",
       "dependencies": {
         "@google/genai": "^1.34.0",
+        "@google/model-viewer": "^4.3.1",
         "@sendgrid/mail": "^8.1.5",
         "bcryptjs": "^2.4.3",
         "firebase": "^11.6.0",
@@ -3022,6 +3023,22 @@
         "url": "https://opencollective.com/node-fetch"
       }
     },
+    "node_modules/@google/model-viewer": {
+      "version": "4.3.1",
+      "resolved": "https://registry.npmjs.org/@google/model-viewer/-/model-viewer-4.3.1.tgz",
+      "integrity": "sha512-GP+inXhAtY31E8rILVmByA6z8CZZjdlNajddppyI1/j1eIaSQiZcMRaUqTFe7+jv4mzRzwKIOiKBud0apiv+WQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@monogrid/gainmap-js": "^3.1.0",
+        "lit": "^3.2.1"
+      },
+      "engines": {
+        "node": ">=6.0.0"
+      },
+      "peerDependencies": {
+        "three": "^0.183.0"
+      }
+    },
     "node_modules/@grpc/grpc-js": {
       "version": "1.9.15",
       "resolved": "https://registry.npmjs.org/@grpc/grpc-js/-/grpc-js-1.9.15.tgz",
@@ -3700,6 +3717,33 @@
       "funding": {
         "type": "opencollective",
         "url": "https://opencollective.com/js-sdsl"
+      }
+    },
+    "node_modules/@lit-labs/ssr-dom-shim": {
+      "version": "1.6.0",
+      "resolved": "https://registry.npmjs.org/@lit-labs/ssr-dom-shim/-/ssr-dom-shim-1.6.0.tgz",
+      "integrity": "sha512-VHb0ALPMTlgKjM6yIxxoQNnpKyUKLD04VzeQdsiXkMqkvYlAHxq9glGLmgbb889/1GsohSOAjvQYoiBppXFqrQ==",
+      "license": "BSD-3-Clause"
+    },
+    "node_modules/@lit/reactive-element": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/@lit/reactive-element/-/reactive-element-2.1.2.tgz",
+      "integrity": "sha512-pbCDiVMnne1lYUIaYNN5wrwQXDtHaYtg7YEFPeW+hws6U47WeFvISGUWekPGKWOP1ygrs0ef0o1VJMk1exos5A==",
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "@lit-labs/ssr-dom-shim": "^1.5.0"
+      }
+    },
+    "node_modules/@monogrid/gainmap-js": {
+      "version": "3.4.0",
+      "resolved": "https://registry.npmjs.org/@monogrid/gainmap-js/-/gainmap-js-3.4.0.tgz",
+      "integrity": "sha512-2Z0FATFHaoYJ8b+Y4y4Hgfn3FRFwuU5zRrk+9dFWp4uGAdHGqVEdP7HP+gLA3X469KXHmfupJaUbKo1b/aDKIg==",
+      "license": "MIT",
+      "dependencies": {
+        "promise-worker-transferable": "^1.0.4"
+      },
+      "peerDependencies": {
+        "three": ">= 0.159.0"
       }
     },
     "node_modules/@napi-rs/wasm-runtime": {
@@ -9597,6 +9641,12 @@
         "node": ">= 4"
       }
     },
+    "node_modules/immediate": {
+      "version": "3.0.6",
+      "resolved": "https://registry.npmjs.org/immediate/-/immediate-3.0.6.tgz",
+      "integrity": "sha512-XXOFtyqDjNDAQxVfYxuF7g9Il/IbWmmlQg2MYKOH8ExIT1qg6xc4zyS3HaEEATgs1btfzxq15ciUiY7gjSXRGQ==",
+      "license": "MIT"
+    },
     "node_modules/immer": {
       "version": "10.2.0",
       "resolved": "https://registry.npmjs.org/immer/-/immer-10.2.0.tgz",
@@ -9979,6 +10029,12 @@
       "engines": {
         "node": ">=6"
       }
+    },
+    "node_modules/is-promise": {
+      "version": "2.2.2",
+      "resolved": "https://registry.npmjs.org/is-promise/-/is-promise-2.2.2.tgz",
+      "integrity": "sha512-+lP4/6lKUBfQjZ2pdxThZvLUAafmZb8OAxFb8XXtiQmS35INgr85hdOGoEs124ez1FCnZJt6jau/T+alh58QFQ==",
+      "license": "MIT"
     },
     "node_modules/is-regex": {
       "version": "1.2.1",
@@ -10513,6 +10569,15 @@
         "node": ">= 0.8.0"
       }
     },
+    "node_modules/lie": {
+      "version": "3.3.0",
+      "resolved": "https://registry.npmjs.org/lie/-/lie-3.3.0.tgz",
+      "integrity": "sha512-UaiMJzeWRlEujzAuw5LokY1L5ecNQYZKfmyZ9L7wDHb/p5etKaxXhohBcrw0EYby+G/NA52vRSN4N39dxHAIwQ==",
+      "license": "MIT",
+      "dependencies": {
+        "immediate": "~3.0.5"
+      }
+    },
     "node_modules/lightningcss": {
       "version": "1.30.1",
       "resolved": "https://registry.npmjs.org/lightningcss/-/lightningcss-1.30.1.tgz",
@@ -10756,6 +10821,37 @@
       "version": "1.1.5",
       "resolved": "https://registry.npmjs.org/limiter/-/limiter-1.1.5.tgz",
       "integrity": "sha512-FWWMIEOxz3GwUI4Ts/IvgVy6LPvoMPgjMdQ185nN6psJyBJ4yOpzqm695/h5umdLJg2vW3GR5iG11MAkR2AzJA=="
+    },
+    "node_modules/lit": {
+      "version": "3.3.3",
+      "resolved": "https://registry.npmjs.org/lit/-/lit-3.3.3.tgz",
+      "integrity": "sha512-fycuvZg/hkpozL00lm1pEJH5nN/lr9ZXd6mJI2HSN4+Bzc+LDNdEApJ6HFbPkdFNHLvOplIIuJvxkS4XUxqirw==",
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "@lit/reactive-element": "^2.1.0",
+        "lit-element": "^4.2.0",
+        "lit-html": "^3.3.0"
+      }
+    },
+    "node_modules/lit-element": {
+      "version": "4.2.2",
+      "resolved": "https://registry.npmjs.org/lit-element/-/lit-element-4.2.2.tgz",
+      "integrity": "sha512-aFKhNToWxoyhkNDmWZwEva2SlQia+jfG0fjIWV//YeTaWrVnOxD89dPKfigCUspXFmjzOEUQpOkejH5Ly6sG0w==",
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "@lit-labs/ssr-dom-shim": "^1.5.0",
+        "@lit/reactive-element": "^2.1.0",
+        "lit-html": "^3.3.0"
+      }
+    },
+    "node_modules/lit-html": {
+      "version": "3.3.3",
+      "resolved": "https://registry.npmjs.org/lit-html/-/lit-html-3.3.3.tgz",
+      "integrity": "sha512-el8M6jK2o3RXBnrSHX3ZKrsN8zEV63pSExTO1wYJz7QndGYZ8353e2a5PPX+qHe2aGayfnchQmkAojaWAREOIA==",
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "@types/trusted-types": "^2.0.2"
+      }
     },
     "node_modules/loader-runner": {
       "version": "4.3.1",
@@ -11919,6 +12015,16 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/promise-worker-transferable": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/promise-worker-transferable/-/promise-worker-transferable-1.0.4.tgz",
+      "integrity": "sha512-bN+0ehEnrXfxV2ZQvU2PetO0n4gqBD4ulq3MI1WOPLgr7/Mg9yRQkX5+0v1vagr74ZTsl7XtzlaYDo2EuCeYJw==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "is-promise": "^2.1.0",
+        "lie": "^3.0.2"
       }
     },
     "node_modules/prop-types": {
@@ -13615,6 +13721,13 @@
         "type": "opencollective",
         "url": "https://opencollective.com/webpack"
       }
+    },
+    "node_modules/three": {
+      "version": "0.183.2",
+      "resolved": "https://registry.npmjs.org/three/-/three-0.183.2.tgz",
+      "integrity": "sha512-di3BsL2FEQ1PA7Hcvn4fyJOlxRRgFYBpMTcyOgkwJIaDOdJMebEFPA+t98EvjuljDx4hNulAGwF6KIjtwI5jgQ==",
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/tiny-case": {
       "version": "1.0.3",

--- a/package.json
+++ b/package.json
@@ -11,6 +11,7 @@
   },
   "dependencies": {
     "@google/genai": "^1.34.0",
+    "@google/model-viewer": "^4.3.1",
     "@sendgrid/mail": "^8.1.5",
     "bcryptjs": "^2.4.3",
     "firebase": "^11.6.0",

--- a/src/app/pool3d/page.tsx
+++ b/src/app/pool3d/page.tsx
@@ -1,0 +1,102 @@
+import type { Metadata } from 'next';
+import Image from 'next/image';
+
+import PoolModelViewer from '@/components/PoolModelViewer';
+
+const modelHref = '/docs/survey/pool-area-scan-polycam.glb';
+
+export const metadata: Metadata = {
+  title: 'Pool 3D Scan | James Square',
+  description:
+    'Explore the James Square pool area with an interactive 3D scan and reference photos.',
+};
+
+const poolImages = [
+  {
+    src: '/images/buildingimages/pool-3D-facing-south.jpg',
+    alt: 'Pool area reference photo facing south',
+    caption: 'Pool area facing south',
+  },
+  {
+    src: '/images/buildingimages/pool-3D-facing-north.PNG',
+    alt: 'Pool area reference photo facing north',
+    caption: 'Pool area facing north',
+  },
+];
+
+export default function Pool3DPage() {
+  return (
+    <main className="mx-auto max-w-6xl space-y-10 px-2 py-6 sm:px-4 lg:py-10">
+      <section className="overflow-hidden rounded-[2rem] bg-gradient-to-br from-sky-50 via-white to-cyan-50 p-6 shadow-xl shadow-sky-950/5 ring-1 ring-sky-100 sm:p-10">
+        <div className="max-w-3xl">
+          <p className="mb-3 text-sm font-semibold uppercase tracking-[0.28em] text-sky-700">
+            Pool survey
+          </p>
+          <h1 className="text-4xl font-bold tracking-tight text-slate-950 sm:text-5xl">
+            Explore the pool area in 3D
+          </h1>
+          <p className="mt-5 text-lg leading-8 text-slate-700">
+            Use the interactive scan below to rotate, pan, and zoom around the James Square pool area.
+            The model is provided alongside two reference photos so residents can compare the scan with
+            fixed views of the space.
+          </p>
+        </div>
+      </section>
+
+      <section aria-labelledby="pool-model-heading" className="space-y-4">
+        <div className="flex flex-col gap-3 sm:flex-row sm:items-end sm:justify-between">
+          <div>
+            <h2 id="pool-model-heading" className="text-2xl font-bold text-slate-950">
+              Interactive pool model
+            </h2>
+            <p className="mt-2 text-slate-600">
+              Drag to rotate, scroll or pinch to zoom, and use touch gestures to inspect the 3D scan.
+            </p>
+          </div>
+          <a
+            href={modelHref}
+            className="inline-flex items-center justify-center rounded-full bg-slate-950 px-5 py-3 text-sm font-semibold text-white shadow-lg shadow-slate-950/10 transition hover:bg-slate-800"
+          >
+            Download/open GLB model
+          </a>
+        </div>
+        <PoolModelViewer />
+        <p className="text-sm text-slate-500">
+          If the 3D viewer does not load in your browser, use the download/open link above to access the GLB file directly.
+        </p>
+      </section>
+
+      <section aria-labelledby="pool-photos-heading" className="space-y-5">
+        <div>
+          <h2 id="pool-photos-heading" className="text-2xl font-bold text-slate-950">
+            Reference photos
+          </h2>
+          <p className="mt-2 text-slate-600">
+            These images show the same pool area from two directions to help orient the 3D scan.
+          </p>
+        </div>
+        <div className="grid gap-6 md:grid-cols-2">
+          {poolImages.map((image) => (
+            <figure
+              key={image.src}
+              className="overflow-hidden rounded-3xl bg-white shadow-xl shadow-slate-950/5 ring-1 ring-slate-200"
+            >
+              <div className="relative aspect-[4/3] w-full bg-slate-100">
+                <Image
+                  src={image.src}
+                  alt={image.alt}
+                  fill
+                  sizes="(min-width: 768px) 50vw, 100vw"
+                  className="object-cover"
+                />
+              </div>
+              <figcaption className="px-5 py-4 text-sm font-medium text-slate-700">
+                {image.caption}
+              </figcaption>
+            </figure>
+          ))}
+        </div>
+      </section>
+    </main>
+  );
+}

--- a/src/components/PoolModelViewer.tsx
+++ b/src/components/PoolModelViewer.tsx
@@ -1,0 +1,30 @@
+'use client';
+
+import '@google/model-viewer';
+
+const modelHref = '/docs/survey/pool-area-scan-polycam.glb';
+
+export default function PoolModelViewer() {
+  return (
+    <div className="overflow-hidden rounded-3xl border border-sky-100 bg-slate-950 shadow-2xl shadow-sky-950/20">
+      <model-viewer
+        src={modelHref}
+        poster="/images/buildingimages/pool-3D-facing-south.jpg"
+        camera-controls
+        auto-rotate
+        touch-action="pan-y"
+        shadow-intensity="0.65"
+        exposure="0.95"
+        aria-label="Interactive 3D scan of the James Square pool area"
+        className="block h-[420px] w-full bg-slate-950 sm:h-[560px] lg:h-[680px]"
+      >
+        <a
+          href={modelHref}
+          className="absolute left-1/2 top-1/2 -translate-x-1/2 -translate-y-1/2 rounded-full bg-white px-5 py-3 text-sm font-semibold text-slate-900 shadow-lg transition hover:bg-sky-50"
+        >
+          Open the pool 3D model
+        </a>
+      </model-viewer>
+    </div>
+  );
+}

--- a/src/types/model-viewer.d.ts
+++ b/src/types/model-viewer.d.ts
@@ -1,0 +1,17 @@
+import type React from 'react';
+
+declare module 'react' {
+  namespace JSX {
+    interface IntrinsicElements {
+      'model-viewer': React.DetailedHTMLProps<React.HTMLAttributes<HTMLElement>, HTMLElement> & {
+        src?: string;
+        poster?: string;
+        'camera-controls'?: boolean | string;
+        'auto-rotate'?: boolean | string;
+        'touch-action'?: string;
+        'shadow-intensity'?: string;
+        exposure?: string;
+      };
+    }
+  }
+}


### PR DESCRIPTION
### Motivation

- Provide an interactive 3D view of the James Square pool area so residents can inspect the scanned model alongside reference photos.

### Description

- Add `@google/model-viewer` as a dependency for rendering GLB assets and client-side model interaction.
- Add a client-side wrapper component `src/components/PoolModelViewer.tsx` that imports `@google/model-viewer` and renders a `<model-viewer>` element configured with `src="/docs/survey/pool-area-scan-polycam.glb"`, `poster="/images/buildingimages/pool-3D-facing-south.jpg"`, `camera-controls`, `auto-rotate`, `touch-action="pan-y"`, and responsive sizing.
- Add TypeScript JSX typings for the custom element in `src/types/model-viewer.d.ts` to allow using `<model-viewer>` in React/TSX safely.
- Add the new page `src/app/pool3d/page.tsx` with metadata, explanatory copy, the two reference pool images, the `PoolModelViewer` component, and a visible fallback download/open link to the GLB file for browsers that cannot render the model.

### Testing

- Ran `npm run lint`, which completed (with unrelated existing warnings in other files). 
- Ran `npx tsc --noEmit`, which completed successfully. 
- Ran `npm run build`, which failed in this environment due to network/font fetch errors from Google Fonts for `next/font` in `src/app/layout.tsx` and not because of the new viewer code.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a46d8cfe8fc83249309285adbb7d769)