### PR TITLE
Add scroll-controlled 3D pool hero

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9,6 +9,8 @@
       "version": "0.1.0",
       "dependencies": {
         "@google/genai": "^1.34.0",
+        "@react-three/drei": "^9.122.0",
+        "@react-three/fiber": "^8.18.0",
         "@sendgrid/mail": "^8.1.5",
         "bcryptjs": "^2.4.3",
         "firebase": "^11.6.0",
@@ -25,7 +27,8 @@
         "react-dom": "^18.3.1",
         "react-router-dom": "^7.10.1",
         "recharts": "^3.5.1",
-        "resend": "^4.2.0"
+        "resend": "^4.2.0",
+        "three": "^0.164.1"
       },
       "devDependencies": {
         "@eslint/eslintrc": "^3",
@@ -1596,6 +1599,12 @@
       "engines": {
         "node": ">=6.9.0"
       }
+    },
+    "node_modules/@dimforge/rapier3d-compat": {
+      "version": "0.12.0",
+      "resolved": "https://registry.npmjs.org/@dimforge/rapier3d-compat/-/rapier3d-compat-0.12.0.tgz",
+      "integrity": "sha512-uekIGetywIgopfD97oDL5PfeezkFpNhwlzlaEYNOA0N6ghdsOvh/HYjSMek5Q2O1PYvRSDFcqFVJl4r4ZBwOow==",
+      "license": "Apache-2.0"
     },
     "node_modules/@emnapi/core": {
       "version": "1.5.0",
@@ -3703,6 +3712,24 @@
         "url": "https://opencollective.com/js-sdsl"
       }
     },
+    "node_modules/@mediapipe/tasks-vision": {
+      "version": "0.10.17",
+      "resolved": "https://registry.npmjs.org/@mediapipe/tasks-vision/-/tasks-vision-0.10.17.tgz",
+      "integrity": "sha512-CZWV/q6TTe8ta61cZXjfnnHsfWIdFhms03M9T7Cnd5y2mdpylJM0rF1qRq+wsQVRMLz1OYPVEBU9ph2Bx8cxrg==",
+      "license": "Apache-2.0"
+    },
+    "node_modules/@monogrid/gainmap-js": {
+      "version": "3.4.0",
+      "resolved": "https://registry.npmjs.org/@monogrid/gainmap-js/-/gainmap-js-3.4.0.tgz",
+      "integrity": "sha512-2Z0FATFHaoYJ8b+Y4y4Hgfn3FRFwuU5zRrk+9dFWp4uGAdHGqVEdP7HP+gLA3X469KXHmfupJaUbKo1b/aDKIg==",
+      "license": "MIT",
+      "dependencies": {
+        "promise-worker-transferable": "^1.0.4"
+      },
+      "peerDependencies": {
+        "three": ">= 0.159.0"
+      }
+    },
     "node_modules/@napi-rs/wasm-runtime": {
       "version": "0.2.12",
       "resolved": "https://registry.npmjs.org/@napi-rs/wasm-runtime/-/wasm-runtime-0.2.12.tgz",
@@ -4005,6 +4032,219 @@
       "peerDependencies": {
         "react": "^18.0 || ^19.0 || ^19.0.0-rc",
         "react-dom": "^18.0 || ^19.0 || ^19.0.0-rc"
+      }
+    },
+    "node_modules/@react-spring/animated": {
+      "version": "9.7.5",
+      "resolved": "https://registry.npmjs.org/@react-spring/animated/-/animated-9.7.5.tgz",
+      "integrity": "sha512-Tqrwz7pIlsSDITzxoLS3n/v/YCUHQdOIKtOJf4yL6kYVSDTSmVK1LI1Q3M/uu2Sx4X3pIWF3xLUhlsA6SPNTNg==",
+      "license": "MIT",
+      "dependencies": {
+        "@react-spring/shared": "~9.7.5",
+        "@react-spring/types": "~9.7.5"
+      },
+      "peerDependencies": {
+        "react": "^16.8.0 || ^17.0.0 || ^18.0.0"
+      }
+    },
+    "node_modules/@react-spring/core": {
+      "version": "9.7.5",
+      "resolved": "https://registry.npmjs.org/@react-spring/core/-/core-9.7.5.tgz",
+      "integrity": "sha512-rmEqcxRcu7dWh7MnCcMXLvrf6/SDlSokLaLTxiPlAYi11nN3B5oiCUAblO72o+9z/87j2uzxa2Inm8UbLjXA+w==",
+      "license": "MIT",
+      "dependencies": {
+        "@react-spring/animated": "~9.7.5",
+        "@react-spring/shared": "~9.7.5",
+        "@react-spring/types": "~9.7.5"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/react-spring/donate"
+      },
+      "peerDependencies": {
+        "react": "^16.8.0 || ^17.0.0 || ^18.0.0"
+      }
+    },
+    "node_modules/@react-spring/rafz": {
+      "version": "9.7.5",
+      "resolved": "https://registry.npmjs.org/@react-spring/rafz/-/rafz-9.7.5.tgz",
+      "integrity": "sha512-5ZenDQMC48wjUzPAm1EtwQ5Ot3bLIAwwqP2w2owG5KoNdNHpEJV263nGhCeKKmuA3vG2zLLOdu3or6kuDjA6Aw==",
+      "license": "MIT"
+    },
+    "node_modules/@react-spring/shared": {
+      "version": "9.7.5",
+      "resolved": "https://registry.npmjs.org/@react-spring/shared/-/shared-9.7.5.tgz",
+      "integrity": "sha512-wdtoJrhUeeyD/PP/zo+np2s1Z820Ohr/BbuVYv+3dVLW7WctoiN7std8rISoYoHpUXtbkpesSKuPIw/6U1w1Pw==",
+      "license": "MIT",
+      "dependencies": {
+        "@react-spring/rafz": "~9.7.5",
+        "@react-spring/types": "~9.7.5"
+      },
+      "peerDependencies": {
+        "react": "^16.8.0 || ^17.0.0 || ^18.0.0"
+      }
+    },
+    "node_modules/@react-spring/three": {
+      "version": "9.7.5",
+      "resolved": "https://registry.npmjs.org/@react-spring/three/-/three-9.7.5.tgz",
+      "integrity": "sha512-RxIsCoQfUqOS3POmhVHa1wdWS0wyHAUway73uRLp3GAL5U2iYVNdnzQsep6M2NZ994BlW8TcKuMtQHUqOsy6WA==",
+      "license": "MIT",
+      "dependencies": {
+        "@react-spring/animated": "~9.7.5",
+        "@react-spring/core": "~9.7.5",
+        "@react-spring/shared": "~9.7.5",
+        "@react-spring/types": "~9.7.5"
+      },
+      "peerDependencies": {
+        "@react-three/fiber": ">=6.0",
+        "react": "^16.8.0 || ^17.0.0 || ^18.0.0",
+        "three": ">=0.126"
+      }
+    },
+    "node_modules/@react-spring/types": {
+      "version": "9.7.5",
+      "resolved": "https://registry.npmjs.org/@react-spring/types/-/types-9.7.5.tgz",
+      "integrity": "sha512-HVj7LrZ4ReHWBimBvu2SKND3cDVUPWKLqRTmWe/fNY6o1owGOX0cAHbdPDTMelgBlVbrTKrre6lFkhqGZErK/g==",
+      "license": "MIT"
+    },
+    "node_modules/@react-three/drei": {
+      "version": "9.122.0",
+      "resolved": "https://registry.npmjs.org/@react-three/drei/-/drei-9.122.0.tgz",
+      "integrity": "sha512-SEO/F/rBCTjlLez7WAlpys+iGe9hty4rNgjZvgkQeXFSiwqD4Hbk/wNHMAbdd8vprO2Aj81mihv4dF5bC7D0CA==",
+      "license": "MIT",
+      "dependencies": {
+        "@babel/runtime": "^7.26.0",
+        "@mediapipe/tasks-vision": "0.10.17",
+        "@monogrid/gainmap-js": "^3.0.6",
+        "@react-spring/three": "~9.7.5",
+        "@use-gesture/react": "^10.3.1",
+        "camera-controls": "^2.9.0",
+        "cross-env": "^7.0.3",
+        "detect-gpu": "^5.0.56",
+        "glsl-noise": "^0.0.0",
+        "hls.js": "^1.5.17",
+        "maath": "^0.10.8",
+        "meshline": "^3.3.1",
+        "react-composer": "^5.0.3",
+        "stats-gl": "^2.2.8",
+        "stats.js": "^0.17.0",
+        "suspend-react": "^0.1.3",
+        "three-mesh-bvh": "^0.7.8",
+        "three-stdlib": "^2.35.6",
+        "troika-three-text": "^0.52.0",
+        "tunnel-rat": "^0.1.2",
+        "utility-types": "^3.11.0",
+        "zustand": "^5.0.1"
+      },
+      "peerDependencies": {
+        "@react-three/fiber": "^8",
+        "react": "^18",
+        "react-dom": "^18",
+        "three": ">=0.137"
+      },
+      "peerDependenciesMeta": {
+        "react-dom": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@react-three/fiber": {
+      "version": "8.18.0",
+      "resolved": "https://registry.npmjs.org/@react-three/fiber/-/fiber-8.18.0.tgz",
+      "integrity": "sha512-FYZZqD0UUHUswKz3LQl2Z7H24AhD14XGTsIRw3SJaXUxyfVMi+1yiZGmqTcPt/CkPpdU7rrxqcyQ1zJE5DjvIQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@babel/runtime": "^7.17.8",
+        "@types/react-reconciler": "^0.26.7",
+        "@types/webxr": "*",
+        "base64-js": "^1.5.1",
+        "buffer": "^6.0.3",
+        "its-fine": "^1.0.6",
+        "react-reconciler": "^0.27.0",
+        "react-use-measure": "^2.1.7",
+        "scheduler": "^0.21.0",
+        "suspend-react": "^0.1.3",
+        "zustand": "^3.7.1"
+      },
+      "peerDependencies": {
+        "expo": ">=43.0",
+        "expo-asset": ">=8.4",
+        "expo-file-system": ">=11.0",
+        "expo-gl": ">=11.0",
+        "react": ">=18 <19",
+        "react-dom": ">=18 <19",
+        "react-native": ">=0.64",
+        "three": ">=0.133"
+      },
+      "peerDependenciesMeta": {
+        "expo": {
+          "optional": true
+        },
+        "expo-asset": {
+          "optional": true
+        },
+        "expo-file-system": {
+          "optional": true
+        },
+        "expo-gl": {
+          "optional": true
+        },
+        "react-dom": {
+          "optional": true
+        },
+        "react-native": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@react-three/fiber/node_modules/buffer": {
+      "version": "6.0.3",
+      "resolved": "https://registry.npmjs.org/buffer/-/buffer-6.0.3.tgz",
+      "integrity": "sha512-FTiCpNxtwiZZHEZbcbTIcZjERVICn9yq/pDFkTl95/AxzD1naBctN7YO68riM/gLSDY7sdrMby8hofADYuuqOA==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "base64-js": "^1.3.1",
+        "ieee754": "^1.2.1"
+      }
+    },
+    "node_modules/@react-three/fiber/node_modules/scheduler": {
+      "version": "0.21.0",
+      "resolved": "https://registry.npmjs.org/scheduler/-/scheduler-0.21.0.tgz",
+      "integrity": "sha512-1r87x5fz9MXqswA2ERLo0EbOAU74DpIUO090gIasYTqlVoJeMcl+Z1Rg7WHz+qtPujhS/hGIt9kxZOYBV3faRQ==",
+      "license": "MIT",
+      "dependencies": {
+        "loose-envify": "^1.1.0"
+      }
+    },
+    "node_modules/@react-three/fiber/node_modules/zustand": {
+      "version": "3.7.2",
+      "resolved": "https://registry.npmjs.org/zustand/-/zustand-3.7.2.tgz",
+      "integrity": "sha512-PIJDIZKtokhof+9+60cpockVOq05sJzHCriyvaLBmEJixseQ1a5Kdov6fWZfWOu5SK9c+FhH1jU0tntLxRJYMA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=12.7.0"
+      },
+      "peerDependencies": {
+        "react": ">=16.8"
+      },
+      "peerDependenciesMeta": {
+        "react": {
+          "optional": true
+        }
       }
     },
     "node_modules/@reduxjs/toolkit": {
@@ -4763,6 +5003,12 @@
         "node": ">= 10"
       }
     },
