### PR TITLE
Add plant room and office 3D scan section

### DIFF
--- a/src/app/pool3d/page.tsx
+++ b/src/app/pool3d/page.tsx
@@ -143,6 +143,25 @@ export default function Pool3DPage() {
         </p>
       </section>
 
+      <section aria-labelledby="plant-room-scan-heading" className="space-y-4">
+        <div className="rounded-[2rem] border border-slate-200 bg-white/90 p-3 shadow-2xl shadow-sky-950/10 dark:border-white/10 dark:bg-slate-900/90 sm:p-4">
+          <div className="mb-4 flex flex-col gap-2 px-2 pt-2 sm:px-3">
+            <h2 id="plant-room-scan-heading" className="text-2xl font-bold text-slate-950 dark:text-white">
+              Plant room and office scan
+            </h2>
+            <p className="text-sm text-slate-600 dark:text-slate-300">
+              A separate 3D scan showing the pool plant room and office areas.
+            </p>
+          </div>
+          <PoolModelViewer
+            modelSrc="/images/pool/plant-room-and-office.glb"
+            modelName="James Square plant room and office scan"
+            loadingLabel="Loading the plant room and office scan…"
+            ariaLabel="Interactive 3D scan of the James Square pool plant room and office"
+          />
+        </div>
+      </section>
+
       <section aria-labelledby="pool-details-heading" className="space-y-4">
         <h2 id="pool-details-heading" className="text-2xl font-bold text-slate-950 dark:text-white">
           Project information


### PR DESCRIPTION
### Motivation
- Provide a separate interactive 3D reference for the pool plant room and office areas to complement the existing pool model and photo scan.
- Keep the new viewer visually consistent with the existing rounded card viewer layout used on the Pool 3D page.

### Description
- Updated `src/app/pool3d/page.tsx` to insert a new `section` directly below the pool photo scan section that follows the same rounded card layout.
- Rendered `PoolModelViewer` with `modelSrc="/images/pool/plant-room-and-office.glb"`, `modelName="James Square plant room and office scan"`, `loadingLabel="Loading the plant room and office scan…"`, and `ariaLabel="Interactive 3D scan of the James Square pool plant room and office"`.
- Added heading `Plant room and office scan` and description copy `A separate 3D scan showing the pool plant room and office areas.` to match the existing pattern.

### Testing
- Verified the GLB asset exists with `test -f public/images/pool/plant-room-and-office.glb` (result: exists).
- Ran `npm run lint` which completed with existing unrelated warnings.
- Started the dev server with `npm run dev` which reported Ready locally, but `npm run build` failed due to inability to fetch Google-hosted Geist font files in the environment.
- Attempted `npx playwright install chromium` which failed with a `403 Domain forbidden` when downloading Chromium, so no browser-based screenshots were captured.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a4bba8529d08324a5c3db3f192d3444)