### PR TITLE
Make PoolModelViewer configurable and add draft pool 3D model section

### DIFF
--- a/src/app/pool3d/page.tsx
+++ b/src/app/pool3d/page.tsx
@@ -3,12 +3,33 @@ import Image from 'next/image';
 
 import PoolModelViewer from '@/components/PoolModelViewer';
 
-const modelHref = '/docs/survey/pool-area-scan-polycam.glb';
+const poolModels = [
+  {
+    heading: 'Current scanned pool area',
+    description:
+      'This scan captures the current pool area so residents can rotate, pan, and zoom around the existing space.',
+    src: '/docs/survey/pool-area-scan-polycam.glb',
+    poster: '/images/buildingimages/pool-3D-facing-south.jpg',
+    ariaLabel: 'Interactive 3D scan of the current James Square pool area',
+    fallbackLabel: 'Open the current pool area scan',
+    linkLabel: 'Download/open current scan GLB',
+  },
+  {
+    heading: 'Draft digital pool improvement model',
+    description:
+      'This draft digital version is an early planning model for considering future pool-area improvements. It is shared with owners and interested James Square residents to support discussion and feedback.',
+    src: '/docs/survey/pool-3D-modelglb.glb',
+    poster: '/images/buildingimages/pool-3D-facing-north.PNG',
+    ariaLabel: 'Interactive draft digital model of possible James Square pool area improvements',
+    fallbackLabel: 'Open the draft pool improvement model',
+    linkLabel: 'Download/open draft improvement GLB',
+  },
+];
 
 export const metadata: Metadata = {
   title: 'Pool 3D Scan | James Square',
   description:
-    'Explore the James Square pool area with an interactive 3D scan and reference photos.',
+    'Explore the James Square pool area with interactive 3D models and reference photos.',
 };
 
 const poolImages = [
@@ -36,33 +57,48 @@ export default function Pool3DPage() {
             Explore the pool area in 3D
           </h1>
           <p className="mt-5 text-lg leading-8 text-slate-700">
-            Use the interactive scan below to rotate, pan, and zoom around the James Square pool area.
-            The model is provided alongside two reference photos so residents can compare the scan with
-            fixed views of the space.
+            Use the interactive models below to rotate, pan, and zoom around the James Square pool area.
+            The current scan is presented alongside an early draft improvement model and two reference photos
+            so residents can compare the existing space with planning ideas.
           </p>
         </div>
       </section>
 
-      <section aria-labelledby="pool-model-heading" className="space-y-4">
-        <div className="flex flex-col gap-3 sm:flex-row sm:items-end sm:justify-between">
-          <div>
-            <h2 id="pool-model-heading" className="text-2xl font-bold text-slate-950">
-              Interactive pool model
-            </h2>
-            <p className="mt-2 text-slate-600">
-              Drag to rotate, scroll or pinch to zoom, and use touch gestures to inspect the 3D scan.
-            </p>
-          </div>
-          <a
-            href={modelHref}
-            className="inline-flex items-center justify-center rounded-full bg-slate-950 px-5 py-3 text-sm font-semibold text-white shadow-lg shadow-slate-950/10 transition hover:bg-slate-800"
-          >
-            Download/open GLB model
-          </a>
+      <section aria-labelledby="pool-models-heading" className="space-y-8">
+        <div>
+          <h2 id="pool-models-heading" className="text-2xl font-bold text-slate-950">
+            Interactive pool models
+          </h2>
+          <p className="mt-2 text-slate-600">
+            Drag to rotate, scroll or pinch to zoom, and use touch gestures to inspect each 3D model.
+          </p>
         </div>
-        <PoolModelViewer />
+
+        {poolModels.map((model) => (
+          <article key={model.src} className="space-y-4">
+            <div className="flex flex-col gap-3 sm:flex-row sm:items-end sm:justify-between">
+              <div>
+                <h3 className="text-xl font-bold text-slate-950">{model.heading}</h3>
+                <p className="mt-2 max-w-3xl text-slate-600">{model.description}</p>
+              </div>
+              <a
+                href={model.src}
+                className="inline-flex items-center justify-center rounded-full bg-slate-950 px-5 py-3 text-sm font-semibold text-white shadow-lg shadow-slate-950/10 transition hover:bg-slate-800"
+              >
+                {model.linkLabel}
+              </a>
+            </div>
+            <PoolModelViewer
+              src={model.src}
+              poster={model.poster}
+              ariaLabel={model.ariaLabel}
+              fallbackLabel={model.fallbackLabel}
+            />
+          </article>
+        ))}
+
         <p className="text-sm text-slate-500">
-          If the 3D viewer does not load in your browser, use the download/open link above to access the GLB file directly.
+          If a 3D viewer does not load in your browser, use the download/open link above that model to access its GLB file directly.
         </p>
       </section>
 

--- a/src/components/PoolModelViewer.tsx
+++ b/src/components/PoolModelViewer.tsx
@@ -2,9 +2,19 @@
 
 import { useEffect } from 'react';
 
-const modelHref = '/docs/survey/pool-area-scan-polycam.glb';
+type PoolModelViewerProps = {
+  src: string;
+  poster?: string;
+  ariaLabel?: string;
+  fallbackLabel?: string;
+};
 
-export default function PoolModelViewer() {
+export default function PoolModelViewer({
+  src,
+  poster = '/images/buildingimages/pool-3D-facing-south.jpg',
+  ariaLabel = 'Interactive 3D model of the James Square pool area',
+  fallbackLabel = 'Open the pool 3D model',
+}: PoolModelViewerProps) {
   useEffect(() => {
     void import('@google/model-viewer');
   }, []);
@@ -12,21 +22,21 @@ export default function PoolModelViewer() {
   return (
     <div className="overflow-hidden rounded-3xl border border-sky-100 bg-slate-950 shadow-2xl shadow-sky-950/20">
       <model-viewer
-        src={modelHref}
-        poster="/images/buildingimages/pool-3D-facing-south.jpg"
+        src={src}
+        poster={poster}
         camera-controls
         auto-rotate
         touch-action="pan-y"
         shadow-intensity="0.65"
         exposure="0.95"
-        aria-label="Interactive 3D scan of the James Square pool area"
+        aria-label={ariaLabel}
         className="block h-[420px] w-full bg-slate-950 sm:h-[560px] lg:h-[680px]"
       >
         <a
-          href={modelHref}
+          href={src}
           className="absolute left-1/2 top-1/2 -translate-x-1/2 -translate-y-1/2 rounded-full bg-white px-5 py-3 text-sm font-semibold text-slate-900 shadow-lg transition hover:bg-sky-50"
         >
-          Open the pool 3D model
+          {fallbackLabel}
         </a>
       </model-viewer>
     </div>


### PR DESCRIPTION
### Motivation
- Present both the existing 3D scan and an early draft improvement model on the pool page while keeping visitors able to download the raw GLB files. 
- Make the embedded viewer reusable so different GLB files, posters and accessible labels can be shown without duplicating component logic. 

### Description
- Update `PoolModelViewer` to accept `src`, `poster`, `ariaLabel`, and `fallbackLabel` props and replace the hardcoded `'/docs/survey/pool-area-scan-polycam.glb'` with the passed `src` for both the viewer and fallback link. 
- Replace the single-model page at `src/app/pool3d/page.tsx` with a two-model layout that renders: `Current scanned pool area` using `'/docs/survey/pool-area-scan-polycam.glb'` and `Draft digital pool improvement model` using `'/docs/survey/pool-3D-modelglb.glb'`. 
- Add explanatory copy clarifying that the draft digital version is an early planning model shared with owners and interested residents. 
- Add separate direct download/open links for each GLB file and retain the existing reference images `'/images/buildingimages/pool-3D-facing-south.jpg'` and `'/images/buildingimages/pool-3D-facing-north.PNG'`. 

### Testing
- Ran `npm run lint`, which completed with the repository's existing lint warnings but no new errors. 
- Ran `npm run build`, which failed in this environment because `next/font` could not fetch Google Fonts from `fonts.gstatic.com`. 
- Attempted an automated page screenshot via a Playwright script, which failed because `playwright` is not installed in the environment.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a46e9edb33483248e8cbeb6366a65ac)