+    "node_modules/@tweenjs/tween.js": {
+      "version": "23.1.3",
+      "resolved": "https://registry.npmjs.org/@tweenjs/tween.js/-/tween.js-23.1.3.tgz",
+      "integrity": "sha512-vJmvvwFxYuGnF2axRtPYocag6Clbb5YS7kLL+SO/TeVFzHqDIWrNKYtcsPMibjDx9O+bu+psAy9NKfWklassUA==",
+      "license": "MIT"
+    },
     "node_modules/@tybys/wasm-util": {
       "version": "0.10.1",
       "resolved": "https://registry.npmjs.org/@tybys/wasm-util/-/wasm-util-0.10.1.tgz",
@@ -4917,6 +5163,12 @@
       "integrity": "sha512-Ps3T8E8dZDam6fUyNiMkekK3XUsaUEik+idO9/YjPtfj2qruF8tFBXS7XhtE4iIXBLxhmLjP3SXpLhVf21I9Lw==",
       "license": "MIT"
     },
+    "node_modules/@types/draco3d": {
+      "version": "1.4.10",
+      "resolved": "https://registry.npmjs.org/@types/draco3d/-/draco3d-1.4.10.tgz",
+      "integrity": "sha512-AX22jp8Y7wwaBgAixaSvkoG4M/+PlAcm3Qs4OW8yT9DM4xUpWKeFhLueTAyZF39pviAdcDdeJoACapiAceqNcw==",
+      "license": "MIT"
+    },
     "node_modules/@types/eslint": {
       "version": "9.6.1",
       "resolved": "https://registry.npmjs.org/@types/eslint/-/eslint-9.6.1.tgz",
@@ -5049,6 +5301,12 @@
         "undici-types": "~6.21.0"
       }
     },
+    "node_modules/@types/offscreencanvas": {
+      "version": "2019.7.3",
+      "resolved": "https://registry.npmjs.org/@types/offscreencanvas/-/offscreencanvas-2019.7.3.tgz",
+      "integrity": "sha512-ieXiYmgSRXUDeOntE1InxjWyvEelZGP63M+cGuquuRLuIKKT1osnkXjxev9B7d1nXSug5vpunx+gNlbVxMlC9A==",
+      "license": "MIT"
+    },
     "node_modules/@types/qs": {
       "version": "6.14.0",
       "resolved": "https://registry.npmjs.org/@types/qs/-/qs-6.14.0.tgz",
@@ -5065,7 +5323,6 @@
       "version": "19.1.13",
       "resolved": "https://registry.npmjs.org/@types/react/-/react-19.1.13.tgz",
       "integrity": "sha512-hHkbU/eoO3EG5/MZkuFSKmYqPbSVk5byPFa3e7y/8TybHiLMACgI8seVYlicwk7H5K/rI2px9xrQp/C+AUDTiQ==",
-      "devOptional": true,
       "license": "MIT",
       "dependencies": {
         "csstype": "^3.0.2"
@@ -5079,6 +5336,15 @@
       "license": "MIT",
       "peerDependencies": {
         "@types/react": "^19.0.0"
+      }
+    },
+    "node_modules/@types/react-reconciler": {
+      "version": "0.26.7",
+      "resolved": "https://registry.npmjs.org/@types/react-reconciler/-/react-reconciler-0.26.7.tgz",
+      "integrity": "sha512-mBDYl8x+oyPX/VBb3E638N0B7xG+SPk/EAMcVPeexqus/5aTpTphQi0curhhshOqRrc9t6OPoJfEUkbymse/lQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/react": "*"
       }
     },
     "node_modules/@types/request": {
@@ -5140,6 +5406,26 @@
         "@types/http-errors": "*",
         "@types/node": "*",
         "@types/send": "*"
+      }
+    },
+    "node_modules/@types/stats.js": {
+      "version": "0.17.4",
+      "resolved": "https://registry.npmjs.org/@types/stats.js/-/stats.js-0.17.4.tgz",
+      "integrity": "sha512-jIBvWWShCvlBqBNIZt0KAshWpvSjhkwkEu4ZUcASoAvhmrgAUI2t1dXrjSL4xXVLB4FznPrIsX3nKXFl/Dt4vA==",
+      "license": "MIT"
+    },
+    "node_modules/@types/three": {
+      "version": "0.185.0",
+      "resolved": "https://registry.npmjs.org/@types/three/-/three-0.185.0.tgz",
+      "integrity": "sha512-O2Uy8Cj4Nonr8dWUUbifMdPe8B0Mq7EdOHb89S4+kjUw/KhbjTZrUuYlrQ1bpUKG+EP9QJnN7qNxbHGlGoLHMA==",
+      "license": "MIT",
+      "dependencies": {
+        "@dimforge/rapier3d-compat": "~0.12.0",
+        "@tweenjs/tween.js": "~23.1.3",
+        "@types/stats.js": "*",
+        "@types/webxr": ">=0.5.17",
+        "fflate": "~0.8.2",
+        "meshoptimizer": "~1.1.1"
       }
     },
     "node_modules/@types/tough-cookie": {
@@ -5723,6 +6009,24 @@
       "os": [
         "win32"
       ]
+    },
+    "node_modules/@use-gesture/core": {
+      "version": "10.3.1",
+      "resolved": "https://registry.npmjs.org/@use-gesture/core/-/core-10.3.1.tgz",
+      "integrity": "sha512-WcINiDt8WjqBdUXye25anHiNxPc0VOrlT8F6LLkU6cycrOGUDyY/yyFmsg3k8i5OLvv25llc0QC45GhR/C8llw==",
+      "license": "MIT"
+    },
+    "node_modules/@use-gesture/react": {
+      "version": "10.3.1",
+      "resolved": "https://registry.npmjs.org/@use-gesture/react/-/react-10.3.1.tgz",
+      "integrity": "sha512-Yy19y6O2GJq8f7CHf7L0nxL8bf4PZCPaVOCgJrusOeFHY1LvHgYXnmnXg6N5iwAnbgbZCDjo60SiM6IPJi9C5g==",
+      "license": "MIT",
+      "dependencies": {
+        "@use-gesture/core": "10.3.1"
+      },
+      "peerDependencies": {
+        "react": ">= 16.8.0"
+      }
     },
     "node_modules/@vitejs/plugin-react": {
       "version": "5.1.2",
@@ -6532,6 +6836,15 @@
       "integrity": "sha512-V/Hy/X9Vt7f3BbPJEi8BdVFMByHi+jNXrYkW3huaybV/kQ0KJg0Y6PkEMbn+zeT+i+SiKZ/HMqJGIIt4LZDqNQ==",
       "license": "MIT"
     },
+    "node_modules/bidi-js": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/bidi-js/-/bidi-js-1.0.3.tgz",
+      "integrity": "sha512-RKshQI1R3YQ+n9YJz2QQ147P66ELpa1FQEg20Dk8oW9t2KgLbpDLLp9aGZ7y8WHSshDknG0bknqGw5/tyCs5tw==",
+      "license": "MIT",
+      "dependencies": {
+        "require-from-string": "^2.0.2"
+      }
+    },
     "node_modules/big.js": {
       "version": "5.2.2",
       "resolved": "https://registry.npmjs.org/big.js/-/big.js-5.2.2.tgz",
@@ -6769,6 +7082,15 @@
       "license": "MIT",
       "engines": {
         "node": ">=6"
+      }
+    },
+    "node_modules/camera-controls": {
+      "version": "2.10.1",
+      "resolved": "https://registry.npmjs.org/camera-controls/-/camera-controls-2.10.1.tgz",
+      "integrity": "sha512-KnaKdcvkBJ1Irbrzl8XD6WtZltkRjp869Jx8c0ujs9K+9WD+1D7ryBsCiVqJYUqt6i/HR5FxT7RLASieUD+Q5w==",
+      "license": "MIT",
+      "peerDependencies": {
+        "three": ">=0.126.1"
       }
     },
     "node_modules/caniuse-lite": {
@@ -7012,6 +7334,24 @@
         "node": ">= 0.10"
       }
     },
+    "node_modules/cross-env": {
+      "version": "7.0.3",
+      "resolved": "https://registry.npmjs.org/cross-env/-/cross-env-7.0.3.tgz",
+      "integrity": "sha512-+/HKd6EgcQCJGh2PSjZuUitQBQynKor4wrFbRg4DtAgS1aWO+gU52xpH7M9ScGgXSYmAVS9bIJ8EzuaGw0oNAw==",
+      "license": "MIT",
+      "dependencies": {
+        "cross-spawn": "^7.0.1"
+      },
+      "bin": {
+        "cross-env": "src/bin/cross-env.js",
+        "cross-env-shell": "src/bin/cross-env-shell.js"
+      },
+      "engines": {
+        "node": ">=10.14",
+        "npm": ">=6",
+        "yarn": ">=1"
+      }
+    },
     "node_modules/cross-spawn": {
       "version": "7.0.6",
       "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-7.0.6.tgz",
@@ -7039,7 +7379,6 @@
       "version": "3.1.3",
       "resolved": "https://registry.npmjs.org/csstype/-/csstype-3.1.3.tgz",
       "integrity": "sha512-M1uQkMl8rQK/szD0LNhtqxIPLpimGm8sOBwU7lLnCpSbTyY3yeU1Vc7l4KT5zT4s/yOxHH5O7tIuuLOCnLADRw==",
-      "devOptional": true,
       "license": "MIT"
     },
     "node_modules/d3-array": {
@@ -7446,6 +7785,15 @@
         "npm": "1.2.8000 || >= 1.4.16"
       }
     },
