### PR TITLE
Add gentle auto-spin to pool model viewers

### DIFF
--- a/src/app/pool3d/page.tsx
+++ b/src/app/pool3d/page.tsx
@@ -114,6 +114,8 @@ export default function Pool3DPage() {
             modelName="James Square pool area 3D model"
             loadingLabel="Loading the modelled pool area…"
             ariaLabel="Interactive 3D model of the James Square heated indoor pool layout"
+            autoSpin
+            autoSpinSpeed={1.4}
           />
         </div>
         <p className="px-2 text-sm leading-6 text-slate-600 dark:text-slate-300">
@@ -136,6 +138,8 @@ export default function Pool3DPage() {
             modelName="James Square pool photo scan"
             loadingLabel="Loading the pool photo scan…"
             ariaLabel="Interactive 3D photo scan of the James Square heated indoor pool area"
+            autoSpin
+            autoSpinSpeed={1.1}
           />
         </div>
         <p className="px-2 text-sm leading-6 text-slate-600 dark:text-slate-300">
@@ -158,6 +162,8 @@ export default function Pool3DPage() {
             modelName="James Square plant room and office scan"
             loadingLabel="Loading the plant room and office scan…"
             ariaLabel="Interactive 3D scan of the James Square pool plant room and office"
+            autoSpin
+            autoSpinSpeed={1.1}
           />
         </div>
       </section>

--- a/src/components/PoolModelViewer.tsx
+++ b/src/components/PoolModelViewer.tsx
@@ -18,6 +18,9 @@ type GlbContainerResource = {
 
 type PoolModelViewerProps = {
   ariaLabel?: string;
+  autoSpin?: boolean;
+  autoSpinSpeed?: number;
+  introMotion?: boolean;
   loadingLabel?: string;
   modelName?: string;
   modelSrc: string;
@@ -27,6 +30,9 @@ const clamp = (value: number, min: number, max: number) => Math.min(Math.max(val
 
 export default function PoolModelViewer({
   ariaLabel = 'Interactive PlayCanvas 3D model of the James Square pool area',
+  autoSpin = false,
+  autoSpinSpeed = 2,
+  introMotion = true,
   loadingLabel = 'Loading PlayCanvas pool model…',
   modelName = 'James Square pool model',
   modelSrc,
@@ -107,6 +113,9 @@ export default function PoolModelViewer({
         const asset = new pc.Asset(modelName, 'container', { url: modelSrc });
         app.assets.add(asset);
 
+        let isReady = false;
+        let autoMotionEnabled = autoSpin && introMotion;
+
         const state = {
           distance: START_DISTANCE,
           yaw: START_YAW,
@@ -146,13 +155,19 @@ export default function PoolModelViewer({
           updateCamera();
         };
 
+        const stopAutoMotion = () => {
+          autoMotionEnabled = false;
+        };
+
         const onWheel = (event: WheelEvent) => {
+          stopAutoMotion();
           event.preventDefault();
           state.distance *= 1 + Math.sign(event.deltaY) * 0.1;
           updateCamera();
         };
 
         const onPointerDown = (event: PointerEvent) => {
+          stopAutoMotion();
           canvas.setPointerCapture(event.pointerId);
           state.pointerId = event.pointerId;
           state.pointerMode = event.button === 1 || event.button === 2 || event.shiftKey ? 'pan' : 'rotate';
@@ -187,8 +202,23 @@ export default function PoolModelViewer({
         };
 
         const onContextMenu = (event: MouseEvent) => event.preventDefault();
+        const onKeyDown = () => {
+          stopAutoMotion();
+        };
+
+        const onUpdate = (deltaTime: number) => {
+          if (!isReady || !autoMotionEnabled) {
+            return;
+          }
+
+          state.yaw += autoSpinSpeed * deltaTime;
+          updateCamera();
+        };
+
+        app.on('update', onUpdate);
 
         const onTouchMove = (event: TouchEvent) => {
+          stopAutoMotion();
           if (event.touches.length !== 2) {
             state.pinchDistance = 0;
             return;
@@ -213,6 +243,7 @@ export default function PoolModelViewer({
         canvas.addEventListener('pointercancel', onPointerUp);
         canvas.addEventListener('contextmenu', onContextMenu);
         canvas.addEventListener('touchmove', onTouchMove, { passive: false });
+        window.addEventListener('keydown', onKeyDown);
 
         cleanup = () => {
           canvas.removeEventListener('wheel', onWheel);
@@ -222,6 +253,8 @@ export default function PoolModelViewer({
           canvas.removeEventListener('pointercancel', onPointerUp);
           canvas.removeEventListener('contextmenu', onContextMenu);
           canvas.removeEventListener('touchmove', onTouchMove);
+          window.removeEventListener('keydown', onKeyDown);
+          app.off('update', onUpdate);
           app.destroy();
         };
 
@@ -277,6 +310,7 @@ export default function PoolModelViewer({
           }
 
           updateCamera();
+          isReady = true;
           setLoadState('ready');
         });
 
@@ -299,7 +333,7 @@ export default function PoolModelViewer({
       isDisposed = true;
       cleanup?.();
     };
-  }, [modelName, modelSrc]);
+  }, [autoSpin, autoSpinSpeed, introMotion, modelName, modelSrc]);
 
   return (
     <div className="overflow-hidden rounded-3xl border border-slate-700 bg-slate-950 shadow-2xl shadow-sky-950/20">


### PR DESCRIPTION
### Motivation
- Make the 3D pool viewers feel more polished by adding a gentle automatic yaw motion after models finish loading.  
- Ensure the automatic motion never fights manual control by pausing it immediately when the user interacts.  

### Description
- Added optional props `autoSpin?: boolean`, `autoSpinSpeed?: number`, and `introMotion?: boolean` to `PoolModelViewer` with defaults that keep existing behaviour unchanged.  
- Begin automatic motion only after the model is ready by tracking `isReady` and `autoMotionEnabled`, and increment `state.yaw` inside a PlayCanvas `app.on('update', onUpdate)` loop using `deltaTime * autoSpinSpeed`.  
- Stop the automatic motion via a `stopAutoMotion()` call on user interactions (`wheel`, `pointerdown`, `touchmove`, and `keydown`) and removed the update listener during cleanup.  
- Enabled slow auto-spin on the three viewers in `src/app/pool3d/page.tsx` by passing `autoSpin` and tuned `autoSpinSpeed` per instance.  

### Testing
- Ran `npm run lint`, which completed (existing unrelated warnings remain).  
- Ran `npx tsc --noEmit`, which succeeded with no type errors.  
- Ran `git diff --check` to validate no whitespace/merge issues (no problems reported).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a4bc3aca61483248132519bde60b1a0)