### PR TITLE
Add lazy previews for pool 3D models

### DIFF
--- a/src/app/pool3d/page.tsx
+++ b/src/app/pool3d/page.tsx
@@ -1,7 +1,7 @@
 import type { Metadata } from 'next';
 import Image from 'next/image';
 
-import PoolModelViewer from '@/components/PoolModelViewer';
+import PoolModelSequence from '@/components/PoolModelSequence';
 
 const infoCards = [
   {
@@ -119,84 +119,7 @@ export default function Pool3DPage() {
           </p>
         </div>
 
-        <article className="rounded-[2rem] border border-slate-200 bg-white/90 p-3 shadow-2xl shadow-sky-950/10 dark:border-white/10 dark:bg-slate-900/90 sm:p-4">
-          <div className="mb-4 flex flex-col gap-3 px-2 pt-2 sm:px-3 lg:flex-row lg:items-end lg:justify-between">
-            <div className="max-w-3xl">
-              <span className="inline-flex rounded-full border border-emerald-200 bg-emerald-50 px-3 py-1 text-xs font-bold uppercase tracking-[0.18em] text-emerald-800 dark:border-emerald-300/30 dark:bg-emerald-300/10 dark:text-emerald-100">
-                Clean model
-              </span>
-              <h3 className="mt-3 text-2xl font-bold text-slate-950 dark:text-white sm:text-3xl">
-                Featured pool area model
-              </h3>
-              <p className="mt-2 text-sm leading-6 text-slate-600 dark:text-slate-300 sm:text-base sm:leading-7">
-                Use this cleaned GLB model as the primary coordination reference for layout, circulation, repair scope conversations and early refurbishment discussions.
-              </p>
-            </div>
-            <p className="text-xs font-semibold uppercase tracking-[0.18em] text-slate-500 dark:text-slate-400">
-              /images/pool/pool-area-3D-model.glb
-            </p>
-          </div>
-          <PoolModelViewer
-            modelSrc="/images/pool/pool-area-3D-model.glb"
-            modelName="James Square pool area 3D model"
-            loadingLabel="Loading the modelled pool area…"
-            ariaLabel="Interactive 3D model of the James Square heated indoor pool layout"
-            autoSpin
-            autoSpinSpeed={1.4}
-            size="hero"
-          />
-          <p className="px-2 pt-4 text-sm leading-6 text-slate-600 dark:text-slate-300 sm:px-3">
-            This model is a working visual reference created from the scan and may be refined as further photos, measurements and survey information become available.
-          </p>
-        </article>
-
-        <div className="grid gap-5 lg:grid-cols-2">
-          <article className="rounded-[2rem] border border-slate-200 bg-white/90 p-3 shadow-2xl shadow-sky-950/10 dark:border-white/10 dark:bg-slate-900/90 sm:p-4">
-            <div className="mb-4 flex flex-col gap-2 px-2 pt-2 sm:px-3">
-              <span className="w-fit rounded-full border border-sky-200 bg-sky-50 px-3 py-1 text-xs font-bold uppercase tracking-[0.18em] text-sky-800 dark:border-sky-300/30 dark:bg-sky-300/10 dark:text-sky-100">
-                Photo scan
-              </span>
-              <h3 className="text-2xl font-bold text-slate-950 dark:text-white">
-                Pool capture reference
-              </h3>
-              <p className="text-sm leading-6 text-slate-600 dark:text-slate-300">
-                Compare the cleaned model against the original photo scan to understand captured geometry, finishes and areas that may need survey confirmation.
-              </p>
-            </div>
-            <PoolModelViewer
-              modelSrc="/images/pool/pool-3D-photo-scan.glb"
-              modelName="James Square pool photo scan"
-              loadingLabel="Loading the pool photo scan…"
-              ariaLabel="Interactive 3D photo scan of the James Square heated indoor pool area"
-              autoSpin
-              autoSpinSpeed={1.1}
-              size="compact"
-            />
-          </article>
-
-          <article className="rounded-[2rem] border border-slate-200 bg-white/90 p-3 shadow-2xl shadow-sky-950/10 dark:border-white/10 dark:bg-slate-900/90 sm:p-4">
-            <div className="mb-4 flex flex-col gap-2 px-2 pt-2 sm:px-3">
-              <span className="w-fit rounded-full border border-violet-200 bg-violet-50 px-3 py-1 text-xs font-bold uppercase tracking-[0.18em] text-violet-800 dark:border-violet-300/30 dark:bg-violet-300/10 dark:text-violet-100">
-                Plant room
-              </span>
-              <h3 className="text-2xl font-bold text-slate-950 dark:text-white">
-                Plant room and office scan
-              </h3>
-              <p className="text-sm leading-6 text-slate-600 dark:text-slate-300">
-                Review this separate scan for plant, office and back-of-house context that supports contractor access planning and services discussions.
-              </p>
-            </div>
-            <PoolModelViewer
-              modelSrc="/images/pool/plant-room-and-office.glb"
-              modelName="James Square plant room and office scan"
-              loadingLabel="Loading the plant room and office scan…"
-              ariaLabel="Interactive 3D scan of the James Square pool plant room and office"
-              autoSpin
-              autoSpinSpeed={1.1}
-              size="compact"
-            />
-          </article>
-        </div>
+        <PoolModelSequence />
       </section>
 
       <section aria-labelledby="pool-details-heading" className="space-y-4">

--- a/src/components/LazyPoolModelCard.tsx
+++ b/src/components/LazyPoolModelCard.tsx
@@ -1,0 +1,125 @@
+'use client';
+
+import Image from 'next/image';
+import { useEffect, useState } from 'react';
+
+import PoolModelViewer from '@/components/PoolModelViewer';
+
+type PoolModelViewerSize = 'hero' | 'standard' | 'compact';
+
+type LazyPoolModelCardProps = {
+  ariaLabel: string;
+  autoSpin?: boolean;
+  autoSpinSpeed?: number;
+  badgeLabel: string;
+  description: string;
+  isActive: boolean;
+  loadingLabel: string;
+  modelName: string;
+  modelSrc: string;
+  onActivate: () => void;
+  size: PoolModelViewerSize;
+  thumbnailAlt: string;
+  thumbnailSrc: string;
+  title: string;
+};
+
+const previewHeightClasses: Record<PoolModelViewerSize, string> = {
+  hero: 'h-[360px] sm:h-[520px] lg:h-[680px]',
+  standard: 'h-[320px] sm:h-[440px] lg:h-[560px]',
+  compact: 'h-[280px] sm:h-[380px] lg:h-[480px]',
+};
+
+export default function LazyPoolModelCard({
+  ariaLabel,
+  autoSpin = false,
+  autoSpinSpeed = 2,
+  badgeLabel,
+  description,
+  isActive,
+  loadingLabel,
+  modelName,
+  modelSrc,
+  onActivate,
+  size,
+  thumbnailAlt,
+  thumbnailSrc,
+  title,
+}: LazyPoolModelCardProps) {
+  const [hasBeenActivated, setHasBeenActivated] = useState(isActive);
+
+  useEffect(() => {
+    if (isActive) {
+      setHasBeenActivated(true);
+    }
+  }, [isActive]);
+
+  const handleActivate = () => {
+    setHasBeenActivated(true);
+    onActivate();
+  };
+
+  return (
+    <>
+      <div className="mb-4 flex flex-col gap-2 px-2 pt-2 sm:px-3">
+        <span className="w-fit rounded-full border border-sky-200 bg-sky-50 px-3 py-1 text-xs font-bold uppercase tracking-[0.18em] text-sky-800 dark:border-sky-300/30 dark:bg-sky-300/10 dark:text-sky-100">
+          {badgeLabel}
+        </span>
+        <h3 className="text-2xl font-bold text-slate-950 dark:text-white sm:text-3xl">
+          {title}
+        </h3>
+        <p className="text-sm leading-6 text-slate-600 dark:text-slate-300 sm:text-base sm:leading-7">
+          {description}
+        </p>
+      </div>
+
+      {isActive ? (
+        <PoolModelViewer
+          modelSrc={modelSrc}
+          modelName={modelName}
+          loadingLabel={loadingLabel}
+          ariaLabel={ariaLabel}
+          autoSpin={autoSpin}
+          autoSpinSpeed={autoSpinSpeed}
+          size={size}
+        />
+      ) : (
+        <button
+          type="button"
+          onClick={handleActivate}
+          aria-label={`${ariaLabel}. Click to view and interact with 3D scan.`}
+          className="group relative block w-full overflow-hidden rounded-3xl border border-slate-200 bg-slate-950 text-left shadow-2xl shadow-sky-950/20 outline-none transition duration-300 hover:-translate-y-0.5 hover:scale-[1.01] focus-visible:ring-4 focus-visible:ring-sky-400/70 dark:border-white/10"
+        >
+          <span className={`relative block w-full ${previewHeightClasses[size]}`}>
+            <Image
+              src={thumbnailSrc}
+              alt={thumbnailAlt}
+              fill
+              sizes={size === 'hero' ? '100vw' : '(min-width: 1024px) 50vw, 100vw'}
+              className="object-cover opacity-80 transition duration-500 group-hover:scale-105 group-hover:opacity-95"
+              priority={size === 'hero'}
+              unoptimized
+            />
+            <span className="absolute inset-0 bg-gradient-to-t from-slate-950 via-slate-950/35 to-cyan-950/20" />
+            <span className="absolute inset-4 rounded-[1.35rem] border border-white/25 ring-2 ring-sky-300/30 transition duration-300 group-hover:ring-4 group-hover:ring-cyan-300/50 sm:inset-6" />
+            <span className="absolute left-1/2 top-1/2 flex -translate-x-1/2 -translate-y-1/2 flex-col items-center gap-4 text-center text-white">
+              <span className="relative flex h-20 w-20 items-center justify-center rounded-full bg-white/15 backdrop-blur-md">
+                <span className="absolute inset-0 rounded-full border border-cyan-200/70 animate-ping" />
+                <span className="absolute inset-2 rounded-full border border-white/60 animate-pulse" />
+                <span className="ml-1 h-0 w-0 border-y-[14px] border-l-[22px] border-y-transparent border-l-white drop-shadow-lg" />
+              </span>
+              <span className="max-w-xs rounded-2xl border border-white/20 bg-slate-950/70 px-5 py-3 text-sm font-bold uppercase tracking-[0.16em] shadow-xl backdrop-blur-md animate-pulse sm:text-base">
+                Click to view and interact with 3D scan
+              </span>
+              {hasBeenActivated ? (
+                <span className="rounded-full bg-white/90 px-3 py-1 text-xs font-bold uppercase tracking-[0.14em] text-slate-900">
+                  Switch back to this model
+                </span>
+              ) : null}
+            </span>
+          </span>
+        </button>
+      )}
+    </>
+  );
+}

--- a/src/components/PoolModelSequence.tsx
+++ b/src/components/PoolModelSequence.tsx
@@ -1,0 +1,103 @@
+'use client';
+
+import { useState } from 'react';
+
+import LazyPoolModelCard from '@/components/LazyPoolModelCard';
+
+const poolModels = [
+  {
+    id: 'clean-model',
+    wrapperClassName:
+      'rounded-[2rem] border border-slate-200 bg-white/90 p-3 shadow-2xl shadow-sky-950/10 dark:border-white/10 dark:bg-slate-900/90 sm:p-4',
+    badgeLabel: 'Clean model',
+    title: 'Featured pool area model',
+    description:
+      'Use this cleaned GLB model as the primary coordination reference for layout, circulation, repair scope conversations and early refurbishment discussions.',
+    modelSrc: '/images/pool/pool-area-3D-model.glb',
+    modelName: 'James Square pool area 3D model',
+    loadingLabel: 'Loading the modelled pool area…',
+    ariaLabel: 'Interactive 3D model of the James Square heated indoor pool layout',
+    size: 'hero' as const,
+    thumbnailSrc: '/images/pool/Pool-facing-south.png',
+    thumbnailAlt: 'Preview image of the James Square pool area facing south',
+    autoSpin: true,
+    autoSpinSpeed: 1.4,
+    footer:
+      'This model is a working visual reference created from the scan and may be refined as further photos, measurements and survey information become available.',
+  },
+  {
+    id: 'photo-scan',
+    wrapperClassName:
+      'rounded-[2rem] border border-slate-200 bg-white/90 p-3 shadow-2xl shadow-sky-950/10 dark:border-white/10 dark:bg-slate-900/90 sm:p-4',
+    badgeLabel: 'Photo scan',
+    title: 'Pool capture reference',
+    description:
+      'Compare the cleaned model against the original photo scan to understand captured geometry, finishes and areas that may need survey confirmation.',
+    modelSrc: '/images/pool/pool-3D-photo-scan.glb',
+    modelName: 'James Square pool photo scan',
+    loadingLabel: 'Loading the pool photo scan…',
+    ariaLabel: 'Interactive 3D photo scan of the James Square heated indoor pool area',
+    size: 'compact' as const,
+    thumbnailSrc: '/images/pool/3Dimage-facing-north.jpg',
+    thumbnailAlt: 'Preview image of the 3D pool model view facing north',
+    autoSpin: true,
+    autoSpinSpeed: 1.1,
+  },
+  {
+    id: 'plant-room',
+    wrapperClassName:
+      'rounded-[2rem] border border-slate-200 bg-white/90 p-3 shadow-2xl shadow-sky-950/10 dark:border-white/10 dark:bg-slate-900/90 sm:p-4',
+    badgeLabel: 'Plant room',
+    title: 'Plant room and office scan',
+    description:
+      'Review this separate scan for plant, office and back-of-house context that supports contractor access planning and services discussions.',
+    modelSrc: '/images/pool/plant-room-and-office.glb',
+    modelName: 'James Square plant room and office scan',
+    loadingLabel: 'Loading the plant room and office scan…',
+    ariaLabel: 'Interactive 3D scan of the James Square pool plant room and office',
+    size: 'compact' as const,
+    thumbnailSrc: '/images/pool/Pool-entrance.png',
+    thumbnailAlt: 'Preview image of the James Square pool entrance area',
+    autoSpin: true,
+    autoSpinSpeed: 1.1,
+  },
+];
+
+export default function PoolModelSequence() {
+  const [activeModelId, setActiveModelId] = useState<string | null>(null);
+  const [featuredModel, ...supportingModels] = poolModels;
+
+  return (
+    <>
+      <article className={featuredModel.wrapperClassName}>
+        <div className="mb-3 flex justify-end px-2 pt-2 sm:px-3">
+          <p className="text-xs font-semibold uppercase tracking-[0.18em] text-slate-500 dark:text-slate-400">
+            {featuredModel.modelSrc}
+          </p>
+        </div>
+        <LazyPoolModelCard
+          {...featuredModel}
+          isActive={activeModelId === featuredModel.id}
+          onActivate={() => setActiveModelId(featuredModel.id)}
+        />
+        {featuredModel.footer ? (
+          <p className="px-2 pt-4 text-sm leading-6 text-slate-600 dark:text-slate-300 sm:px-3">
+            {featuredModel.footer}
+          </p>
+        ) : null}
+      </article>
+
+      <div className="grid gap-5 lg:grid-cols-2">
+        {supportingModels.map((model) => (
+          <article key={model.id} className={model.wrapperClassName}>
+            <LazyPoolModelCard
+              {...model}
+              isActive={activeModelId === model.id}
+              onActivate={() => setActiveModelId(model.id)}
+            />
+          </article>
+        ))}
+      </div>
+    </>
+  );
+}


### PR DESCRIPTION
### Motivation
- Avoid mounting multiple PlayCanvas `PoolModelViewer` instances on page load to reduce CPU/memory usage and improve initial load performance.
- Only initialise a PlayCanvas app when the user explicitly requests to view a model, and preserve existing model metadata and paths.

### Description
- Add a client component `src/components/LazyPoolModelCard.tsx` that accepts props such as `modelSrc`, `modelName`, `loadingLabel`, `ariaLabel`, `size`, `thumbnailSrc`, `thumbnailAlt`, `title`, `description`, `badgeLabel`, `autoSpin`, and `autoSpinSpeed`, keeps local activation state, renders an accessible `<button>` thumbnail with Tailwind animations, and only mounts `PoolModelViewer` when active.
- Add `src/components/PoolModelSequence.tsx` which stores `activeModelId`, renders the three pool model cards (clean model, photo scan, plant room), and ensures only the card matching `activeModelId` mounts `PoolModelViewer` so previous viewers are unmounted and cleaned up.
- Update `src/app/pool3d/page.tsx` to import and render `PoolModelSequence` in place of the previous directly-mounted viewers while preserving GLB paths: `/images/pool/pool-area-3D-model.glb`, `/images/pool/pool-3D-photo-scan.glb`, and `/images/pool/plant-room-and-office.glb`.

### Testing
- `npm run lint` completed (only unrelated pre-existing ESLint warnings were reported). 
- `npx tsc --noEmit` completed successfully with no type errors.
- `npm run build` failed due to `next/font` being unable to fetch Google Fonts in the environment (network/font fetch failure), so a full production build could not complete.
- Dev server started successfully (`next dev`), and an automated Playwright screenshot attempt was blocked because Playwright failed to download browsers from its CDN (403), preventing headless screenshot verification.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a4bd0f024dc8324b4f7509b6c60aebe)