+    "node_modules/detect-gpu": {
+      "version": "5.0.70",
+      "resolved": "https://registry.npmjs.org/detect-gpu/-/detect-gpu-5.0.70.tgz",
+      "integrity": "sha512-bqerEP1Ese6nt3rFkwPnGbsUF9a4q+gMmpTVVOEzoCyeCc+y7/RvJnQZJx1JwhgQI5Ntg0Kgat8Uu7XpBqnz1w==",
+      "license": "MIT",
+      "dependencies": {
+        "webgl-constants": "^1.1.1"
+      }
+    },
     "node_modules/detect-libc": {
       "version": "2.1.1",
       "resolved": "https://registry.npmjs.org/detect-libc/-/detect-libc-2.1.1.tgz",
@@ -7535,6 +7883,12 @@
       "funding": {
         "url": "https://github.com/fb55/domutils?sponsor=1"
       }
+    },
+    "node_modules/draco3d": {
+      "version": "1.5.7",
+      "resolved": "https://registry.npmjs.org/draco3d/-/draco3d-1.5.7.tgz",
+      "integrity": "sha512-m6WCKt/erDXcw+70IJXnG7M3awwQPAsZvJGX5zY7beBqpELw6RDGkYVU0W43AFxye4pDZ5i2Lbyc/NNGqwjUVQ==",
+      "license": "Apache-2.0"
     },
     "node_modules/dunder-proto": {
       "version": "1.0.1",
@@ -8598,6 +8952,12 @@
         "node": "^12.20 || >= 14.13"
       }
     },
+    "node_modules/fflate": {
+      "version": "0.8.3",
+      "resolved": "https://registry.npmjs.org/fflate/-/fflate-0.8.3.tgz",
+      "integrity": "sha512-tbZNuJrLwGUp3zshBtdy4W+ORxZuIh8a5ilyIEQDC5rY1f3U20JMry0Ll3WBzU58EZKsEuJFXhb5gwv8CsPvgA==",
+      "license": "MIT"
+    },
     "node_modules/file-entry-cache": {
       "version": "8.0.0",
       "resolved": "https://registry.npmjs.org/file-entry-cache/-/file-entry-cache-8.0.0.tgz",
@@ -9337,6 +9697,12 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/glsl-noise": {
+      "version": "0.0.0",
+      "resolved": "https://registry.npmjs.org/glsl-noise/-/glsl-noise-0.0.0.tgz",
+      "integrity": "sha512-b/ZCF6amfAUb7dJM/MxRs7AetQEahYzJ8PtgfrmEdtw6uyGOr+ZSGtgjFm6mfsBkxJ4d2W7kg+Nlqzqvn3Bc0w==",
+      "license": "MIT"
+    },
     "node_modules/google-auth-library": {
       "version": "9.15.1",
       "resolved": "https://registry.npmjs.org/google-auth-library/-/google-auth-library-9.15.1.tgz",
@@ -9559,6 +9925,12 @@
         "node": ">= 0.4"
       }
     },
+    "node_modules/hls.js": {
+      "version": "1.6.16",
+      "resolved": "https://registry.npmjs.org/hls.js/-/hls.js-1.6.16.tgz",
+      "integrity": "sha512-VSIRpLfRwlAAdGL4wiTucx2ScRipo0ed1FBatWkyt832jC4CReKstga6yIhYVwGu9LOBjuX9wzmRMeQdBJtzEA==",
+      "license": "Apache-2.0"
+    },
     "node_modules/html-entities": {
       "version": "2.6.0",
       "resolved": "https://registry.npmjs.org/html-entities/-/html-entities-2.6.0.tgz",
@@ -9721,8 +10093,7 @@
           "url": "https://feross.org/support"
         }
       ],
-      "license": "BSD-3-Clause",
-      "optional": true
+      "license": "BSD-3-Clause"
     },
     "node_modules/ignore": {
       "version": "5.3.2",
@@ -9732,6 +10103,12 @@
       "engines": {
         "node": ">= 4"
       }
+    },
+    "node_modules/immediate": {
+      "version": "3.0.6",
+      "resolved": "https://registry.npmjs.org/immediate/-/immediate-3.0.6.tgz",
+      "integrity": "sha512-XXOFtyqDjNDAQxVfYxuF7g9Il/IbWmmlQg2MYKOH8ExIT1qg6xc4zyS3HaEEATgs1btfzxq15ciUiY7gjSXRGQ==",
+      "license": "MIT"
     },
     "node_modules/immer": {
       "version": "10.2.0",
@@ -10123,6 +10500,12 @@
         "node": ">=6"
       }
     },
+    "node_modules/is-promise": {
+      "version": "2.2.2",
+      "resolved": "https://registry.npmjs.org/is-promise/-/is-promise-2.2.2.tgz",
+      "integrity": "sha512-+lP4/6lKUBfQjZ2pdxThZvLUAafmZb8OAxFb8XXtiQmS35INgr85hdOGoEs124ez1FCnZJt6jau/T+alh58QFQ==",
+      "license": "MIT"
+    },
     "node_modules/is-regex": {
       "version": "1.2.1",
       "resolved": "https://registry.npmjs.org/is-regex/-/is-regex-1.2.1.tgz",
@@ -10308,6 +10691,27 @@
       },
       "engines": {
         "node": ">= 0.4"
+      }
+    },
+    "node_modules/its-fine": {
+      "version": "1.2.5",
+      "resolved": "https://registry.npmjs.org/its-fine/-/its-fine-1.2.5.tgz",
+      "integrity": "sha512-fXtDA0X0t0eBYAGLVM5YsgJGsJ5jEmqZEPrGbzdf5awjv0xE7nqv3TVnvtUF060Tkes15DbDAKW/I48vsb6SyA==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/react-reconciler": "^0.28.0"
+      },
+      "peerDependencies": {
+        "react": ">=18.0"
+      }
+    },
+    "node_modules/its-fine/node_modules/@types/react-reconciler": {
+      "version": "0.28.9",
+      "resolved": "https://registry.npmjs.org/@types/react-reconciler/-/react-reconciler-0.28.9.tgz",
+      "integrity": "sha512-HHM3nxyUZ3zAylX8ZEyrDNd2XZOnQ0D5XfunJF5FLQnZbHHYq4UWvW1QfelQNXv1ICNkwYhfxjwfnqivYB6bFg==",
+      "license": "MIT",
+      "peerDependencies": {
+        "@types/react": "*"
       }
     },
     "node_modules/jackspeak": {
@@ -10654,6 +11058,15 @@
       },
       "engines": {
         "node": ">= 0.8.0"
+      }
+    },
+    "node_modules/lie": {
+      "version": "3.3.0",
+      "resolved": "https://registry.npmjs.org/lie/-/lie-3.3.0.tgz",
+      "integrity": "sha512-UaiMJzeWRlEujzAuw5LokY1L5ecNQYZKfmyZ9L7wDHb/p5etKaxXhohBcrw0EYby+G/NA52vRSN4N39dxHAIwQ==",
+      "license": "MIT",
+      "dependencies": {
+        "immediate": "~3.0.5"
       }
     },
     "node_modules/lightningcss": {
@@ -11093,6 +11506,16 @@
         "node": ">=12"
       }
     },
+    "node_modules/maath": {
+      "version": "0.10.8",
+      "resolved": "https://registry.npmjs.org/maath/-/maath-0.10.8.tgz",
+      "integrity": "sha512-tRvbDF0Pgqz+9XUa4jjfgAQ8/aPKmQdWXilFu2tMy4GWj4NOsx99HlULO4IeREfbO3a0sA145DZYyvXPkybm0g==",
+      "license": "MIT",
+      "peerDependencies": {
+        "@types/three": ">=0.134.0",
+        "three": ">=0.134.0"
+      }
+    },
     "node_modules/magic-string": {
       "version": "0.30.19",
       "resolved": "https://registry.npmjs.org/magic-string/-/magic-string-0.30.19.tgz",
@@ -11168,6 +11591,21 @@
       "engines": {
         "node": ">= 8"
       }
+    },
+    "node_modules/meshline": {
+      "version": "3.3.1",
+      "resolved": "https://registry.npmjs.org/meshline/-/meshline-3.3.1.tgz",
+      "integrity": "sha512-/TQj+JdZkeSUOl5Mk2J7eLcYTLiQm2IDzmlSvYm7ov15anEcDJ92GHqqazxTSreeNgfnYu24kiEvvv0WlbCdFQ==",
+      "license": "MIT",
+      "peerDependencies": {
+        "three": ">=0.137"
+      }
+    },
+    "node_modules/meshoptimizer": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/meshoptimizer/-/meshoptimizer-1.1.1.tgz",
+      "integrity": "sha512-oRFNWJRDA/WTrVj7NWvqa5HqE1t9MYDj2VaWirQCzCCrAd2GHrqR/sQezCxiWATPNlKTcRaPRHPJwIRoPBAp5g==",
+      "license": "MIT"
     },
     "node_modules/methods": {
       "version": "1.1.2",
@@ -12090,6 +12528,12 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/potpack": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/potpack/-/potpack-1.0.2.tgz",
+      "integrity": "sha512-choctRBIV9EMT9WGAZHn3V7t0Z2pMQyl0EZE6pFc/6ml3ssw7Dlf/oAOvFwjm1HVsqfQN8GfeFyJ+d8tRzqueQ==",
+      "license": "ISC"
+    },
     "node_modules/prebuild-install": {
       "version": "7.1.3",
       "resolved": "https://registry.npmjs.org/prebuild-install/-/prebuild-install-7.1.3.tgz",
@@ -12155,11 +12599,20 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/promise-worker-transferable": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/promise-worker-transferable/-/promise-worker-transferable-1.0.4.tgz",
+      "integrity": "sha512-bN+0ehEnrXfxV2ZQvU2PetO0n4gqBD4ulq3MI1WOPLgr7/Mg9yRQkX5+0v1vagr74ZTsl7XtzlaYDo2EuCeYJw==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "is-promise": "^2.1.0",
+        "lie": "^3.0.2"
+      }
+    },
     "node_modules/prop-types": {
       "version": "15.8.1",
       "resolved": "https://registry.npmjs.org/prop-types/-/prop-types-15.8.1.tgz",
       "integrity": "sha512-oj87CgZICdulUohogVAR7AjlC0327U4el4L6eAvOqCeudMDVU0NThNaV+b9Df4dXgSP1gXMTnPdhfe/2qDH5cg==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "loose-envify": "^1.4.0",
@@ -12355,6 +12808,18 @@
         "node": ">=0.10.0"
       }
     },
