### PR TITLE
Add responsive viewer heights and `size` prop to PoolModelViewer

### DIFF
--- a/src/app/pool3d/page.tsx
+++ b/src/app/pool3d/page.tsx
@@ -116,6 +116,7 @@ export default function Pool3DPage() {
             ariaLabel="Interactive 3D model of the James Square heated indoor pool layout"
             autoSpin
             autoSpinSpeed={1.4}
+            size="hero"
           />
         </div>
         <p className="px-2 text-sm leading-6 text-slate-600 dark:text-slate-300">
@@ -140,6 +141,7 @@ export default function Pool3DPage() {
             ariaLabel="Interactive 3D photo scan of the James Square heated indoor pool area"
             autoSpin
             autoSpinSpeed={1.1}
+            size="standard"
           />
         </div>
         <p className="px-2 text-sm leading-6 text-slate-600 dark:text-slate-300">
@@ -164,6 +166,7 @@ export default function Pool3DPage() {
             ariaLabel="Interactive 3D scan of the James Square pool plant room and office"
             autoSpin
             autoSpinSpeed={1.1}
+            size="compact"
           />
         </div>
       </section>

--- a/src/components/PoolModelViewer.tsx
+++ b/src/components/PoolModelViewer.tsx
@@ -16,6 +16,14 @@ type GlbContainerResource = {
   instantiateRenderEntity: (options?: { castShadows?: boolean }) => PlayCanvasEntity;
 };
 
+type PoolModelViewerSize = 'hero' | 'standard' | 'compact';
+
+const viewerHeightClasses: Record<PoolModelViewerSize, string> = {
+  hero: 'h-[360px] sm:h-[520px] lg:h-[680px]',
+  standard: 'h-[320px] sm:h-[440px] lg:h-[560px]',
+  compact: 'h-[280px] sm:h-[380px] lg:h-[480px]',
+};
+
 type PoolModelViewerProps = {
   ariaLabel?: string;
   autoSpin?: boolean;
@@ -24,6 +32,7 @@ type PoolModelViewerProps = {
   loadingLabel?: string;
   modelName?: string;
   modelSrc: string;
+  size?: PoolModelViewerSize;
 };
 
 const clamp = (value: number, min: number, max: number) => Math.min(Math.max(value, min), max);
@@ -36,6 +45,7 @@ export default function PoolModelViewer({
   loadingLabel = 'Loading PlayCanvas pool model…',
   modelName = 'James Square pool model',
   modelSrc,
+  size = 'hero',
 }: PoolModelViewerProps) {
   const canvasRef = useRef<HTMLCanvasElement | null>(null);
   const [loadState, setLoadState] = useState<'loading' | 'ready' | 'error'>('loading');
@@ -337,7 +347,7 @@ export default function PoolModelViewer({
 
   return (
     <div className="overflow-hidden rounded-3xl border border-slate-700 bg-slate-950 shadow-2xl shadow-sky-950/20">
-      <div className="relative h-[520px] w-full sm:h-[640px] lg:h-[760px]">
+      <div className={`relative w-full ${viewerHeightClasses[size]}`}>
         <canvas
           ref={canvasRef}
           aria-label={ariaLabel}


### PR DESCRIPTION
### Motivation
- Replace the fixed wrapper height classes with responsive presets so the 3D viewer adapts across breakpoints and different uses. 
- Allow the page to keep the main model visually larger while using smaller viewers for supporting scans via a simple `size` prop.

### Description
- Introduced `PoolModelViewerSize` and a `viewerHeightClasses` mapping with `hero`, `standard`, and `compact` presets (for example `hero: 'h-[360px] sm:h-[520px] lg:h-[680px]'`).
- Added an optional `size?: PoolModelViewerSize` prop to `PoolModelViewer` with default `size = 'hero'` and applied the height classes to the wrapper via ``${viewerHeightClasses[size]}``.
- Updated `src/app/pool3d/page.tsx` to pass `size="hero"` for the main model, `size="standard"` for the pool photo scan, and `size="compact"` for the plant room/office scan.
- Changed files: `src/components/PoolModelViewer.tsx` and `src/app/pool3d/page.tsx`.

### Testing
- Ran `npm run lint` which completed successfully while reporting unrelated lint warnings in other files. 
- Ran `git diff --check` which reported no whitespace or diff issues.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a4bc52d393483249e0042aae3a0ce7a)