### PR TITLE
Polish pool 3D model page and update viewer to latest GLB

### DIFF
--- a/src/app/pool3d/page.tsx
+++ b/src/app/pool3d/page.tsx
@@ -5,33 +5,44 @@ import PoolModelViewer from '@/components/PoolModelViewer';
 
 const poolWalkthroughVideo = '/docs/survey/pool-walkthrough-website.mp4';
 
-const poolModel = {
-  heading: 'Interactive pool model',
-  description:
-    'Use the new PlayCanvas viewer to inspect the latest Blender GLB model of the pool area from any angle.',
-  ariaLabel: 'Interactive PlayCanvas 3D model of the James Square pool area',
-};
-
-const surveyHighlights = [
-  'Watch the 10-second walkthrough first for a quick sense of the model layout.',
-  'Use the PlayCanvas viewer when you want to inspect details from your own angle.',
-  'Use the reference photos at the bottom of the page to match the scan to the real pool area.',
+const infoCards = [
+  {
+    title: 'About the pool area',
+    summary:
+      'James Square has a heated indoor residents’ pool area with associated gym, sauna, changing and shower facilities.',
+    details:
+      'The pool area forms part of the original James Square leisure facilities. It includes the heated indoor swimming pool, gym, sauna, changing rooms, showers, seating and plant room. This digital model is intended to help explain the general layout of the space.',
+  },
+  {
+    title: 'Current repair position',
+    summary:
+      'The pool is temporarily closed following issues linked to the electrical fault and issues with ventilation/dehumidification system and resulting high humidity.',
+    details:
+      'The pool area has recently been affected by high humidity levels following an electrical fault and knock-on issues with the ventilation/dehumidification system. The elevated moisture levels caused damage to parts of the pool area, including ceiling finishes that now require repair. Further surveys, assessments and repair works are being considered so the facilities can be reopened safely.',
+  },
+  {
+    title: 'Purpose of this page',
+    summary:
+      'This page can be shared with contractors, designers, surveyors and others involved in reviewing the pool area.',
+    details:
+      'This page is intended to provide a useful visual reference for anyone involved in the pool repair and refurbishment process. It may assist contractors, designers, architects, surveyors, RLSS UK, committee members and residents by giving them a better understanding of the layout before visiting or reviewing the space. The page is still in its early stages and more information, images and updates may be added in due course.',
+  },
 ];
 
 export const metadata: Metadata = {
-  title: 'Pool 3D Scan – James Square',
+  title: 'James Square Pool 3D Model',
   description:
-    'Explore an interactive 3D scan and short walkthrough video of the current James Square pool hall, captured to support upcoming maintenance and renovation planning.',
+    'Interactive digital model of the James Square heated indoor pool, created to support repair and refurbishment discussions.',
   openGraph: {
-    title: 'Pool 3D Scan – James Square',
+    title: 'James Square Pool 3D Model',
     description:
-      'Explore an interactive 3D scan and short walkthrough video of the current James Square pool hall, captured to support upcoming maintenance and renovation planning.',
+      'Interactive digital model of the James Square heated indoor pool, created to support repair and refurbishment discussions.',
     images: [
       {
-        url: '/images/buildingimages/pool-3D-facing-south.jpg',
+        url: '/images/pool/Pool-facing-south.png',
         width: 1301,
         height: 771,
-        alt: 'James Square pool hall 3D scan preview',
+        alt: 'James Square pool area preview',
       },
     ],
   },
@@ -39,135 +50,143 @@ export const metadata: Metadata = {
 
 const poolImages = [
   {
-    src: '/images/buildingimages/pool-3D-facing-south.jpg',
-    alt: 'Pool area reference photo facing south',
+    src: '/images/pool/Pool-facing-south.png',
+    alt: 'Pool area facing south',
     caption: 'Pool area facing south',
   },
   {
-    src: '/images/buildingimages/pool-3D-facing-north.PNG',
-    alt: 'Pool area reference photo facing north',
-    caption: 'Pool area facing north',
+    src: '/images/pool/3Dimage-facing-north.jpg',
+    alt: '3D pool model view facing north',
+    caption: '3D model facing north',
+  },
+  {
+    src: '/images/pool/01-entrance-hallway.jpeg',
+    alt: 'Pool entrance hallway',
+    caption: 'Entrance hallway',
+  },
+  {
+    src: '/images/pool/03-gym-facing-south.jpeg',
+    alt: 'Gym area facing south',
+    caption: 'Gym area',
+  },
+  {
+    src: '/images/pool/05-sauna-entrance-door.jpeg',
+    alt: 'Sauna entrance door',
+    caption: 'Sauna entrance',
+  },
+  {
+    src: '/images/pool/08-ceiling-damage.jpeg',
+    alt: 'Ceiling finishes requiring repair',
+    caption: 'Ceiling repair area',
   },
 ];
 
 export default function Pool3DPage() {
   return (
-    <main className="mx-auto max-w-6xl space-y-10 px-2 py-6 sm:px-4 lg:py-10">
-      <section className="overflow-hidden rounded-[2rem] bg-gradient-to-br from-sky-50 via-white to-cyan-50 shadow-xl shadow-sky-950/5 ring-1 ring-sky-100">
-        <div className="grid gap-8 p-6 sm:p-10 lg:grid-cols-[minmax(0,1fr)_420px] lg:items-center">
-          <div className="max-w-3xl">
-            <p className="mb-3 text-sm font-semibold uppercase tracking-[0.28em] text-sky-700">
-              Pool survey
-            </p>
-            <h1 className="text-4xl font-bold tracking-tight text-slate-950 sm:text-5xl">
-              Explore the pool area in 3D
-            </h1>
-            <p className="mt-5 text-lg leading-8 text-slate-700">
-              This page brings together the short walkthrough video, the interactive 3D model, and reference photos for the current pool hall so owners and contractors can quickly understand the space before inspecting the model in detail.
-            </p>
-            <div className="mt-6 grid gap-3 sm:grid-cols-3">
-              <div className="rounded-2xl border border-sky-100 bg-white/80 px-4 py-3 shadow-sm">
-                <p className="text-2xl font-bold text-slate-950">10 sec</p>
-                <p className="text-sm text-slate-600">quick video preview</p>
-              </div>
-              <div className="rounded-2xl border border-sky-100 bg-white/80 px-4 py-3 shadow-sm">
-                <p className="text-2xl font-bold text-slate-950">1</p>
-                <p className="text-sm text-slate-600">PlayCanvas model</p>
-              </div>
-              <div className="rounded-2xl border border-sky-100 bg-white/80 px-4 py-3 shadow-sm">
-                <p className="text-2xl font-bold text-slate-950">2</p>
-                <p className="text-sm text-slate-600">orientation photos</p>
-              </div>
-            </div>
-          </div>
-
-          <div className="rounded-[1.75rem] bg-slate-950 p-3 shadow-2xl shadow-sky-950/20 ring-1 ring-slate-900/10">
-            <video
-              className="aspect-video w-full rounded-[1.25rem] bg-slate-900 object-cover"
-              src={poolWalkthroughVideo}
-              controls
-              muted
-              playsInline
-              preload="metadata"
-              poster="/images/buildingimages/pool-3D-facing-south.jpg"
-              aria-label="10-second walkthrough video of the James Square pool 3D model"
-            />
-            <div className="px-2 pb-1 pt-3 text-sm leading-6 text-slate-200">
-              <p className="font-semibold text-white">Quick model walkthrough</p>
-              <p className="text-slate-300">A short video preview helps orient the interactive model below.</p>
-            </div>
+    <main className="mx-auto max-w-7xl space-y-8 px-3 py-6 sm:px-5 lg:py-10">
+      <section className="overflow-hidden rounded-[2rem] border border-sky-100 bg-gradient-to-br from-sky-50 via-white to-cyan-50 p-6 shadow-xl shadow-sky-950/5 dark:border-white/10 dark:from-slate-950 dark:via-slate-900 dark:to-cyan-950/40 sm:p-8 lg:p-10">
+        <div className="max-w-4xl">
+          <p className="mb-3 text-sm font-semibold uppercase tracking-[0.28em] text-sky-700 dark:text-sky-300">
+            Pool project reference
+          </p>
+          <h1 className="text-4xl font-bold tracking-tight text-slate-950 dark:text-white sm:text-5xl lg:text-6xl">
+            James Square Pool 3D Model
+          </h1>
+          <p className="mt-5 max-w-3xl text-base leading-7 text-slate-700 dark:text-slate-200 sm:text-lg">
+            An interactive digital model of the James Square heated indoor pool, created to help visualise the layout and support future repair and refurbishment discussions.
+          </p>
+          <div className="mt-6 inline-flex rounded-2xl border border-amber-200 bg-amber-50 px-4 py-3 text-sm font-semibold text-amber-900 shadow-sm dark:border-amber-300/30 dark:bg-amber-300/10 dark:text-amber-100">
+            Pool currently closed pending repairs and further assessment.
           </div>
         </div>
       </section>
 
-      <section aria-labelledby="pool-guide-heading" className="rounded-3xl bg-white p-5 shadow-lg shadow-slate-950/5 ring-1 ring-slate-200 sm:p-6">
-        <h2 id="pool-guide-heading" className="text-2xl font-bold text-slate-950">
-          How to use this page
+      <section aria-labelledby="pool-model-heading" className="space-y-4">
+        <div className="rounded-[2rem] border border-slate-200 bg-white/90 p-3 shadow-2xl shadow-sky-950/10 dark:border-white/10 dark:bg-slate-900/90 sm:p-4">
+          <div className="mb-4 flex flex-col gap-2 px-2 pt-2 sm:px-3">
+            <h2 id="pool-model-heading" className="text-2xl font-bold text-slate-950 dark:text-white">
+              Interactive 3D pool model
+            </h2>
+            <p className="text-sm text-slate-600 dark:text-slate-300">
+              Rotate, zoom and pan the latest pool model directly in the viewer.
+            </p>
+          </div>
+          <PoolModelViewer ariaLabel="Interactive 3D model of the James Square heated indoor pool layout" />
+        </div>
+        <p className="px-2 text-sm leading-6 text-slate-600 dark:text-slate-300">
+          This model is a working visual reference and may be refined as further photos, measurements and survey information become available.
+        </p>
+      </section>
+
+      <section aria-labelledby="pool-scan-heading" className="rounded-3xl border border-slate-200 bg-white/85 p-4 shadow-lg shadow-slate-950/5 dark:border-white/10 dark:bg-slate-900/80 sm:p-5">
+        <div className="grid gap-4 md:grid-cols-[minmax(0,1fr)_340px] md:items-center">
+          <div>
+            <h2 id="pool-scan-heading" className="text-xl font-bold text-slate-950 dark:text-white">
+              3D scan preview
+            </h2>
+            <p className="mt-2 text-sm leading-6 text-slate-600 dark:text-slate-300">
+              A short scan walkthrough is available as a secondary reference alongside the interactive model.
+            </p>
+          </div>
+          <video
+            className="aspect-video w-full rounded-2xl bg-slate-950 object-cover shadow-lg"
+            src={poolWalkthroughVideo}
+            controls
+            muted
+            playsInline
+            preload="metadata"
+            poster="/images/pool/Pool-facing-south.png"
+            aria-label="Walkthrough video scan of the James Square pool 3D model"
+          />
+        </div>
+      </section>
+
+      <section aria-labelledby="pool-details-heading" className="space-y-4">
+        <h2 id="pool-details-heading" className="text-2xl font-bold text-slate-950 dark:text-white">
+          Project information
         </h2>
-        <div className="mt-4 grid gap-3 md:grid-cols-3">
-          {surveyHighlights.map((highlight, index) => (
-            <div key={highlight} className="rounded-2xl border border-slate-200 bg-slate-50 p-4">
-              <p className="mb-2 flex h-8 w-8 items-center justify-center rounded-full bg-sky-100 text-sm font-bold text-sky-800">
-                {index + 1}
+        <div className="grid gap-4 lg:grid-cols-3">
+          {infoCards.map((card) => (
+            <details key={card.title} className="group rounded-3xl border border-slate-200 bg-white/85 p-5 shadow-lg shadow-slate-950/5 dark:border-white/10 dark:bg-slate-900/80">
+              <summary className="cursor-pointer list-none">
+                <div className="flex items-start justify-between gap-4">
+                  <div>
+                    <h3 className="text-lg font-bold text-slate-950 dark:text-white">{card.title}</h3>
+                    <p className="mt-3 text-sm leading-6 text-slate-600 dark:text-slate-300">{card.summary}</p>
+                  </div>
+                  <span className="shrink-0 rounded-full border border-sky-200 bg-sky-50 px-3 py-1 text-xs font-semibold text-sky-800 dark:border-sky-300/30 dark:bg-sky-300/10 dark:text-sky-100">
+                    <span className="group-open:hidden">View more</span>
+                    <span className="hidden group-open:inline">Hide details</span>
+                  </span>
+                </div>
+              </summary>
+              <p className="mt-4 border-t border-slate-200 pt-4 text-sm leading-6 text-slate-700 dark:border-white/10 dark:text-slate-200">
+                {card.details}
               </p>
-              <p className="text-sm leading-6 text-slate-700">{highlight}</p>
-            </div>
+            </details>
           ))}
         </div>
-        <div className="mt-5 rounded-2xl border border-amber-200 bg-amber-50 px-5 py-4 text-sm leading-6 text-amber-900">
-          The scan will be refined as more capture data is added.
-        </div>
       </section>
 
-      <section aria-labelledby="pool-models-heading" className="space-y-8">
-        <div className="rounded-3xl bg-white p-5 shadow-lg shadow-slate-950/5 ring-1 ring-slate-200 sm:p-6">
-          <h2 id="pool-models-heading" className="text-2xl font-bold text-slate-950">
-            Interactive pool viewer
+      <section aria-labelledby="pool-gallery-heading" className="space-y-4 pb-4">
+        <div className="max-w-3xl">
+          <h2 id="pool-gallery-heading" className="text-2xl font-bold text-slate-950 dark:text-white">
+            Pool image gallery
           </h2>
-          <p className="mt-2 text-slate-600">
-            Drag to rotate, scroll or pinch to zoom, and pan with Shift-drag, middle-drag, or right-drag to inspect the latest Blender GLB model directly on this page.
+          <p className="mt-2 text-sm leading-6 text-slate-600 dark:text-slate-300">
+            Reference images are included for orientation and remain secondary to the interactive model.
           </p>
         </div>
-
-        <article className="overflow-hidden rounded-[2rem] bg-white p-4 shadow-xl shadow-slate-950/5 ring-1 ring-slate-200 sm:p-6">
-          <div className="mb-5 max-w-3xl">
-            <h3 className="text-xl font-bold text-slate-950">{poolModel.heading}</h3>
-            <p className="mt-2 text-slate-600">{poolModel.description}</p>
-          </div>
-          <PoolModelViewer ariaLabel={poolModel.ariaLabel} />
-        </article>
-      </section>
-
-      <section aria-labelledby="pool-photos-heading" className="space-y-5">
-        <div>
-          <h2 id="pool-photos-heading" className="text-2xl font-bold text-slate-950">
-            Reference photos
-          </h2>
-          <p className="mt-2 text-slate-600">
-            These images show the same pool area from two directions to help orient the 3D scan.
-          </p>
-        </div>
-        <div className="grid gap-6 md:grid-cols-2">
+        <div className="grid gap-4 sm:grid-cols-2 lg:grid-cols-3">
           {poolImages.map((image) => (
-            <figure
-              key={image.src}
-              className="overflow-hidden rounded-3xl bg-white shadow-xl shadow-slate-950/5 ring-1 ring-slate-200"
-            >
-              <div className="relative aspect-[4/3] w-full bg-slate-100">
-                <Image
-                  src={image.src}
-                  alt={image.alt}
-                  fill
-                  sizes="(min-width: 768px) 640px, 100vw"
-                  loading="lazy"
-                  unoptimized
-                  className="object-cover"
-                />
-              </div>
-              <figcaption className="px-5 py-4 text-sm font-medium text-slate-700">
-                {image.caption}
-              </figcaption>
-            </figure>
+            <a key={image.src} href={image.src} target="_blank" rel="noreferrer" className="group overflow-hidden rounded-3xl border border-slate-200 bg-white shadow-lg shadow-slate-950/5 transition hover:-translate-y-0.5 hover:shadow-xl dark:border-white/10 dark:bg-slate-900">
+              <figure>
+                <div className="relative aspect-[4/3] w-full bg-slate-100 dark:bg-slate-800">
+                  <Image src={image.src} alt={image.alt} fill sizes="(min-width: 1024px) 31vw, (min-width: 640px) 48vw, 100vw" loading="lazy" unoptimized className="object-cover transition duration-300 group-hover:scale-[1.03]" />
+                </div>
+                <figcaption className="px-4 py-3 text-sm font-medium text-slate-700 dark:text-slate-200">{image.caption}</figcaption>
+              </figure>
+            </a>
           ))}
         </div>
       </section>

--- a/src/components/PoolModelViewer.tsx
+++ b/src/components/PoolModelViewer.tsx
@@ -2,7 +2,7 @@
 
 import { useEffect, useRef, useState } from 'react';
 
-const MODEL_SRC = '/docs/survey/pool-3D-model-website.glb';
+const MODEL_SRC = '/images/pool/02-edit-floor-plan-pool.glb';
 const MIN_DISTANCE = 3.5;
 const MAX_DISTANCE = 28;
 const START_DISTANCE = 13;
@@ -63,8 +63,8 @@ export default function PoolModelViewer({
 
         app.setCanvasFillMode(pc.FILLMODE_FILL_WINDOW);
         app.setCanvasResolution(pc.RESOLUTION_AUTO);
-        app.scene.ambientLight = new pc.Color(0.35, 0.38, 0.42);
-        app.scene.exposure = 1.15;
+        app.scene.ambientLight = new pc.Color(0.55, 0.62, 0.68);
+        app.scene.exposure = 1.28;
         (app.scene as unknown as { toneMapping: number }).toneMapping = pc.TONEMAP_ACES;
         app.start();
 
@@ -81,7 +81,7 @@ export default function PoolModelViewer({
         keyLight.addComponent('light', {
           type: 'directional',
           color: new pc.Color(1, 0.96, 0.88),
-          intensity: 2.8,
+          intensity: 3.2,
           castShadows: true,
           shadowDistance: 35,
         });
@@ -92,7 +92,7 @@ export default function PoolModelViewer({
         fillLight.addComponent('light', {
           type: 'directional',
           color: new pc.Color(0.55, 0.7, 1),
-          intensity: 1.1,
+          intensity: 1.35,
         });
         fillLight.setEulerAngles(20, -135, 0);
         app.root.addChild(fillLight);
@@ -228,11 +228,27 @@ export default function PoolModelViewer({
           model.name = 'James Square pool model';
           app.root.addChild(model);
 
+          const poolWaterMaterial = new pc.StandardMaterial();
+          poolWaterMaterial.name = 'Pool water blue reference material';
+          poolWaterMaterial.diffuse = new pc.Color(0.02, 0.48, 0.78);
+          poolWaterMaterial.emissive = new pc.Color(0, 0.06, 0.09);
+          poolWaterMaterial.opacity = 0.78;
+          poolWaterMaterial.blendType = pc.BLEND_NORMAL;
+          poolWaterMaterial.useMetalness = true;
+          poolWaterMaterial.metalness = 0;
+          poolWaterMaterial.gloss = 0.85;
+          poolWaterMaterial.update();
+
           const bounds = new pc.BoundingBox();
           let hasBounds = false;
           const renders = model.findComponents('render') as PlayCanvasRenderComponent[];
           renders.forEach((render: PlayCanvasRenderComponent) => {
             render.meshInstances.forEach((meshInstance: PlayCanvasMeshInstance) => {
+              const meshName = `${meshInstance.node?.name ?? ''} ${meshInstance.material?.name ?? ''}`.toLowerCase();
+              if (meshName.includes('waterbody') || meshName.includes('watervolume')) {
+                meshInstance.material = poolWaterMaterial;
+              }
+
               if (!hasBounds) {
                 bounds.copy(meshInstance.aabb);
                 hasBounds = true;
@@ -280,7 +296,7 @@ export default function PoolModelViewer({
 
   return (
     <div className="overflow-hidden rounded-3xl border border-slate-700 bg-slate-950 shadow-2xl shadow-sky-950/20">
-      <div className="relative h-[420px] w-full sm:h-[560px] lg:h-[680px]">
+      <div className="relative h-[520px] w-full sm:h-[640px] lg:h-[760px]">
         <canvas
           ref={canvasRef}
           aria-label={ariaLabel}


### PR DESCRIPTION
### Motivation
- Make the `/pool3d` page model-first and professional so owners, contractors and surveyors can quickly understand the pool layout. 
- Replace the outdated GLB with the most recent model and ensure the pool reads as water (blue) while keeping the existing interactive viewer controls intact. 

### Description
- Reworked the page at `src/app/pool3d/page.tsx` to include a concise hero (`James Square Pool 3D Model`), a closure status badge, the 3D viewer immediately after the hero, a secondary 3D scan walkthrough, compact expandable details cards, and a lazy-loading clickable image gallery sourced from `public/images/pool/`.
- Updated the PlayCanvas viewer in `src/components/PoolModelViewer.tsx` to load `public/images/pool/02-edit-floor-plan-pool.glb`, increased viewer height for prominence, and retained all existing controls (drag/zoom/pan and touch gestures).
- Improved visual presentation by adjusting ambient/exposure and light intensities, and by adding a targeted `poolWaterMaterial` which is applied to mesh instances that identify as pool water (`waterbody`/`watervolume`) so the pool visually appears blue with appropriate gloss/transparency.
- Kept dark/light compatibility and existing styling patterns (glass cards, rounded corners); the text is brief by default with longer content hidden behind `details`/`summary` expandable cards.

### Testing
- Type-check: ran `npx tsc --noEmit` and it completed successfully.
- Full build: attempted `npm run build` but the Next.js production build failed in this environment because Google-hosted Geist fonts could not be fetched from `fonts.gstatic.com`, causing the build step to fail; the failure is environmental and unrelated to the page or viewer logic.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a4b0140352083249f754432fd9abe94)