+    "node_modules/react-composer": {
+      "version": "5.0.3",
+      "resolved": "https://registry.npmjs.org/react-composer/-/react-composer-5.0.3.tgz",
+      "integrity": "sha512-1uWd07EME6XZvMfapwZmc7NgCZqDemcvicRi3wMJzXsQLvZ3L7fTHVyPy1bZdnWXM4iPjYuNE+uJ41MLKeTtnA==",
+      "license": "MIT",
+      "dependencies": {
+        "prop-types": "^15.6.0"
+      },
+      "peerDependencies": {
+        "react": "^15.0.0 || ^16.0.0 || ^17.0.0 || ^18.0.0"
+      }
+    },
     "node_modules/react-dom": {
       "version": "18.3.1",
       "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-18.3.1.tgz",
@@ -12388,6 +12853,31 @@
       "resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-2.0.1.tgz",
       "integrity": "sha512-bCK/2Z4zLidyB4ReuIsvALH6w31YfAQDmXMqMx6FyfHqvBxtjC0eRumeSu4Bs3XtXwpyIywtSTrVT99BxY1f9w==",
       "license": "MIT"
+    },
+    "node_modules/react-reconciler": {
+      "version": "0.27.0",
+      "resolved": "https://registry.npmjs.org/react-reconciler/-/react-reconciler-0.27.0.tgz",
+      "integrity": "sha512-HmMDKciQjYmBRGuuhIaKA1ba/7a+UsM5FzOZsMO2JYHt9Jh8reCb7j1eDC95NOyUlKM9KRyvdx0flBuDvYSBoA==",
+      "license": "MIT",
+      "dependencies": {
+        "loose-envify": "^1.1.0",
+        "scheduler": "^0.21.0"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      },
+      "peerDependencies": {
+        "react": "^18.0.0"
+      }
+    },
+    "node_modules/react-reconciler/node_modules/scheduler": {
+      "version": "0.21.0",
+      "resolved": "https://registry.npmjs.org/scheduler/-/scheduler-0.21.0.tgz",
+      "integrity": "sha512-1r87x5fz9MXqswA2ERLo0EbOAU74DpIUO090gIasYTqlVoJeMcl+Z1Rg7WHz+qtPujhS/hGIt9kxZOYBV3faRQ==",
+      "license": "MIT",
+      "dependencies": {
+        "loose-envify": "^1.1.0"
+      }
     },
     "node_modules/react-redux": {
       "version": "9.2.0",
@@ -12471,6 +12961,21 @@
       "funding": {
         "type": "opencollective",
         "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/react-use-measure": {
+      "version": "2.1.7",
+      "resolved": "https://registry.npmjs.org/react-use-measure/-/react-use-measure-2.1.7.tgz",
+      "integrity": "sha512-KrvcAo13I/60HpwGO5jpW7E9DfusKyLPLvuHlUyP5zqnmAPhNc6qTRjUQrdTADl0lpPpDVU2/Gg51UlOGHXbdg==",
+      "license": "MIT",
+      "peerDependencies": {
+        "react": ">=16.13",
+        "react-dom": ">=16.13"
+      },
+      "peerDependenciesMeta": {
+        "react-dom": {
+          "optional": true
+        }
       }
     },
     "node_modules/readable-stream": {
@@ -13348,6 +13853,32 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/stats-gl": {
+      "version": "2.4.2",
+      "resolved": "https://registry.npmjs.org/stats-gl/-/stats-gl-2.4.2.tgz",
+      "integrity": "sha512-g5O9B0hm9CvnM36+v7SFl39T7hmAlv541tU81ME8YeSb3i1CIP5/QdDeSB3A0la0bKNHpxpwxOVRo2wFTYEosQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/three": "*",
+        "three": "^0.170.0"
+      },
+      "peerDependencies": {
+        "@types/three": "*",
+        "three": "*"
+      }
+    },
+    "node_modules/stats-gl/node_modules/three": {
+      "version": "0.170.0",
+      "resolved": "https://registry.npmjs.org/three/-/three-0.170.0.tgz",
+      "integrity": "sha512-FQK+LEpYc0fBD+J8g6oSEyyNzjp+Q7Ks1C568WWaoMRLW+TkNNWmenWeGgJjV105Gd+p/2ql1ZcjYvNiPZBhuQ==",
+      "license": "MIT"
+    },
+    "node_modules/stats.js": {
+      "version": "0.17.0",
+      "resolved": "https://registry.npmjs.org/stats.js/-/stats.js-0.17.0.tgz",
+      "integrity": "sha512-hNKz8phvYLPEcRkeG1rsGmV5ChMjKDAWU7/OJJdDErPBNChQXxCo3WZurGpnWc6gZhAzEPFad1aVgyOANH1sMw==",
+      "license": "MIT"
+    },
     "node_modules/statuses": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/statuses/-/statuses-2.0.1.tgz",
@@ -13685,6 +14216,15 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/suspend-react": {
+      "version": "0.1.3",
+      "resolved": "https://registry.npmjs.org/suspend-react/-/suspend-react-0.1.3.tgz",
+      "integrity": "sha512-aqldKgX9aZqpoDp3e8/BZ8Dm7x1pJl+qI3ZKxDN0i/IQTWUwBx/ManmlVJ3wowqbno6c2bmiIfs+Um6LbsjJyQ==",
+      "license": "MIT",
+      "peerDependencies": {
+        "react": ">=17.0"
+      }
+    },
     "node_modules/tailwindcss": {
       "version": "4.1.13",
       "resolved": "https://registry.npmjs.org/tailwindcss/-/tailwindcss-4.1.13.tgz",
@@ -13971,6 +14511,45 @@
         "url": "https://opencollective.com/webpack"
       }
     },
+    "node_modules/three": {
+      "version": "0.164.1",
+      "resolved": "https://registry.npmjs.org/three/-/three-0.164.1.tgz",
+      "integrity": "sha512-iC/hUBbl1vzFny7f5GtqzVXYjMJKaTPxiCxXfrvVdBi1Sf+jhd1CAkitiFwC7mIBFCo3MrDLJG97yisoaWig0w==",
+      "license": "MIT"
+    },
+    "node_modules/three-mesh-bvh": {
+      "version": "0.7.8",
+      "resolved": "https://registry.npmjs.org/three-mesh-bvh/-/three-mesh-bvh-0.7.8.tgz",
+      "integrity": "sha512-BGEZTOIC14U0XIRw3tO4jY7IjP7n7v24nv9JXS1CyeVRWOCkcOMhRnmENUjuV39gktAw4Ofhr0OvIAiTspQrrw==",
+      "deprecated": "Deprecated due to three.js version incompatibility. Please use v0.8.0, instead.",
+      "license": "MIT",
+      "peerDependencies": {
+        "three": ">= 0.151.0"
+      }
+    },
+    "node_modules/three-stdlib": {
+      "version": "2.36.1",
+      "resolved": "https://registry.npmjs.org/three-stdlib/-/three-stdlib-2.36.1.tgz",
+      "integrity": "sha512-XyGQrFmNQ5O/IoKm556ftwKsBg11TIb301MB5dWNicziQBEs2g3gtOYIf7pFiLa0zI2gUwhtCjv9fmjnxKZ1Cg==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/draco3d": "^1.4.0",
+        "@types/offscreencanvas": "^2019.6.4",
+        "@types/webxr": "^0.5.2",
+        "draco3d": "^1.4.1",
+        "fflate": "^0.6.9",
+        "potpack": "^1.0.1"
+      },
+      "peerDependencies": {
+        "three": ">=0.128.0"
+      }
+    },
+    "node_modules/three-stdlib/node_modules/fflate": {
+      "version": "0.6.10",
+      "resolved": "https://registry.npmjs.org/fflate/-/fflate-0.6.10.tgz",
+      "integrity": "sha512-IQrh3lEPM93wVCEczc9SaAOvkmcoQn/G8Bo1e8ZPlY3X3bnAxWaBdvTdvM1hP62iZp0BXWDy4vTAy4fF0+Dlpg==",
+      "license": "MIT"
+    },
     "node_modules/tiny-case": {
       "version": "1.0.3",
       "resolved": "https://registry.npmjs.org/tiny-case/-/tiny-case-1.0.3.tgz",
@@ -14064,6 +14643,36 @@
       "integrity": "sha512-N3WMsuqV66lT30CrXNbEjx4GEwlow3v6rr4mCcv6prnfwhS01rkgyFdjPNBYd9br7LpXV1+Emh01fHnq2Gdgrw==",
       "license": "MIT"
     },
