### PR TITLE
Add 3D pool area CTA and preview card to booking page

### DIFF
--- a/src/app/book/BookClient.tsx
+++ b/src/app/book/BookClient.tsx
@@ -53,6 +53,36 @@ const OPENING_TIMES = [
   { label: 'Booking required', time: '05:30–09:30 and 17:00–23:00', note: 'Secure a slot for early morning and evening peaks.' },
 ];
 
+function Pool3DCallout({ className = '' }: { className?: string }) {
+  return (
+    <article
+      className={`overflow-hidden rounded-2xl border border-sky-200/70 bg-gradient-to-br from-sky-50 via-white to-blue-50 shadow-sm dark:border-sky-300/20 dark:from-sky-950/40 dark:via-gray-800 dark:to-blue-950/30 ${className}`}
+    >
+      <div className="relative aspect-[16/9] w-full overflow-hidden bg-slate-100 dark:bg-slate-800">
+        <Image
+          src="/images/buildingimages/pool-3D-facing-south.jpg"
+          alt="3D scan preview of the pool area facing south"
+          fill
+          sizes="(min-width: 768px) 50vw, 100vw"
+          className="object-cover"
+        />
+      </div>
+      <div className="space-y-3 px-5 py-4 text-left">
+        <div className="space-y-1">
+          <p className="text-xs font-semibold uppercase tracking-[0.2em] text-sky-700 dark:text-sky-300">Pool preview</p>
+          <h2 className="text-lg font-semibold text-slate-950 dark:text-white">Explore the pool area in 3D</h2>
+          <p className="text-sm text-slate-600 dark:text-slate-300">
+            Take a quick virtual look around the pool, showers, and access route before you book.
+          </p>
+        </div>
+        <Button variant="secondary" href="/pool3d" className="w-full justify-center text-sm sm:w-auto">
+          View 3D pool area scan
+        </Button>
+      </div>
+    </article>
+  );
+}
+
 export default function BookClient() {
   return (
     <main className="max-w-4xl mx-auto py-16 px-6 font-sans bg-white dark:bg-gray-900">
@@ -66,10 +96,13 @@ export default function BookClient() {
           <Button variant="secondary" href="/dashboard" className="w-full text-sm sm:text-base md:w-auto">
             My dashboard
           </Button>
+          <Button variant="secondary" href="/pool3d" className="w-full text-sm sm:text-base md:w-auto">
+            View 3D pool area scan
+          </Button>
         </div>
       </div>
 
-      <section className="mt-12 md:hidden">
+      <section className="mt-12 space-y-5 md:hidden">
         <FacilitySelectorMobile
           options={FACILITIES.map((facility) => ({
             key: facility.key,
@@ -78,12 +111,14 @@ export default function BookClient() {
             href: facility.href,
           }))}
         />
+        <Pool3DCallout />
       </section>
 
       <div className="mt-12 hidden grid-cols-1 gap-5 sm:gap-6 md:grid md:grid-cols-2 xl:grid-cols-3">
         {FACILITIES.map(({ key, ...facility }) => (
           <FacilityCard key={key} {...facility} />
         ))}
+        <Pool3DCallout className="md:col-span-2 xl:col-span-3" />
       </div>
       <div className="mt-14 md:mt-16">
         <GlassCard

--- a/src/components/PoolModelViewer.tsx
+++ b/src/components/PoolModelViewer.tsx
@@ -1,10 +1,14 @@
 'use client';
 
-import '@google/model-viewer';
+import { useEffect } from 'react';
 
 const modelHref = '/docs/survey/pool-area-scan-polycam.glb';
 
 export default function PoolModelViewer() {
+  useEffect(() => {
+    void import('@google/model-viewer');
+  }, []);
+
   return (
     <div className="overflow-hidden rounded-3xl border border-sky-100 bg-slate-950 shadow-2xl shadow-sky-950/20">
       <model-viewer


### PR DESCRIPTION
### Motivation
- Make the 3D pool scan discoverable from the booking page in both mobile and desktop layouts so users can preview the pool before booking. 
- Surface a clear call-to-action next to the existing primary actions to increase visibility of the `/pool3d` experience. 
- Use the provided pool scan image asset and `next/image` for a higher-quality visual preview. 

### Description
- Added a new `Pool3DCallout` component inside `src/app/book/BookClient.tsx` that renders a preview card using `next/image` with the image at `/images/buildingimages/pool-3D-facing-south.jpg` and copy `Explore the pool area in 3D` / `View 3D pool area scan`.
- Inserted a visible secondary `Button` linking to `/pool3d` alongside the existing `View availability` and `My dashboard` actions in the booking header using the existing `Button` component.
- Rendered the `Pool3DCallout` below the mobile `FacilitySelectorMobile` so it is reachable in the mobile flow and added the callout into the desktop card grid with `md:col-span-2 xl:col-span-3` so it is reachable in the desktop layout.
- Kept styling consistent with existing UI by reusing the app's utility classes and the `Button` component for navigation.

### Testing
- Ran `npm run lint`, which completed successfully and reported unrelated warnings in other files but no new lint errors for the modified file.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a46daa667a48324bfc6fc90d9c81c9b)