### PR TITLE
Add pool 3D promo to owners page

### DIFF
--- a/src/app/owners/page.tsx
+++ b/src/app/owners/page.tsx
@@ -1,5 +1,7 @@
 'use client';
 
+import Image from 'next/image';
+import Link from 'next/link';
 import { useRouter } from 'next/navigation';
 import { AnimatePresence, motion, useReducedMotion } from 'framer-motion';
 import { FormEvent, useState } from 'react';
@@ -122,6 +124,34 @@ const OwnersPage = () => {
               )}
             </AnimatePresence>
           </GlassCard>
+
+          <Link href="/pool3d" className="block group focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-cyan-500/50 focus-visible:ring-offset-2 focus-visible:ring-offset-transparent rounded-3xl">
+            <GlassCard
+              title="View the pool area in 3D"
+              titleClassName="text-slate-800/80 dark:text-slate-100/90"
+              className="bg-white/80 border-white/80 shadow-[0_18px_45px_rgba(15,23,42,0.08)] transition-all duration-200 group-hover:-translate-y-0.5 group-hover:shadow-[0_22px_55px_rgba(15,23,42,0.12)] dark:bg-slate-900/30"
+            >
+              <div className="grid gap-5 md:grid-cols-[minmax(0,1.15fr)_minmax(220px,0.85fr)] md:items-center">
+                <div className="space-y-3">
+                  <p className="text-sm leading-relaxed text-slate-700 dark:text-slate-200">
+                    Explore a 3D model of the James Square pool area to view the layout and surrounding features.
+                  </p>
+                  <span className="inline-flex items-center justify-center rounded-full px-5 py-2.5 text-sm font-semibold text-slate-900 bg-white/90 backdrop-blur-lg shadow-[0_6px_18px_rgba(0,0,0,0.08)] border border-black/5 transition-all duration-200 group-hover:scale-[1.01] group-hover:shadow-[0_10px_28px_rgba(0,0,0,0.12)] dark:bg-white/85 dark:text-slate-900 dark:border-white/20">
+                    Open 3D pool model
+                  </span>
+                </div>
+                <div className="relative aspect-[4/3] overflow-hidden rounded-2xl border border-white/70 bg-slate-200/60 shadow-sm dark:border-white/10 dark:bg-slate-800/50">
+                  <Image
+                    src="/images/buildingimages/pool-3D-facing-south.jpg"
+                    alt="3D model preview of the James Square pool area facing south"
+                    fill
+                    sizes="(min-width: 768px) 360px, calc(100vw - 64px)"
+                    className="object-cover transition-transform duration-300 group-hover:scale-105"
+                  />
+                </div>
+              </div>
+            </GlassCard>
+          </Link>
 
         </div>
       </div>


### PR DESCRIPTION
### Motivation
- Provide owners a clear, linked promo on the Owners page to view a 3D model of the pool area. 
- Surface the pool preview visually so owners can access the `/pool3d` experience directly from the Owners area.

### Description
- Import `Image` from `next/image` and `Link` from `next/link` into `src/app/owners/page.tsx`.
- Add a new `GlassCard` directly below the existing owners access card and wrap the entire card in a `Link` to `/pool3d`.
- Use `/images/buildingimages/pool-3D-facing-south.jpg` as the promo image with descriptive `alt` text and `fill`/`sizes` for responsive behavior.
- Include a concise copy and CTA (`Open 3D pool model`) and interactive hover/focus styles consistent with existing UI.

### Testing
- Ran `npm run lint`, which completed and reported pre-existing warnings in unrelated files but no new lint failures.
- Started the dev server with `npm run dev` and confirmed the application became ready locally.
- Attempted an automated screenshot via Playwright, which failed because Playwright is not installed in this environment.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a46e64196d48324b028578a9539373d)