+    "node_modules/troika-three-text": {
+      "version": "0.52.4",
+      "resolved": "https://registry.npmjs.org/troika-three-text/-/troika-three-text-0.52.4.tgz",
+      "integrity": "sha512-V50EwcYGruV5rUZ9F4aNsrytGdKcXKALjEtQXIOBfhVoZU9VAqZNIoGQ3TMiooVqFAbR1w15T+f+8gkzoFzawg==",
+      "license": "MIT",
+      "dependencies": {
+        "bidi-js": "^1.0.2",
+        "troika-three-utils": "^0.52.4",
+        "troika-worker-utils": "^0.52.0",
+        "webgl-sdf-generator": "1.1.1"
+      },
+      "peerDependencies": {
+        "three": ">=0.125.0"
+      }
+    },
+    "node_modules/troika-three-utils": {
+      "version": "0.52.4",
+      "resolved": "https://registry.npmjs.org/troika-three-utils/-/troika-three-utils-0.52.4.tgz",
+      "integrity": "sha512-NORAStSVa/BDiG52Mfudk4j1FG4jC4ILutB3foPnfGbOeIs9+G5vZLa0pnmnaftZUGm4UwSoqEpWdqvC7zms3A==",
+      "license": "MIT",
+      "peerDependencies": {
+        "three": ">=0.125.0"
+      }
+    },
+    "node_modules/troika-worker-utils": {
+      "version": "0.52.0",
+      "resolved": "https://registry.npmjs.org/troika-worker-utils/-/troika-worker-utils-0.52.0.tgz",
+      "integrity": "sha512-W1CpvTHykaPH5brv5VHLfQo9D1OYuo0cSBEUQFFT/nBUzM8iD6Lq2/tgG/f1OelbAS1WtaTPQzE5uM49egnngw==",
+      "license": "MIT"
+    },
     "node_modules/ts-api-utils": {
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/ts-api-utils/-/ts-api-utils-2.1.0.tgz",
@@ -14107,6 +14716,43 @@
       },
       "engines": {
         "node": "*"
+      }
+    },
+    "node_modules/tunnel-rat": {
+      "version": "0.1.2",
+      "resolved": "https://registry.npmjs.org/tunnel-rat/-/tunnel-rat-0.1.2.tgz",
+      "integrity": "sha512-lR5VHmkPhzdhrM092lI2nACsLO4QubF0/yoOhzX7c+wIpbN1GjHNzCc91QlpxBi+cnx8vVJ+Ur6vL5cEoQPFpQ==",
+      "license": "MIT",
+      "dependencies": {
+        "zustand": "^4.3.2"
+      }
+    },
+    "node_modules/tunnel-rat/node_modules/zustand": {
+      "version": "4.5.7",
+      "resolved": "https://registry.npmjs.org/zustand/-/zustand-4.5.7.tgz",
+      "integrity": "sha512-CHOUy7mu3lbD6o6LJLfllpjkzhHXSBlX8B9+qPddUsIfeF5S/UZ5q0kmCsnRqT1UHFQZchNFDDzMbQsuesHWlw==",
+      "license": "MIT",
+      "dependencies": {
+        "use-sync-external-store": "^1.2.2"
+      },
+      "engines": {
+        "node": ">=12.7.0"
+      },
+      "peerDependencies": {
+        "@types/react": ">=16.8",
+        "immer": ">=9.0.6",
+        "react": ">=16.8"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "immer": {
+          "optional": true
+        },
+        "react": {
+          "optional": true
+        }
       }
     },
     "node_modules/type-check": {
@@ -14429,6 +15075,15 @@
       "license": "MIT",
       "optional": true
     },
+    "node_modules/utility-types": {
+      "version": "3.11.0",
+      "resolved": "https://registry.npmjs.org/utility-types/-/utility-types-3.11.0.tgz",
+      "integrity": "sha512-6Z7Ma2aVEWisaL6TvBCy7P8rm2LQoPv6dJ7ecIaIixHcwfbJ0x7mWdbcwlIM5IGQxPZSFYeqRCqlOOeKoJYMkw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 4"
+      }
+    },
     "node_modules/utils-merge": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/utils-merge/-/utils-merge-1.0.1.tgz",
@@ -14616,6 +15271,17 @@
       "resolved": "https://registry.npmjs.org/web-vitals/-/web-vitals-4.2.4.tgz",
       "integrity": "sha512-r4DIlprAGwJ7YM11VZp4R884m0Vmgr6EAKe3P+kO0PPj3Unqyvv59rczf6UiGcb9Z8QxZVcqKNwv/g0WNdWwsw==",
       "license": "Apache-2.0"
+    },
+    "node_modules/webgl-constants": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/webgl-constants/-/webgl-constants-1.1.1.tgz",
+      "integrity": "sha512-LkBXKjU5r9vAW7Gcu3T5u+5cvSvh5WwINdr0C+9jpzVB41cjQAP5ePArDtk/WHYdVj0GefCgM73BA7FlIiNtdg=="
+    },
+    "node_modules/webgl-sdf-generator": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/webgl-sdf-generator/-/webgl-sdf-generator-1.1.1.tgz",
+      "integrity": "sha512-9Z0JcMTFxeE+b2x1LJTdnaT8rT8aEp7MVxkNwoycNmJWwPdzoXzMh0BjJSh/AEFP+KPYZUli814h8bJZFIZ2jA==",
+      "license": "MIT"
     },
     "node_modules/webidl-conversions": {
       "version": "3.0.1",
@@ -15496,6 +16162,35 @@
         "tiny-case": "^1.0.3",
         "toposort": "^2.0.2",
         "type-fest": "^2.19.0"
+      }
+    },
+    "node_modules/zustand": {
+      "version": "5.0.14",
+      "resolved": "https://registry.npmjs.org/zustand/-/zustand-5.0.14.tgz",
+      "integrity": "sha512-/8tAspM5LMPr28b3fwLYrtdj77ECpfZviaP75CMTnwO8ISyaE4GDIG/9rDDYq/cH9D2Xw2A2RXglLInmVBQB/g==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=12.20.0"
+      },
+      "peerDependencies": {
+        "@types/react": ">=18.0.0",
+        "immer": ">=9.0.6",
+        "react": ">=18.0.0",
+        "use-sync-external-store": ">=1.2.0"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "immer": {
+          "optional": true
+        },
+        "react": {
+          "optional": true
+        },
+        "use-sync-external-store": {
+          "optional": true
+        }
       }
     }
   }

