### PR TITLE
Pool 3D: lazy-load viewer, content updates, image tweaks and footer year

### DIFF
--- a/src/app/book/BookClient.tsx
+++ b/src/app/book/BookClient.tsx
@@ -72,7 +72,7 @@ function Pool3DCallout({ className = '' }: { className?: string }) {
           <p className="text-xs font-semibold uppercase tracking-[0.2em] text-sky-700 dark:text-sky-300">Pool preview</p>
           <h2 className="text-lg font-semibold text-slate-950 dark:text-white">Explore the pool area in 3D</h2>
           <p className="text-sm text-slate-600 dark:text-slate-300">
-            View the current pool area scan and the draft improvement model before you book.
+            View the current pool area scan before you book.
           </p>
         </div>
         <Button variant="secondary" href="/pool3d" className="w-full justify-center text-sm sm:w-auto">

--- a/src/app/owners/page.tsx
+++ b/src/app/owners/page.tsx
@@ -134,7 +134,7 @@ const OwnersPage = () => {
               <div className="grid gap-5 md:grid-cols-[minmax(0,1.15fr)_minmax(220px,0.85fr)] md:items-center">
                 <div className="space-y-3">
                   <p className="text-sm leading-relaxed text-slate-700 dark:text-slate-200">
-                    Owners can view the current pool area scan alongside a draft digital model for future improvement planning.
+                    Owners can view the current pool area scan for maintenance and renovation planning.
                   </p>
                   <span className="inline-flex items-center justify-center rounded-full px-5 py-2.5 text-sm font-semibold text-slate-900 bg-white/90 backdrop-blur-lg shadow-[0_6px_18px_rgba(0,0,0,0.08)] border border-black/5 transition-all duration-200 group-hover:scale-[1.01] group-hover:shadow-[0_10px_28px_rgba(0,0,0,0.12)] dark:bg-white/85 dark:text-slate-900 dark:border-white/20">
                     Open pool 3D models

--- a/src/app/pool3d/page.tsx
+++ b/src/app/pool3d/page.tsx
@@ -7,25 +7,38 @@ const poolModels = [
   {
     heading: 'Current scanned pool area',
     description:
-      'View the latest scan of the existing pool area. This viewer is intended for on-page inspection only, so residents can rotate, pan, and zoom without needing to download the scan file.',
+      'View the latest captured scan of the existing pool hall for maintenance and renovation planning.',
     src: '/docs/survey/pool-area-scan-polycam.glb',
     poster: '/images/buildingimages/pool-3D-facing-south.jpg',
     ariaLabel: 'Interactive 3D scan of the current James Square pool area',
   },
   {
-    heading: 'Draft digital pool improvement model',
+    heading: 'Additional current pool scan',
     description:
-      'Compare the current scan with an early digital planning model for possible pool-area improvements. More renovation mock-ups will be added as the design work develops.',
+      'Use this second scan to inspect another captured view of the existing pool hall as maintenance and renovation planning continues.',
     src: '/docs/survey/pool-3D-modelglb.glb',
     poster: '/images/buildingimages/pool-3D-facing-north.PNG',
-    ariaLabel: 'Interactive draft digital model of possible James Square pool area improvements',
+    ariaLabel: 'Interactive 3D scan of another current James Square pool area capture',
   },
 ];
 
 export const metadata: Metadata = {
-  title: 'Pool 3D Scan | James Square',
+  title: 'Pool 3D Scan – James Square',
   description:
-    'View the James Square pool area with interactive 3D scans, planning models, and reference photos.',
+    'Explore an interactive 3D scan of the current James Square pool hall, captured to support upcoming maintenance and renovation planning.',
+  openGraph: {
+    title: 'Pool 3D Scan – James Square',
+    description:
+      'Explore an interactive 3D scan of the current James Square pool hall, captured to support upcoming maintenance and renovation planning.',
+    images: [
+      {
+        url: '/images/buildingimages/pool-3D-facing-south.jpg',
+        width: 1301,
+        height: 771,
+        alt: 'James Square pool hall 3D scan preview',
+      },
+    ],
+  },
 };
 
 const poolImages = [
@@ -53,13 +66,11 @@ export default function Pool3DPage() {
             Explore the pool area in 3D
           </h1>
           <p className="mt-5 text-lg leading-8 text-slate-700">
-            Use the interactive viewers below to rotate, pan, and zoom around the James Square pool area.
-            The current scan is presented alongside an early draft digital model and reference photos so
-            residents can compare the existing space with future renovation ideas.
+            This page provides an interactive 3D scan of the pool hall as it currently is, captured to support upcoming maintenance and renovation planning.
+            Reference photos are included below to help orient the scan.
           </p>
           <div className="mt-6 rounded-2xl border border-amber-200 bg-amber-50 px-5 py-4 text-sm leading-6 text-amber-900">
-            <strong className="font-semibold">Work in progress:</strong> this page is still being edited and
-            will be updated soon with potential mock-ups showing what the pool area could look like after renovation.
+            The scan will be refined as more capture data is added.
           </div>
         </div>
       </section>
@@ -70,8 +81,7 @@ export default function Pool3DPage() {
             Interactive pool viewers
           </h2>
           <p className="mt-2 text-slate-600">
-            Drag to rotate, scroll or pinch to zoom, and use touch gestures to inspect each model directly on this page.
-            Download/open links have been removed from the viewer area so the scans stay out of the way on mobile.
+            Drag to rotate, scroll or pinch to zoom, and use touch gestures to inspect the scan directly on this page.
           </p>
         </div>
 
@@ -91,13 +101,6 @@ export default function Pool3DPage() {
             />
           </article>
         ))}
-
-        <div className="rounded-3xl border border-slate-200 bg-slate-50 p-5 text-sm leading-6 text-slate-600">
-          <p>
-            This is a view-only page for reviewing the pool scan and digital version. A separate download option will be
-            placed at the bottom of the page when the shared files are ready.
-          </p>
-        </div>
       </section>
 
       <section aria-labelledby="pool-photos-heading" className="space-y-5">
@@ -120,7 +123,9 @@ export default function Pool3DPage() {
                   src={image.src}
                   alt={image.alt}
                   fill
-                  sizes="(min-width: 768px) 50vw, 100vw"
+                  sizes="(min-width: 768px) 640px, 100vw"
+                  loading="lazy"
+                  unoptimized
                   className="object-cover"
                 />
               </div>

--- a/src/components/Footer.tsx
+++ b/src/components/Footer.tsx
@@ -20,10 +20,6 @@ export default function Footer() {
     <footer className="mt-12">
       <div className="jqs-glass rounded-t-3xl rounded-b-none border border-slate-200/60 dark:border-slate-800/60">
         <div className="max-w-6xl mx-auto px-3 sm:px-6 py-4 md:py-8">
-          <div className="flex justify-center md:hidden mb-3">
-            <LogoMark />
-          </div>
-
           <div className="grid grid-cols-[minmax(0,1fr)_minmax(0,1fr)_minmax(0,1fr)] gap-3 sm:gap-4 md:gap-10 text-[10px] sm:text-[11px] md:text-sm text-slate-600 dark:text-slate-300">
             <section className="min-w-0 flex flex-col gap-2 md:gap-3">
               <div className="hidden md:flex items-center gap-3">
@@ -84,7 +80,7 @@ export default function Footer() {
           </div>
 
           <div className="mt-4 border-t border-slate-200/70 dark:border-slate-700/60 pt-2 text-[10px] text-slate-500 dark:text-slate-400">
-            © 2025 James Square. All rights reserved.
+            © {new Date().getFullYear()} James Square. All rights reserved.
           </div>
         </div>
       </div>

--- a/src/components/PoolModelViewer.tsx
+++ b/src/components/PoolModelViewer.tsx
@@ -115,8 +115,6 @@ export default function PoolModelViewer({
               min-field-of-view={insideView ? '50deg' : '25deg'}
               max-field-of-view={insideView ? '60deg' : '75deg'}
               interaction-prompt={insideView ? 'none' : 'auto'}
-              loading="lazy"
-              reveal="interaction"
               aria-label={`${ariaLabel}${insideView ? ' in inside view mode' : ''}`}
               className="block h-full w-full bg-slate-950"
             />

--- a/src/components/PoolModelViewer.tsx
+++ b/src/components/PoolModelViewer.tsx
@@ -1,5 +1,6 @@
 'use client';
 
+import Image from 'next/image';
 import { useEffect, useRef, useState } from 'react';
 
 type PoolModelViewerProps = {
@@ -21,15 +22,20 @@ export default function PoolModelViewer({
 }: PoolModelViewerProps) {
   const viewerRef = useRef<HTMLElement | null>(null);
   const [insideView, setInsideView] = useState(false);
+  const [isLoaded, setIsLoaded] = useState(false);
 
   useEffect(() => {
+    if (!isLoaded) {
+      return;
+    }
+
     void import('@google/model-viewer');
-  }, []);
+  }, [isLoaded]);
 
   useEffect(() => {
     const viewer = viewerRef.current;
 
-    if (!viewer) {
+    if (!viewer || !isLoaded) {
       return;
     }
 
@@ -56,39 +62,66 @@ export default function PoolModelViewer({
       window.cancelAnimationFrame(frameId);
       viewer.setAttribute('orientation', '0deg 0deg 0deg');
     };
-  }, [insideView]);
+  }, [insideView, isLoaded]);
 
   return (
     <div className="overflow-hidden rounded-3xl border border-sky-100 bg-slate-950 shadow-2xl shadow-sky-950/20">
-      <div className="relative">
-        <button
-          type="button"
-          aria-pressed={insideView}
-          onClick={() => setInsideView((enabled) => !enabled)}
-          className="absolute right-3 top-3 z-10 rounded-full border border-white/30 bg-white/90 px-4 py-2 text-sm font-semibold text-slate-950 shadow-lg shadow-slate-950/20 transition hover:bg-white focus:outline-none focus:ring-2 focus:ring-cyan-300 focus:ring-offset-2 focus:ring-offset-slate-950 sm:right-4 sm:top-4"
-        >
-          Inside View
-        </button>
-        <model-viewer
-          ref={viewerRef}
-          src={src}
-          poster={poster}
-          camera-controls
-          {...(!insideView ? { 'auto-rotate': true } : {})}
-          touch-action="pan-y"
-          shadow-intensity="0.65"
-          exposure="0.95"
-          camera-orbit={insideView ? INSIDE_CAMERA_ORBIT : EXTERNAL_CAMERA_ORBIT}
-          camera-target={insideView ? INSIDE_CAMERA_TARGET : EXTERNAL_CAMERA_TARGET}
-          min-camera-orbit={insideView ? '170deg 82deg 1.6m' : 'auto auto 3m'}
-          max-camera-orbit={insideView ? '190deg 96deg 2.7m' : 'auto auto 14m'}
-          field-of-view={insideView ? '55deg' : '45deg'}
-          min-field-of-view={insideView ? '50deg' : '25deg'}
-          max-field-of-view={insideView ? '60deg' : '75deg'}
-          interaction-prompt={insideView ? 'none' : 'auto'}
-          aria-label={`${ariaLabel}${insideView ? ' in inside view mode' : ''}`}
-          className="block h-[420px] w-full bg-slate-950 sm:h-[560px] lg:h-[680px]"
-        />
+      <div className="relative h-[420px] sm:h-[560px] lg:h-[680px]">
+        {!isLoaded ? (
+          <>
+            <Image
+              src={poster}
+              alt="Pool 3D viewer preview"
+              fill
+              sizes="(min-width: 1024px) 1024px, 100vw"
+              className="object-cover opacity-80"
+              loading="lazy"
+              unoptimized
+            />
+            <div className="absolute inset-0 flex items-center justify-center bg-slate-950/35 p-6">
+              <button
+                type="button"
+                onClick={() => setIsLoaded(true)}
+                className="rounded-full border border-white/40 bg-white px-6 py-3 text-sm font-semibold text-slate-950 shadow-xl shadow-slate-950/30 transition hover:bg-slate-100 focus:outline-none focus:ring-2 focus:ring-cyan-300 focus:ring-offset-2 focus:ring-offset-slate-950"
+              >
+                Load 3D viewer
+              </button>
+            </div>
+          </>
+        ) : (
+          <>
+            <button
+              type="button"
+              aria-pressed={insideView}
+              onClick={() => setInsideView((enabled) => !enabled)}
+              className="absolute right-3 top-3 z-10 rounded-full border border-white/30 bg-white/90 px-4 py-2 text-sm font-semibold text-slate-950 shadow-lg shadow-slate-950/20 transition hover:bg-white focus:outline-none focus:ring-2 focus:ring-cyan-300 focus:ring-offset-2 focus:ring-offset-slate-950 sm:right-4 sm:top-4"
+            >
+              Inside View
+            </button>
+            <model-viewer
+              ref={viewerRef}
+              src={src}
+              poster={poster}
+              camera-controls
+              {...(!insideView ? { 'auto-rotate': true } : {})}
+              touch-action="pan-y"
+              shadow-intensity="0.65"
+              exposure="0.95"
+              camera-orbit={insideView ? INSIDE_CAMERA_ORBIT : EXTERNAL_CAMERA_ORBIT}
+              camera-target={insideView ? INSIDE_CAMERA_TARGET : EXTERNAL_CAMERA_TARGET}
+              min-camera-orbit={insideView ? '170deg 82deg 1.6m' : 'auto auto 3m'}
+              max-camera-orbit={insideView ? '190deg 96deg 2.7m' : 'auto auto 14m'}
+              field-of-view={insideView ? '55deg' : '45deg'}
+              min-field-of-view={insideView ? '50deg' : '25deg'}
+              max-field-of-view={insideView ? '60deg' : '75deg'}
+              interaction-prompt={insideView ? 'none' : 'auto'}
+              loading="lazy"
+              reveal="interaction"
+              aria-label={`${ariaLabel}${insideView ? ' in inside view mode' : ''}`}
+              className="block h-full w-full bg-slate-950"
+            />
+          </>
+        )}
       </div>
     </div>
   );


### PR DESCRIPTION
### Motivation
- Clarify messaging to present the 3D scan as a current capture used for maintenance and renovation planning rather than as a draft improvement model.
- Improve page performance and UX by deferring the heavy `model-viewer` bundle until the user requests the 3D viewer.
- Reduce unnecessary image decoding work on initial load and ensure correct responsive sizing for pool reference photos.
- Keep footer copyright up to date automatically.

### Description
- Reworded copy across `pool3d/page.tsx`, `owners/page.tsx`, and `BookClient.tsx` to emphasise the current pool scan and maintenance/renovation planning instead of draft improvement models and mock-ups, and updated headings/aria labels accordingly.
- Added Open Graph metadata to `pool3d/page.tsx` under `metadata` including `openGraph.title`, `openGraph.description`, and `openGraph.images` for better sharing previews.
- Adjusted pool reference image sizing and loading in `pool3d/page.tsx` by changing `sizes` to `'(min-width: 768px) 640px, 100vw'` and enabling `loading="lazy"` and `unoptimized` on the `Image` elements.
- Implemented lazy-load UX in `PoolModelViewer.tsx` by introducing `isLoaded` state, showing a poster image with a `Load 3D viewer` button, and only importing `@google/model-viewer` and rendering the `<model-viewer>` element after the user requests it; preserved inside/external view logic and added `loading`, `reveal`, and other attributes to the viewer.
- Updated the `PoolModelViewer` rotation/effect logic to only run when the viewer is loaded and cleaned up animations correctly.
- Minor UI cleanup in `Footer.tsx` including removal of a duplicate mobile logo wrapper and changing the copyright line to `© {new Date().getFullYear()} James Square. All rights reserved.`.

### Testing
- Ran TypeScript type-check and `next build` to validate compilation and routing, and the build completed successfully.
- Ran the linting pipeline (`eslint`) and no new lint errors were reported after the changes.
- Manually tested the pool page in a local dev server to verify the poster/placeholder shows, the `Load 3D viewer` button imports and initializes the viewer, and image lazy-loading behaves as expected.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a479f053b808324a33d632a494e6a7b)