### PR TITLE
Integrate 10s walkthrough video and guidance into Pool 3D page

### DIFF
--- a/src/app/pool3d/page.tsx
+++ b/src/app/pool3d/page.tsx
@@ -3,6 +3,8 @@ import Image from 'next/image';
 
 import PoolModelViewer from '@/components/PoolModelViewer';
 
+const poolWalkthroughVideo = '/docs/survey/pool-walkthrough-website.mp4';
+
 const poolModels = [
   {
     heading: 'Current scanned pool area',
@@ -22,14 +24,20 @@ const poolModels = [
   },
 ];
 
+const surveyHighlights = [
+  'Watch the 10-second walkthrough first for a quick sense of the model layout.',
+  'Load either interactive viewer when you want to inspect details from your own angle.',
+  'Use the reference photos at the bottom of the page to match the scan to the real pool area.',
+];
+
 export const metadata: Metadata = {
   title: 'Pool 3D Scan – James Square',
   description:
-    'Explore an interactive 3D scan of the current James Square pool hall, captured to support upcoming maintenance and renovation planning.',
+    'Explore an interactive 3D scan and short walkthrough video of the current James Square pool hall, captured to support upcoming maintenance and renovation planning.',
   openGraph: {
     title: 'Pool 3D Scan – James Square',
     description:
-      'Explore an interactive 3D scan of the current James Square pool hall, captured to support upcoming maintenance and renovation planning.',
+      'Explore an interactive 3D scan and short walkthrough video of the current James Square pool hall, captured to support upcoming maintenance and renovation planning.',
     images: [
       {
         url: '/images/buildingimages/pool-3D-facing-south.jpg',
@@ -57,21 +65,69 @@ const poolImages = [
 export default function Pool3DPage() {
   return (
     <main className="mx-auto max-w-6xl space-y-10 px-2 py-6 sm:px-4 lg:py-10">
-      <section className="overflow-hidden rounded-[2rem] bg-gradient-to-br from-sky-50 via-white to-cyan-50 p-6 shadow-xl shadow-sky-950/5 ring-1 ring-sky-100 sm:p-10">
-        <div className="max-w-3xl">
-          <p className="mb-3 text-sm font-semibold uppercase tracking-[0.28em] text-sky-700">
-            Pool survey
-          </p>
-          <h1 className="text-4xl font-bold tracking-tight text-slate-950 sm:text-5xl">
-            Explore the pool area in 3D
-          </h1>
-          <p className="mt-5 text-lg leading-8 text-slate-700">
-            This page provides an interactive 3D scan of the pool hall as it currently is, captured to support upcoming maintenance and renovation planning.
-            Reference photos are included below to help orient the scan.
-          </p>
-          <div className="mt-6 rounded-2xl border border-amber-200 bg-amber-50 px-5 py-4 text-sm leading-6 text-amber-900">
-            The scan will be refined as more capture data is added.
+      <section className="overflow-hidden rounded-[2rem] bg-gradient-to-br from-sky-50 via-white to-cyan-50 shadow-xl shadow-sky-950/5 ring-1 ring-sky-100">
+        <div className="grid gap-8 p-6 sm:p-10 lg:grid-cols-[minmax(0,1fr)_420px] lg:items-center">
+          <div className="max-w-3xl">
+            <p className="mb-3 text-sm font-semibold uppercase tracking-[0.28em] text-sky-700">
+              Pool survey
+            </p>
+            <h1 className="text-4xl font-bold tracking-tight text-slate-950 sm:text-5xl">
+              Explore the pool area in 3D
+            </h1>
+            <p className="mt-5 text-lg leading-8 text-slate-700">
+              This page brings together the short walkthrough video, interactive 3D scans, and reference photos for the current pool hall so owners and contractors can quickly understand the space before inspecting the model in detail.
+            </p>
+            <div className="mt-6 grid gap-3 sm:grid-cols-3">
+              <div className="rounded-2xl border border-sky-100 bg-white/80 px-4 py-3 shadow-sm">
+                <p className="text-2xl font-bold text-slate-950">10 sec</p>
+                <p className="text-sm text-slate-600">quick video preview</p>
+              </div>
+              <div className="rounded-2xl border border-sky-100 bg-white/80 px-4 py-3 shadow-sm">
+                <p className="text-2xl font-bold text-slate-950">2</p>
+                <p className="text-sm text-slate-600">interactive scans</p>
+              </div>
+              <div className="rounded-2xl border border-sky-100 bg-white/80 px-4 py-3 shadow-sm">
+                <p className="text-2xl font-bold text-slate-950">2</p>
+                <p className="text-sm text-slate-600">orientation photos</p>
+              </div>
+            </div>
           </div>
+
+          <div className="rounded-[1.75rem] bg-slate-950 p-3 shadow-2xl shadow-sky-950/20 ring-1 ring-slate-900/10">
+            <video
+              className="aspect-video w-full rounded-[1.25rem] bg-slate-900 object-cover"
+              src={poolWalkthroughVideo}
+              controls
+              muted
+              playsInline
+              preload="metadata"
+              poster="/images/buildingimages/pool-3D-facing-south.jpg"
+              aria-label="10-second walkthrough video of the James Square pool 3D model"
+            />
+            <div className="px-2 pb-1 pt-3 text-sm leading-6 text-slate-200">
+              <p className="font-semibold text-white">Quick model walkthrough</p>
+              <p className="text-slate-300">A short video preview helps orient the interactive scans below.</p>
+            </div>
+          </div>
+        </div>
+      </section>
+
+      <section aria-labelledby="pool-guide-heading" className="rounded-3xl bg-white p-5 shadow-lg shadow-slate-950/5 ring-1 ring-slate-200 sm:p-6">
+        <h2 id="pool-guide-heading" className="text-2xl font-bold text-slate-950">
+          How to use this page
+        </h2>
+        <div className="mt-4 grid gap-3 md:grid-cols-3">
+          {surveyHighlights.map((highlight, index) => (
+            <div key={highlight} className="rounded-2xl border border-slate-200 bg-slate-50 p-4">
+              <p className="mb-2 flex h-8 w-8 items-center justify-center rounded-full bg-sky-100 text-sm font-bold text-sky-800">
+                {index + 1}
+              </p>
+              <p className="text-sm leading-6 text-slate-700">{highlight}</p>
+            </div>
+          ))}
+        </div>
+        <div className="mt-5 rounded-2xl border border-amber-200 bg-amber-50 px-5 py-4 text-sm leading-6 text-amber-900">
+          The scan will be refined as more capture data is added.
         </div>
       </section>
 
@@ -81,7 +137,7 @@ export default function Pool3DPage() {
             Interactive pool viewers
           </h2>
           <p className="mt-2 text-slate-600">
-            Drag to rotate, scroll or pinch to zoom, and use touch gestures to inspect the scan directly on this page.
+            Drag to rotate, scroll or pinch to zoom, and use touch gestures to inspect the scan directly on this page. Select <span className="font-semibold text-slate-800">Inside View</span> after loading a model for a closer walkthrough-style inspection.
           </p>
         </div>
 


### PR DESCRIPTION
### Motivation
- Improve orientation and first-pass understanding of the Pool 3D content by adding a short walkthrough video alongside the interactive scans and reference photos. 
- Make the page easier to use for owners and contractors by surfacing usage guidance and calling out the interactive viewer's `Inside View` for walkthrough-style inspection.

### Description
- Added a `poolWalkthroughVideo` reference and embedded a responsive `<video>` hero using `/docs/survey/pool-walkthrough-website.mp4` with `controls`, `muted`, `playsInline`, `preload="metadata"`, a poster image, and an accessible `aria-label` in `src/app/pool3d/page.tsx`.
- Reworked the hero layout into a two-column grid that pairs the video with refreshed intro copy and three short overview stat cards for `10 sec` video, `2` interactive scans, and `2` orientation photos.
- Introduced a `surveyHighlights` array and a new "How to use this page" section that lists simple inspection steps, and clarified the interactive viewer instructions to mention `Inside View` for closer inspection.
- Updated page `metadata`/OpenGraph copy to include the short walkthrough video and adjusted copy to better describe the combined video + interactive scan experience.

### Testing
- Ran `npm run lint` which completed successfully but left unrelated warnings in other files. 
- Attempted `npm run build` but the build was blocked by network/font download failures from `fonts.gstatic.com`. 
- Attempted a headless screenshot via Playwright, but the Playwright browser install failed with `403 Domain forbidden` from `cdn.playwright.dev`, so end-to-end screenshot verification was not completed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a49635d5e6c8324aa27f01251463da6)