--- a/package.json
+++ b/package.json
@@ -11,6 +11,8 @@
   },
   "dependencies": {
     "@google/genai": "^1.34.0",
+    "@react-three/drei": "^9.122.0",
+    "@react-three/fiber": "^8.18.0",
     "@sendgrid/mail": "^8.1.5",
     "bcryptjs": "^2.4.3",
     "firebase": "^11.6.0",
@@ -27,7 +29,8 @@
     "react-dom": "^18.3.1",
     "react-router-dom": "^7.10.1",
     "recharts": "^3.5.1",
-    "resend": "^4.2.0"
+    "resend": "^4.2.0",
+    "three": "^0.164.1"
   },
   "devDependencies": {
     "@eslint/eslintrc": "^3",

--- a/src/app/pool3d/page.tsx
+++ b/src/app/pool3d/page.tsx
@@ -1,42 +1,15 @@
 import type { Metadata } from 'next';
-import Image from 'next/image';
 
 import PoolModelViewer from '@/components/PoolModelViewer';
-
-const poolWalkthroughVideo = '/docs/survey/pool-walkthrough-website.mp4';
-
-const infoCards = [
-  {
-    title: 'About the pool area',
-    summary:
-      'James Square has a heated indoor residents’ pool area with associated gym, sauna, changing and shower facilities.',
-    details:
-      'The pool area forms part of the original James Square leisure facilities. It includes the heated indoor swimming pool, gym, sauna, changing rooms, showers, seating and plant room. This digital model is intended to help explain the general layout of the space.',
-  },
-  {
-    title: 'Current repair position',
-    summary:
-      'The pool is temporarily closed following issues linked to the electrical fault and issues with ventilation/dehumidification system and resulting high humidity.',
-    details:
-      'The pool area has recently been affected by high humidity levels following an electrical fault and knock-on issues with the ventilation/dehumidification system. The elevated moisture levels caused damage to parts of the pool area, including ceiling finishes that now require repair. Further surveys, assessments and repair works are being considered so the facilities can be reopened safely.',
-  },
-  {
-    title: 'Purpose of this page',
-    summary:
-      'This page can be shared with contractors, designers, surveyors and others involved in reviewing the pool area.',
-    details:
-      'This page is intended to provide a useful visual reference for anyone involved in the pool repair and refurbishment process. It may assist contractors, designers, architects, surveyors, RLSS UK, committee members and residents by giving them a better understanding of the layout before visiting or reviewing the space. The page is still in its early stages and more information, images and updates may be added in due course.',
-  },
-];
 
 export const metadata: Metadata = {
   title: 'James Square Pool 3D Model',
   description:
-    'Interactive digital model of the James Square heated indoor pool, created to support repair and refurbishment discussions.',
+    'Scroll-controlled interactive 3D model of the James Square heated indoor pool, created to support repair and refurbishment discussions.',
   openGraph: {
     title: 'James Square Pool 3D Model',
     description:
-      'Interactive digital model of the James Square heated indoor pool, created to support repair and refurbishment discussions.',
+      'Scroll-controlled interactive 3D model of the James Square heated indoor pool, created to support repair and refurbishment discussions.',
     images: [
       {
         url: '/images/pool/Pool-facing-south.png',
@@ -48,146 +21,48 @@ export const metadata: Metadata = {
   },
 };
 
-const poolImages = [
-  {
-    src: '/images/pool/Pool-facing-south.png',
-    alt: 'Pool area facing south',
-    caption: 'Pool area facing south',
-  },
-  {
-    src: '/images/pool/3Dimage-facing-north.jpg',
-    alt: '3D pool model view facing north',
-    caption: '3D model facing north',
-  },
-  {
-    src: '/images/pool/01-entrance-hallway.jpeg',
-    alt: 'Pool entrance hallway',
-    caption: 'Entrance hallway',
-  },
-  {
-    src: '/images/pool/03-gym-facing-south.jpeg',
-    alt: 'Gym area facing south',
-    caption: 'Gym area',
-  },
-  {
-    src: '/images/pool/05-sauna-entrance-door.jpeg',
-    alt: 'Sauna entrance door',
-    caption: 'Sauna entrance',
-  },
-  {
-    src: '/images/pool/08-ceiling-damage.jpeg',
-    alt: 'Ceiling finishes requiring repair',
-    caption: 'Ceiling repair area',
-  },
+const supportingNotes = [
+  'Use the scroll sequence for orientation before taking manual control.',
+  'The model is a working visual reference for pool repair and refurbishment discussions.',
+  'Reduced-motion users see a static interactive viewer without the guided camera path.',
 ];
 
 export default function Pool3DPage() {
   return (
-    <main className="mx-auto max-w-7xl space-y-8 px-3 py-6 sm:px-5 lg:py-10">
-      <section className="overflow-hidden rounded-[2rem] border border-sky-100 bg-gradient-to-br from-sky-50 via-white to-cyan-50 p-6 shadow-xl shadow-sky-950/5 dark:border-white/10 dark:from-slate-950 dark:via-slate-900 dark:to-cyan-950/40 sm:p-8 lg:p-10">
-        <div className="max-w-4xl">
+    <main className="bg-slate-50 text-slate-950 dark:bg-slate-950 dark:text-white">
+      <section className="mx-auto max-w-7xl px-3 py-6 sm:px-5 lg:py-10">
+        <div className="rounded-[2rem] border border-sky-100 bg-gradient-to-br from-sky-50 via-white to-cyan-50 p-6 shadow-xl shadow-sky-950/5 dark:border-white/10 dark:from-slate-950 dark:via-slate-900 dark:to-cyan-950/40 sm:p-8 lg:p-10">
           <p className="mb-3 text-sm font-semibold uppercase tracking-[0.28em] text-sky-700 dark:text-sky-300">
             Pool project reference
           </p>
-          <h1 className="text-4xl font-bold tracking-tight text-slate-950 dark:text-white sm:text-5xl lg:text-6xl">
-            James Square Pool 3D Model
-          </h1>
-          <p className="mt-5 max-w-3xl text-base leading-7 text-slate-700 dark:text-slate-200 sm:text-lg">
-            An interactive digital model of the James Square heated indoor pool, created to help visualise the layout and support future repair and refurbishment discussions.
-          </p>
-          <div className="mt-6 inline-flex rounded-2xl border border-amber-200 bg-amber-50 px-4 py-3 text-sm font-semibold text-amber-900 shadow-sm dark:border-amber-300/30 dark:bg-amber-300/10 dark:text-amber-100">
-            Pool currently closed pending repairs and further assessment.
-          </div>
-        </div>
-      </section>
-
-      <section aria-labelledby="pool-model-heading" className="space-y-4">
-        <div className="rounded-[2rem] border border-slate-200 bg-white/90 p-3 shadow-2xl shadow-sky-950/10 dark:border-white/10 dark:bg-slate-900/90 sm:p-4">
-          <div className="mb-4 flex flex-col gap-2 px-2 pt-2 sm:px-3">
-            <h2 id="pool-model-heading" className="text-2xl font-bold text-slate-950 dark:text-white">
-              Interactive 3D pool model
-            </h2>
-            <p className="text-sm text-slate-600 dark:text-slate-300">
-              Rotate, zoom and pan the latest pool model directly in the viewer.
-            </p>
-          </div>
-          <PoolModelViewer ariaLabel="Interactive 3D model of the James Square heated indoor pool layout" />
-        </div>
-        <p className="px-2 text-sm leading-6 text-slate-600 dark:text-slate-300">
-          This model is a working visual reference and may be refined as further photos, measurements and survey information become available.
-        </p>
-      </section>
-
-      <section aria-labelledby="pool-scan-heading" className="rounded-3xl border border-slate-200 bg-white/85 p-4 shadow-lg shadow-slate-950/5 dark:border-white/10 dark:bg-slate-900/80 sm:p-5">
-        <div className="grid gap-4 md:grid-cols-[minmax(0,1fr)_340px] md:items-center">
-          <div>
-            <h2 id="pool-scan-heading" className="text-xl font-bold text-slate-950 dark:text-white">
-              3D scan preview
-            </h2>
-            <p className="mt-2 text-sm leading-6 text-slate-600 dark:text-slate-300">
-              A short scan walkthrough is available as a secondary reference alongside the interactive model.
-            </p>
-          </div>
-          <video
-            className="aspect-video w-full rounded-2xl bg-slate-950 object-cover shadow-lg"
-            src={poolWalkthroughVideo}
-            controls
-            muted
-            playsInline
-            preload="metadata"
-            poster="/images/pool/Pool-facing-south.png"
-            aria-label="Walkthrough video scan of the James Square pool 3D model"
-          />
-        </div>
-      </section>
-
-      <section aria-labelledby="pool-details-heading" className="space-y-4">
-        <h2 id="pool-details-heading" className="text-2xl font-bold text-slate-950 dark:text-white">
-          Project information
-        </h2>
-        <div className="grid gap-4 lg:grid-cols-3">
-          {infoCards.map((card) => (
-            <details key={card.title} className="group rounded-3xl border border-slate-200 bg-white/85 p-5 shadow-lg shadow-slate-950/5 dark:border-white/10 dark:bg-slate-900/80">
-              <summary className="cursor-pointer list-none">
-                <div className="flex items-start justify-between gap-4">
-                  <div>
-                    <h3 className="text-lg font-bold text-slate-950 dark:text-white">{card.title}</h3>
-                    <p className="mt-3 text-sm leading-6 text-slate-600 dark:text-slate-300">{card.summary}</p>
-                  </div>
-                  <span className="shrink-0 rounded-full border border-sky-200 bg-sky-50 px-3 py-1 text-xs font-semibold text-sky-800 dark:border-sky-300/30 dark:bg-sky-300/10 dark:text-sky-100">
-                    <span className="group-open:hidden">View more</span>
-                    <span className="hidden group-open:inline">Hide details</span>
-                  </span>
-                </div>
-              </summary>
-              <p className="mt-4 border-t border-slate-200 pt-4 text-sm leading-6 text-slate-700 dark:border-white/10 dark:text-slate-200">
-                {card.details}
+          <div className="grid gap-6 lg:grid-cols-[minmax(0,1fr)_320px] lg:items-end">
+            <div>
+              <h1 className="text-4xl font-bold tracking-tight sm:text-5xl lg:text-6xl">
+                James Square Pool 3D Model
+              </h1>
+              <p className="mt-5 max-w-3xl text-base leading-7 text-slate-700 dark:text-slate-200 sm:text-lg">
+                Scroll to guide the camera from a dollhouse overview into the pool space, then take control and inspect the model manually.
               </p>
-            </details>
-          ))}
+            </div>
+            <div className="rounded-2xl border border-amber-200 bg-amber-50 px-4 py-3 text-sm font-semibold text-amber-900 shadow-sm dark:border-amber-300/30 dark:bg-amber-300/10 dark:text-amber-100">
+              Pool currently closed pending repairs and further assessment.
+            </div>
+          </div>
         </div>
       </section>
 
-      <section aria-labelledby="pool-gallery-heading" className="space-y-4 pb-4">
-        <div className="max-w-3xl">
-          <h2 id="pool-gallery-heading" className="text-2xl font-bold text-slate-950 dark:text-white">
-            Pool image gallery
-          </h2>
-          <p className="mt-2 text-sm leading-6 text-slate-600 dark:text-slate-300">
-            Reference images are included for orientation and remain secondary to the interactive model.
-          </p>
-        </div>
-        <div className="grid gap-4 sm:grid-cols-2 lg:grid-cols-3">
-          {poolImages.map((image) => (
-            <a key={image.src} href={image.src} target="_blank" rel="noreferrer" className="group overflow-hidden rounded-3xl border border-slate-200 bg-white shadow-lg shadow-slate-950/5 transition hover:-translate-y-0.5 hover:shadow-xl dark:border-white/10 dark:bg-slate-900">
-              <figure>
-                <div className="relative aspect-[4/3] w-full bg-slate-100 dark:bg-slate-800">
-                  <Image src={image.src} alt={image.alt} fill sizes="(min-width: 1024px) 31vw, (min-width: 640px) 48vw, 100vw" loading="lazy" unoptimized className="object-cover transition duration-300 group-hover:scale-[1.03]" />
-                </div>
-                <figcaption className="px-4 py-3 text-sm font-medium text-slate-700 dark:text-slate-200">{image.caption}</figcaption>
-              </figure>
-            </a>
-          ))}
+      <PoolModelViewer ariaLabel="Scroll-controlled 3D model of the James Square heated indoor pool layout" />
+
+      <section className="mx-auto max-w-5xl px-3 py-10 sm:px-5 lg:py-14">
+        <div className="rounded-[2rem] border border-slate-200 bg-white/90 p-5 shadow-xl shadow-slate-950/5 dark:border-white/10 dark:bg-slate-900/80 sm:p-6">
+          <h2 className="text-2xl font-bold">Model notes</h2>
+          <div className="mt-4 grid gap-3 md:grid-cols-3">
+            {supportingNotes.map((note) => (
+              <p key={note} className="rounded-2xl border border-slate-200 bg-slate-50 p-4 text-sm leading-6 text-slate-700 dark:border-white/10 dark:bg-slate-950/60 dark:text-slate-200">
+                {note}
+              </p>
+            ))}
+          </div>
         </div>
       </section>
     </main>

--- a/src/components/PoolModelViewer.tsx
+++ b/src/components/PoolModelViewer.tsx
@@ -1,319 +1,285 @@
 'use client';
 
-import { useEffect, useRef, useState } from 'react';
+import { Html, OrbitControls, useGLTF } from '@react-three/drei';
+import { Canvas, useFrame } from '@react-three/fiber';
+import { Suspense, useEffect, useMemo, useRef, useState } from 'react';
+import type { Group } from 'three';
+import { Box3, Vector3 } from 'three';
+import type { OrbitControls as OrbitControlsImpl } from 'three-stdlib';
 
-const MODEL_SRC = '/images/pool/02-edit-floor-plan-pool.glb';
-const MIN_DISTANCE = 3.5;
-const MAX_DISTANCE = 28;
-const START_DISTANCE = 13;
-const START_YAW = -35;
-const START_PITCH = -38;
 
-type PlayCanvasModule = typeof import('playcanvas');
-type PlayCanvasEntity = import('playcanvas').Entity;
-type PlayCanvasMeshInstance = import('playcanvas').MeshInstance;
-type PlayCanvasRenderComponent = import('playcanvas').RenderComponent;
-type GlbContainerResource = {
-  instantiateRenderEntity: (options?: { castShadows?: boolean }) => PlayCanvasEntity;
-};
+const MODEL_SRC = '/docs/survey/pool-3D-model-website.glb';
 
 type PoolModelViewerProps = {
   ariaLabel?: string;
 };
 
-const clamp = (value: number, min: number, max: number) => Math.min(Math.max(value, min), max);
+type PoolSceneProps = {
+  progress: number;
+  reducedMotion: boolean;
+};
 
-export default function PoolModelViewer({
-  ariaLabel = 'Interactive PlayCanvas 3D model of the James Square pool area',
-}: PoolModelViewerProps) {
-  const canvasRef = useRef<HTMLCanvasElement | null>(null);
-  const [loadState, setLoadState] = useState<'loading' | 'ready' | 'error'>('loading');
+const SCROLL_STAGES = [
+  {
+    eyebrow: '01 / Dollhouse',
+    title: 'Start above the pool area.',
+    copy: 'A clean bird’s-eye view gives the overall layout first.',
+  },
+  {
+    eyebrow: '02 / Exterior orbit',
+    title: 'Circle the outside envelope.',
+    copy: 'Scroll slowly to orbit around the pool building and roofline.',
+  },
+  {
+    eyebrow: '03 / Move inside',
+    title: 'Push toward the pool interior.',
+    copy: 'The camera drops closer so the main pool space becomes the focus.',
+  },
+  {
+    eyebrow: '04 / Pool edge',
+    title: 'Glide past the windows.',
+    copy: 'Follow the pool edge and look across the primary swimming area.',
+  },
+  {
+    eyebrow: '05 / Inspect',
+    title: 'Take control of the model.',
+    copy: 'At the end, orbit, zoom and inspect the scan manually.',
+  },
+];
+
+const clamp01 = (value: number) => Math.min(Math.max(value, 0), 1);
+const smoothstep = (value: number) => {
+  const x = clamp01(value);
+  return x * x * (3 - 2 * x);
+};
+const mix = (from: number, to: number, amount: number) => from + (to - from) * amount;
+
+function useReducedMotionPreference() {
+  const [reducedMotion, setReducedMotion] = useState(false);
 
   useEffect(() => {
-    const canvas = canvasRef.current;
-    if (!canvas) {
+    const mediaQuery = window.matchMedia('(prefers-reduced-motion: reduce)');
+    const update = () => setReducedMotion(mediaQuery.matches);
+    update();
+    mediaQuery.addEventListener('change', update);
+    return () => mediaQuery.removeEventListener('change', update);
+  }, []);
+
+  return reducedMotion;
+}
+
+function PoolModel({ onReady }: { onReady: (bounds: Box3) => void }) {
+  const groupRef = useRef<Group>(null);
+  const { scene } = useGLTF(MODEL_SRC);
+
+  useEffect(() => {
+    if (!groupRef.current) {
       return;
     }
 
-    let isDisposed = false;
-    let cleanup: (() => void) | undefined;
+    const bounds = new Box3().setFromObject(groupRef.current);
+    const center = bounds.getCenter(new Vector3());
+    groupRef.current.position.sub(center);
 
-    const setup = async () => {
-      try {
-        const pc: PlayCanvasModule = await import('playcanvas');
+    requestAnimationFrame(() => {
+      if (groupRef.current) {
+        onReady(new Box3().setFromObject(groupRef.current));
+      }
+    });
+  }, [onReady, scene]);
 
-        if (isDisposed) {
-          return;
-        }
+  return <primitive ref={groupRef} object={scene} dispose={null} />;
+}
 
-        const app = new pc.Application(canvas, {
-          mouse: new pc.Mouse(canvas),
-          touch: new pc.TouchDevice(canvas),
-          keyboard: new pc.Keyboard(window),
-          graphicsDeviceOptions: {
-            alpha: false,
-            antialias: true,
-            powerPreference: 'high-performance',
-          },
-        });
+function PoolScene({ progress, reducedMotion }: PoolSceneProps) {
+  const controlsRef = useRef<OrbitControlsImpl | null>(null);
+  const [bounds, setBounds] = useState<Box3 | null>(null);
 
-        cleanup = () => {
-          app.destroy();
-        };
+  const radius = useMemo(() => {
+    if (!bounds) {
+      return 10;
+    }
+    return Math.max(bounds.getSize(new Vector3()).length() * 0.42, 6);
+  }, [bounds]);
 
-        app.setCanvasFillMode(pc.FILLMODE_FILL_WINDOW);
-        app.setCanvasResolution(pc.RESOLUTION_AUTO);
-        app.scene.ambientLight = new pc.Color(0.55, 0.62, 0.68);
-        app.scene.exposure = 1.28;
-        (app.scene as unknown as { toneMapping: number }).toneMapping = pc.TONEMAP_ACES;
-        app.start();
+  const targetBase = useMemo(() => {
+    if (!bounds) {
+      return new Vector3(0, 0, 0);
+    }
+    const center = bounds.getCenter(new Vector3());
+    center.y += bounds.getSize(new Vector3()).y * 0.08;
+    return center;
+  }, [bounds]);
 
-        const camera = new pc.Entity('Pool camera');
-        camera.addComponent('camera', {
-          clearColor: new pc.Color(0.05, 0.06, 0.08),
-          farClip: 1000,
-          fov: 42,
-          nearClip: 0.08,
-        });
-        app.root.addChild(camera);
+  useFrame(({ camera }) => {
+    const controls = controlsRef.current;
 
-        const keyLight = new pc.Entity('Main soft light');
-        keyLight.addComponent('light', {
-          type: 'directional',
-          color: new pc.Color(1, 0.96, 0.88),
-          intensity: 3.2,
-          castShadows: true,
-          shadowDistance: 35,
-        });
-        keyLight.setEulerAngles(45, 35, 0);
-        app.root.addChild(keyLight);
+    if (reducedMotion || progress >= 0.96) {
+      controls?.update();
+      return;
+    }
 
-        const fillLight = new pc.Entity('Fill light');
-        fillLight.addComponent('light', {
-          type: 'directional',
-          color: new pc.Color(0.55, 0.7, 1),
-          intensity: 1.35,
-        });
-        fillLight.setEulerAngles(20, -135, 0);
-        app.root.addChild(fillLight);
+    const stage = Math.min(Math.floor(progress * 4), 3);
+    const local = smoothstep(progress * 4 - stage);
+    const keyframes = [
+      {
+        yaw: -0.55,
+        height: 1.95,
+        distance: 1.45,
+        targetX: 0,
+        targetY: 0.02,
+        targetZ: 0,
+      },
+      {
+        yaw: 1.7,
+        height: 1.05,
+        distance: 1.35,
+        targetX: 0.05,
+        targetY: 0.05,
+        targetZ: 0,
+      },
+      {
+        yaw: 2.75,
+        height: 0.48,
+        distance: 0.82,
+        targetX: 0.1,
+        targetY: 0.08,
+        targetZ: -0.08,
+      },
+      {
+        yaw: 3.65,
+        height: 0.34,
+        distance: 0.58,
+        targetX: -0.2,
+        targetY: 0.04,
+        targetZ: -0.18,
+      },
+      {
+        yaw: 4.25,
+        height: 0.55,
+        distance: 0.95,
+        targetX: 0,
+        targetY: 0.06,
+        targetZ: 0,
+      },
+    ];
 
-        const asset = new pc.Asset('James Square pool GLB', 'container', { url: MODEL_SRC });
-        app.assets.add(asset);
+    const from = keyframes[stage];
+    const to = keyframes[stage + 1];
+    const yaw = mix(from.yaw, to.yaw, local);
+    const distance = radius * mix(from.distance, to.distance, local);
+    const height = radius * mix(from.height, to.height, local);
+    const target = targetBase.clone().add(
+      new Vector3(
+        radius * mix(from.targetX, to.targetX, local),
+        radius * mix(from.targetY, to.targetY, local),
+        radius * mix(from.targetZ, to.targetZ, local),
+      ),
+    );
 
-        const state = {
-          distance: START_DISTANCE,
-          yaw: START_YAW,
-          pitch: START_PITCH,
-          target: new pc.Vec3(0, 1.2, 0),
-          minDistance: MIN_DISTANCE,
-          maxDistance: MAX_DISTANCE,
-          pointerMode: null as 'rotate' | 'pan' | null,
-          pointerId: null as number | null,
-          lastX: 0,
-          lastY: 0,
-          pinchDistance: 0,
-        };
+    const cameraPosition = new Vector3(
+      target.x + Math.sin(yaw) * distance,
+      target.y + height,
+      target.z + Math.cos(yaw) * distance,
+    );
 
-        const updateCamera = () => {
-          state.pitch = clamp(state.pitch, -80, -8);
-          state.distance = clamp(state.distance, state.minDistance, state.maxDistance);
+    camera.position.lerp(cameraPosition, 0.08);
+    camera.lookAt(target);
+    if (controls) {
+      controls.target.lerp(target, 0.08);
+      controls.update();
+    }
+  });
 
-          const yaw = state.yaw * pc.math.DEG_TO_RAD;
-          const pitch = state.pitch * pc.math.DEG_TO_RAD;
-          const horizontal = Math.cos(pitch) * state.distance;
-          const position = new pc.Vec3(
-            state.target.x + Math.sin(yaw) * horizontal,
-            state.target.y + Math.sin(-pitch) * state.distance,
-            state.target.z + Math.cos(yaw) * horizontal,
-          );
+  return (
+    <>
+      <ambientLight intensity={1.25} />
+      <directionalLight position={[8, 14, 8]} intensity={2.4} />
+      <directionalLight position={[-10, 6, -8]} intensity={0.9} color="#9fd5ff" />
+      <Suspense fallback={<Html center className="rounded-full bg-slate-950/80 px-4 py-2 text-sm font-semibold text-white">Loading model…</Html>}>
+        <PoolModel onReady={setBounds} />
+      </Suspense>
+      <OrbitControls
+        ref={controlsRef}
+        enabled={reducedMotion || progress >= 0.96}
+        enableDamping
+        dampingFactor={0.08}
+        minDistance={Math.max(radius * 0.2, 2)}
+        maxDistance={Math.max(radius * 2.6, 18)}
+      />
+    </>
+  );
+}
 
-          camera.setPosition(position);
-          camera.lookAt(state.target);
-        };
+export default function PoolModelViewer({
+  ariaLabel = 'Scroll-controlled 3D model of the James Square pool area',
+}: PoolModelViewerProps) {
+  const wrapperRef = useRef<HTMLDivElement | null>(null);
+  const reducedMotion = useReducedMotionPreference();
+  const [progress, setProgress] = useState(0);
 
-        const panCamera = (deltaX: number, deltaY: number) => {
-          const scale = state.distance * 0.0017;
-          const right = camera.right.clone().mulScalar(-deltaX * scale);
-          const up = camera.up.clone().mulScalar(deltaY * scale);
-          state.target.add(right).add(up);
-          updateCamera();
-        };
+  useEffect(() => {
+    if (reducedMotion) {
+      setProgress(1);
+      return;
+    }
 
-        const onWheel = (event: WheelEvent) => {
-          event.preventDefault();
-          state.distance *= 1 + Math.sign(event.deltaY) * 0.1;
-          updateCamera();
-        };
-
-        const onPointerDown = (event: PointerEvent) => {
-          canvas.setPointerCapture(event.pointerId);
-          state.pointerId = event.pointerId;
-          state.pointerMode = event.button === 1 || event.button === 2 || event.shiftKey ? 'pan' : 'rotate';
-          state.lastX = event.clientX;
-          state.lastY = event.clientY;
-        };
-
-        const onPointerMove = (event: PointerEvent) => {
-          if (state.pointerId !== event.pointerId || !state.pointerMode) {
-            return;
-          }
-
-          const deltaX = event.clientX - state.lastX;
-          const deltaY = event.clientY - state.lastY;
-          state.lastX = event.clientX;
-          state.lastY = event.clientY;
-
-          if (state.pointerMode === 'pan') {
-            panCamera(deltaX, deltaY);
-          } else {
-            state.yaw -= deltaX * 0.35;
-            state.pitch -= deltaY * 0.25;
-            updateCamera();
-          }
-        };
-
-        const onPointerUp = (event: PointerEvent) => {
-          if (state.pointerId === event.pointerId) {
-            state.pointerId = null;
-            state.pointerMode = null;
-          }
-        };
-
-        const onContextMenu = (event: MouseEvent) => event.preventDefault();
-
-        const onTouchMove = (event: TouchEvent) => {
-          if (event.touches.length !== 2) {
-            state.pinchDistance = 0;
-            return;
-          }
-
-          event.preventDefault();
-          const [first, second] = Array.from(event.touches);
-          const distance = Math.hypot(first.clientX - second.clientX, first.clientY - second.clientY);
-
-          if (state.pinchDistance > 0) {
-            state.distance *= state.pinchDistance / distance;
-            updateCamera();
-          }
-
-          state.pinchDistance = distance;
-        };
-
-        canvas.addEventListener('wheel', onWheel, { passive: false });
-        canvas.addEventListener('pointerdown', onPointerDown);
-        canvas.addEventListener('pointermove', onPointerMove);
-        canvas.addEventListener('pointerup', onPointerUp);
-        canvas.addEventListener('pointercancel', onPointerUp);
-        canvas.addEventListener('contextmenu', onContextMenu);
-        canvas.addEventListener('touchmove', onTouchMove, { passive: false });
-
-        cleanup = () => {
-          canvas.removeEventListener('wheel', onWheel);
-          canvas.removeEventListener('pointerdown', onPointerDown);
-          canvas.removeEventListener('pointermove', onPointerMove);
-          canvas.removeEventListener('pointerup', onPointerUp);
-          canvas.removeEventListener('pointercancel', onPointerUp);
-          canvas.removeEventListener('contextmenu', onContextMenu);
-          canvas.removeEventListener('touchmove', onTouchMove);
-          app.destroy();
-        };
-
-        asset.ready(() => {
-          if (isDisposed) {
-            return;
-          }
-
-          const container = asset.resource as GlbContainerResource;
-          const model = container.instantiateRenderEntity({ castShadows: true });
-          model.name = 'James Square pool model';
-          app.root.addChild(model);
-
-          const poolWaterMaterial = new pc.StandardMaterial();
-          poolWaterMaterial.name = 'Pool water blue reference material';
-          poolWaterMaterial.diffuse = new pc.Color(0.02, 0.48, 0.78);
-          poolWaterMaterial.emissive = new pc.Color(0, 0.06, 0.09);
-          poolWaterMaterial.opacity = 0.78;
-          poolWaterMaterial.blendType = pc.BLEND_NORMAL;
-          poolWaterMaterial.useMetalness = true;
-          poolWaterMaterial.metalness = 0;
-          poolWaterMaterial.gloss = 0.85;
-          poolWaterMaterial.update();
-
-          const bounds = new pc.BoundingBox();
-          let hasBounds = false;
-          const renders = model.findComponents('render') as PlayCanvasRenderComponent[];
-          renders.forEach((render: PlayCanvasRenderComponent) => {
-            render.meshInstances.forEach((meshInstance: PlayCanvasMeshInstance) => {
-              const meshName = `${meshInstance.node?.name ?? ''} ${meshInstance.material?.name ?? ''}`.toLowerCase();
-              if (meshName.includes('waterbody') || meshName.includes('watervolume')) {
-                meshInstance.material = poolWaterMaterial;
-              }
-
-              if (!hasBounds) {
-                bounds.copy(meshInstance.aabb);
-                hasBounds = true;
-              } else {
-                bounds.add(meshInstance.aabb);
-              }
-            });
-          });
-
-          if (hasBounds) {
-            state.target.copy(bounds.center);
-            state.target.y += bounds.halfExtents.y * 0.12;
-            const radius = bounds.halfExtents.length();
-            state.minDistance = Math.max(radius * 0.35, MIN_DISTANCE);
-            state.maxDistance = Math.max(radius * 3.5, MAX_DISTANCE);
-            state.distance = clamp(radius * 1.55, state.minDistance, state.maxDistance);
-            camera.camera!.nearClip = Math.max(radius * 0.004, 0.05);
-            camera.camera!.farClip = Math.max(radius * 10, 100);
-          }
-
-          updateCamera();
-          setLoadState('ready');
-        });
-
-        asset.on('error', (error: unknown) => {
-          console.error('Failed to load pool model:', error);
-          setLoadState('error');
-        });
-
-        app.assets.load(asset);
-        updateCamera();
-      } catch (error) {
-        console.error('Failed to initialise PlayCanvas:', error);
-        setLoadState('error');
+    let frame = 0;
+    const updateProgress = () => {
+      frame = 0;
+      const wrapper = wrapperRef.current;
+      if (!wrapper) {
+        return;
+      }
+      const rect = wrapper.getBoundingClientRect();
+      const scrollable = rect.height - window.innerHeight;
+      setProgress(clamp01(scrollable > 0 ? -rect.top / scrollable : 0));
+    };
+    const onScroll = () => {
+      if (!frame) {
+        frame = window.requestAnimationFrame(updateProgress);
       }
     };
 
-    void setup();
-
+    updateProgress();
+    window.addEventListener('scroll', onScroll, { passive: true });
+    window.addEventListener('resize', onScroll);
     return () => {
-      isDisposed = true;
-      cleanup?.();
+      if (frame) {
+        window.cancelAnimationFrame(frame);
+      }
+      window.removeEventListener('scroll', onScroll);
+      window.removeEventListener('resize', onScroll);
     };
-  }, []);
+  }, [reducedMotion]);
+
+  const activeStage = reducedMotion ? SCROLL_STAGES.length - 1 : Math.min(Math.floor(progress * SCROLL_STAGES.length), SCROLL_STAGES.length - 1);
 
   return (
-    <div className="overflow-hidden rounded-3xl border border-slate-700 bg-slate-950 shadow-2xl shadow-sky-950/20">
-      <div className="relative h-[520px] w-full sm:h-[640px] lg:h-[760px]">
-        <canvas
-          ref={canvasRef}
+    <section ref={wrapperRef} aria-labelledby="pool-model-heading" className="relative min-h-[520vh]">
+      <div className="sticky top-0 min-h-screen overflow-hidden rounded-[2rem] border border-slate-200 bg-slate-950 shadow-2xl shadow-sky-950/20 dark:border-white/10">
+        <div className="absolute inset-0 bg-[radial-gradient(circle_at_top_left,rgba(14,165,233,0.3),transparent_34%),linear-gradient(180deg,rgba(15,23,42,0.2),rgba(2,6,23,0.85))]" />
+        <Canvas
           aria-label={ariaLabel}
           role="img"
-          className="h-full w-full touch-none bg-slate-950 outline-none"
-        />
-        {loadState !== 'ready' ? (
-          <div className="pointer-events-none absolute inset-0 flex items-center justify-center bg-slate-950/55 p-6 text-center text-sm font-semibold text-white">
-            {loadState === 'error'
-              ? 'The 3D model could not be loaded. Please try refreshing the page.'
-              : 'Loading PlayCanvas pool model…'}
+          camera={{ position: [8, 12, 8], fov: 42, near: 0.05, far: 500 }}
+          dpr={[1, 1.6]}
+          gl={{ antialias: true, powerPreference: 'high-performance' }}
+          className="min-h-screen"
+        >
+          <PoolScene progress={progress} reducedMotion={reducedMotion} />
+        </Canvas>
+        <div className="pointer-events-none absolute inset-x-0 bottom-0 p-4 sm:p-6 lg:p-8">
+          <div className="max-w-xl rounded-3xl border border-white/10 bg-slate-950/70 p-4 text-white shadow-2xl backdrop-blur-md sm:p-5">
+            <p className="text-xs font-semibold uppercase tracking-[0.24em] text-cyan-200">{SCROLL_STAGES[activeStage].eyebrow}</p>
+            <h2 id="pool-model-heading" className="mt-2 text-2xl font-bold sm:text-3xl">{SCROLL_STAGES[activeStage].title}</h2>
+            <p className="mt-2 text-sm leading-6 text-slate-200">{reducedMotion ? 'Reduced motion is on, so the model loads directly in interactive mode.' : SCROLL_STAGES[activeStage].copy}</p>
+            <p className="mt-3 text-xs font-semibold text-slate-300">{progress >= 0.96 || reducedMotion ? 'Drag to orbit. Scroll or pinch to zoom.' : 'Scroll to guide the camera.'}</p>
           </div>
-        ) : null}
-        <div className="pointer-events-none absolute bottom-3 left-3 right-3 rounded-2xl border border-white/10 bg-slate-950/70 px-4 py-3 text-xs leading-5 text-slate-200 backdrop-blur sm:bottom-4 sm:left-4 sm:right-auto sm:max-w-md">
-          Drag to rotate. Scroll or pinch to zoom. Shift-drag, middle-drag, or right-drag to pan.
         </div>
       </div>
-    </div>
+    </section>
   );
 }
+
+useGLTF.preload(MODEL_SRC);

--- a/src/types/three-jsx.d.ts
+++ b/src/types/three-jsx.d.ts
@@ -1,0 +1,11 @@
+import 'react';
+
+declare module 'react' {
+  namespace JSX {
+    interface IntrinsicElements {
+      ambientLight: Record<string, unknown>;
+      directionalLight: Record<string, unknown>;
+      primitive: Record<string, unknown>;
+    }
+  }
+}


### PR DESCRIPTION
### Motivation
- Replace the legacy PlayCanvas viewer with a modern React Three Fiber / Three.js / Drei implementation so the pool model can be guided by page scroll and remain the primary visual focus.
- Provide a pinned 3D hero that walks the viewer through staged camera positions (dollhouse → exterior orbit → approach → pool-edge glide → manual inspect) for clearer orientation before manual interaction.
- Keep performance and accessibility in mind by limiting DPR, using Suspense fallbacks, and adding a `prefers-reduced-motion` fallback that opens the model directly in interactive mode.

### Description
- Rewrote `src/components/PoolModelViewer.tsx` to use `@react-three/fiber`, `three`, and `@react-three/drei`, loading the existing GLB at `/docs/survey/pool-3D-model-website.glb` and implementing the staged scroll-driven camera path and final interactive `OrbitControls`.
- Reworked the page at `src/app/pool3d/page.tsx` into a compact, model-first layout with a pinned full-screen hero, brief intro, and short supporting notes (removed the longer gallery/video layout in favor of the walkthrough-first experience).
- Added a small JSX types augmentation at `src/types/three-jsx.d.ts` so Three/Drei JSX elements are accepted by the repo TypeScript setup.
- Updated `package.json`/`package-lock.json` to add `three`, `@react-three/fiber`, and `@react-three/drei` and their resolved transitive deps required by the new viewer.

### Testing
- Ran `npx tsc --noEmit` which completed successfully against the modified codebase.
- Ran `npm run lint`; lint finished with pre-existing unrelated warnings but no new blocking errors from the added files.
- Attempted `npm run build`; build failed due to environment-level font fetch failures from Google Fonts used by `next/font` (font fetch retries/error), which blocked the production build but did not indicate runtime issues with the new viewer code itself.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a4b95bfe32c8324a7fdb1fb172ec875)