### PR TITLE
Add pool reference image folder

### DIFF
--- a/public/images/pool/README.md
+++ b/public/images/pool/README.md
@@ -1,0 +1,3 @@
+# Pool reference images
+
+Add pool area reference photos and related image assets for the future `/pool3d` page in this folder.


### PR DESCRIPTION
### Motivation
- Create a dedicated place for pool area reference images to support the forthcoming `/pool3d` page and keep related assets organized.

### Description
- Add `public/images/pool/` directory with a placeholder `README.md` that documents the folder's purpose for pool area photos and related image assets.

### Testing
- No automated tests were necessary for this documentation-only filesystem change.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a4ad30bc7908324a92181573aee5e47)