### PR TITLE
Redesign pool 3D hero experience

### DIFF
--- a/src/app/pool3d/page.tsx
+++ b/src/app/pool3d/page.tsx
@@ -2,6 +2,7 @@ import type { Metadata } from 'next';
 import Image from 'next/image';
 
 import PoolModelSequence from '@/components/PoolModelSequence';
+import PoolBuildHero from '@/components/pool/PoolBuildHero';
 
 const infoCards = [
   {
@@ -81,7 +82,9 @@ const poolImages = [
 
 export default function Pool3DPage() {
   return (
-    <main className="mx-auto max-w-7xl space-y-8 px-3 py-6 sm:px-5 lg:py-10">
+    <main className="mx-auto max-w-7xl space-y-8 px-3 pb-6 sm:px-5 lg:pb-10">
+      <PoolBuildHero />
+
       <section className="overflow-hidden rounded-[2rem] border border-sky-100 bg-gradient-to-br from-sky-50 via-white to-cyan-50 p-6 shadow-xl shadow-sky-950/5 dark:border-white/10 dark:from-slate-950 dark:via-slate-900 dark:to-cyan-950/40 sm:p-8 lg:p-10">
         <div className="max-w-4xl">
           <p className="mb-3 text-sm font-semibold uppercase tracking-[0.28em] text-sky-700 dark:text-sky-300">
@@ -106,7 +109,7 @@ export default function Pool3DPage() {
         </div>
       </section>
 
-      <section aria-labelledby="pool-models-heading" className="space-y-6">
+      <section id="pool-interactive-model" aria-labelledby="pool-models-heading" className="scroll-mt-6 space-y-6">
         <div className="max-w-4xl space-y-3 px-1">
           <p className="text-sm font-semibold uppercase tracking-[0.22em] text-sky-700 dark:text-sky-300">
             Interactive sequence

--- a/src/components/pool/PoolBuildHero.tsx
+++ b/src/components/pool/PoolBuildHero.tsx
@@ -1,0 +1,213 @@
+'use client';
+
+import { useCallback, useEffect, useRef, useState } from 'react';
+
+const VIDEO_SRC = '/images/pool/3D model.mp4';
+const SCROLL_EPSILON_SECONDS = 0.035;
+
+function clamp(value: number, min = 0, max = 1) {
+  return Math.min(Math.max(value, min), max);
+}
+
+function easeOutCubic(value: number) {
+  return 1 - Math.pow(1 - value, 3);
+}
+
+export default function PoolBuildHero() {
+  const sectionRef = useRef<HTMLElement | null>(null);
+  const videoRef = useRef<HTMLVideoElement | null>(null);
+  const frameRef = useRef<number | null>(null);
+  const lastTimeRef = useRef(-1);
+  const [progress, setProgress] = useState(0);
+  const [duration, setDuration] = useState(0);
+  const [isMobile, setIsMobile] = useState(false);
+  const [reducedMotion, setReducedMotion] = useState(false);
+  const [isReady, setIsReady] = useState(false);
+  const [hasEntered, setHasEntered] = useState(false);
+
+  const completeProgress = reducedMotion ? 1 : progress;
+  const easedProgress = easeOutCubic(completeProgress);
+  const textOpacity = clamp((completeProgress - 0.58) / 0.28);
+  const finalOpacity = clamp((completeProgress - 0.82) / 0.16);
+  const videoScale = 0.96 + easedProgress * 0.04;
+  const videoTranslate = 20 - easedProgress * 20;
+
+  const scrollToModel = useCallback(() => {
+    document.getElementById('pool-interactive-model')?.scrollIntoView({
+      behavior: reducedMotion ? 'auto' : 'smooth',
+      block: 'start',
+    });
+  }, [reducedMotion]);
+
+  useEffect(() => {
+    const mobileQuery = window.matchMedia('(max-width: 767px)');
+    const motionQuery = window.matchMedia('(prefers-reduced-motion: reduce)');
+
+    const syncQueries = () => {
+      setIsMobile(mobileQuery.matches);
+      setReducedMotion(motionQuery.matches);
+    };
+
+    syncQueries();
+    mobileQuery.addEventListener('change', syncQueries);
+    motionQuery.addEventListener('change', syncQueries);
+
+    return () => {
+      mobileQuery.removeEventListener('change', syncQueries);
+      motionQuery.removeEventListener('change', syncQueries);
+    };
+  }, []);
+
+  useEffect(() => {
+    const video = videoRef.current;
+    if (!video) return;
+
+    const onMetadata = () => {
+      setDuration(video.duration || 0);
+      setIsReady(true);
+      if (reducedMotion && Number.isFinite(video.duration)) {
+        video.currentTime = video.duration;
+        lastTimeRef.current = video.duration;
+        setProgress(1);
+      }
+    };
+
+    if (video.readyState >= 1) onMetadata();
+    video.addEventListener('loadedmetadata', onMetadata);
+    return () => video.removeEventListener('loadedmetadata', onMetadata);
+  }, [reducedMotion]);
+
+  useEffect(() => {
+    const video = videoRef.current;
+    if (!video || !duration) return;
+
+    video.pause();
+
+    if (reducedMotion) {
+      video.currentTime = duration;
+      lastTimeRef.current = duration;
+      setProgress(1);
+      return;
+    }
+
+    if (isMobile) {
+      video.currentTime = 0;
+      lastTimeRef.current = 0;
+      setProgress(0);
+      const playPromise = video.play();
+      playPromise?.catch(() => {
+        video.muted = true;
+        void video.play().catch(() => undefined);
+      });
+      return;
+    }
+
+    video.currentTime = 0;
+    lastTimeRef.current = 0;
+    setProgress(0);
+  }, [duration, isMobile, reducedMotion]);
+
+  useEffect(() => {
+    const section = sectionRef.current;
+    if (!section) return;
+
+    const observer = new IntersectionObserver(
+      ([entry]) => setHasEntered(entry.isIntersecting),
+      { threshold: 0.01 },
+    );
+
+    observer.observe(section);
+    return () => observer.disconnect();
+  }, []);
+
+  useEffect(() => {
+    if (!hasEntered || isMobile || reducedMotion || !duration) return;
+
+    const update = () => {
+      frameRef.current = null;
+      const section = sectionRef.current;
+      const video = videoRef.current;
+      if (!section || !video) return;
+
+      const rect = section.getBoundingClientRect();
+      const scrollable = Math.max(section.offsetHeight - window.innerHeight, 1);
+      const nextProgress = clamp(-rect.top / scrollable);
+      const nextTime = nextProgress * duration;
+
+      setProgress(nextProgress);
+      if (Math.abs(nextTime - lastTimeRef.current) >= SCROLL_EPSILON_SECONDS) {
+        video.currentTime = nextTime;
+        lastTimeRef.current = nextTime;
+      }
+    };
+
+    const requestUpdate = () => {
+      if (frameRef.current === null) {
+        frameRef.current = window.requestAnimationFrame(update);
+      }
+    };
+
+    requestUpdate();
+    window.addEventListener('scroll', requestUpdate, { passive: true });
+    window.addEventListener('resize', requestUpdate);
+
+    return () => {
+      window.removeEventListener('scroll', requestUpdate);
+      window.removeEventListener('resize', requestUpdate);
+      if (frameRef.current !== null) window.cancelAnimationFrame(frameRef.current);
+    };
+  }, [duration, hasEntered, isMobile, reducedMotion]);
+
+  return (
+    <section ref={sectionRef} className="relative -mx-3 h-[200vh] overflow-clip bg-slate-950 text-white sm:-mx-5 lg:-mx-[calc((100vw-80rem)/2)]" aria-labelledby="pool-build-hero-title">
+      <div className="sticky top-0 flex h-screen items-center justify-center overflow-hidden bg-[radial-gradient(circle_at_50%_38%,rgba(56,189,248,0.20),transparent_34%),radial-gradient(circle_at_50%_115%,rgba(14,165,233,0.16),transparent_45%),linear-gradient(180deg,#020617_0%,#06111f_52%,#020617_100%)] px-5 py-8 sm:px-8">
+        <div className="pointer-events-none absolute left-1/2 top-1/2 h-[42rem] w-[42rem] -translate-x-1/2 -translate-y-1/2 rounded-full bg-cyan-300/10 blur-3xl" />
+        <div className="pointer-events-none absolute inset-0 bg-[radial-gradient(circle_at_center,transparent_42%,rgba(2,6,23,0.72)_100%)]" />
+
+        <div className="relative z-10 flex h-full w-full max-w-6xl flex-col items-center justify-center gap-8">
+          <div className="text-center transition-opacity duration-700" style={{ opacity: isReady ? 1 : 0 }}>
+            <p className="text-xs font-semibold uppercase tracking-[0.34em] text-cyan-100/70">James Square</p>
+            <h1 id="pool-build-hero-title" className="mt-4 text-4xl font-semibold tracking-[-0.04em] text-white sm:text-6xl lg:text-7xl">
+              Swimming Pool 3D Model
+            </h1>
+            <p className="mt-5 text-sm font-medium text-slate-300 sm:text-base">Scroll to watch the digital model come to life.</p>
+          </div>
+
+          <div className="relative w-full max-w-5xl transition-transform duration-200 will-change-transform" style={{ transform: `translate3d(0, ${videoTranslate}px, 0) scale(${videoScale})` }}>
+            <div className="absolute -inset-8 rounded-[3rem] bg-cyan-200/10 blur-3xl" />
+            <div className="relative overflow-hidden rounded-[2rem] border border-white/10 bg-black/40 shadow-[0_2rem_5rem_rgba(0,0,0,0.55)]">
+              <video
+                ref={videoRef}
+                className="aspect-video w-full bg-slate-950 object-contain"
+                src={VIDEO_SRC}
+                muted
+                playsInline
+                preload="metadata"
+                onEnded={() => {
+                  const video = videoRef.current;
+                  if (!video) return;
+                  video.pause();
+                  setProgress(1);
+                }}
+                aria-label="Scroll controlled animation showing the James Square swimming pool 3D model being constructed"
+              />
+              <div className="pointer-events-none absolute inset-0 bg-[radial-gradient(circle_at_center,transparent_58%,rgba(2,6,23,0.62)_100%)]" />
+            </div>
+          </div>
+
+          <div className="max-w-2xl text-center transition duration-700" style={{ opacity: Math.max(textOpacity, reducedMotion ? 1 : 0), transform: `translateY(${(1 - textOpacity) * 12}px)` }}>
+            <p className="text-base leading-7 text-slate-300 sm:text-lg">
+              A clean construction sequence introduces the completed pool model before handing you directly into the interactive PlayCanvas viewer.
+            </p>
+            <div className="mt-6 flex flex-col items-center gap-3 sm:flex-row sm:justify-center" style={{ opacity: Math.max(finalOpacity, reducedMotion ? 1 : 0) }}>
+              <button type="button" onClick={scrollToModel} className="rounded-full bg-white px-6 py-3 text-sm font-semibold text-slate-950 shadow-2xl shadow-cyan-950/40 transition hover:-translate-y-0.5 hover:bg-cyan-50 focus:outline-none focus:ring-2 focus:ring-cyan-200 focus:ring-offset-2 focus:ring-offset-slate-950">
+                Explore the Model
+              </button>
+              <span className="text-xs font-semibold uppercase tracking-[0.22em] text-cyan-100/60">Interactive model below</span>
+            </div>
+          </div>
+        </div>
+      </div>
+    </section>
+  );
+}


### PR DESCRIPTION
### Motivation
- Introduce a premium, interactive hero that places the 3D build animation at the centre of the /pool3d experience and gives the visitor the feeling of constructing the model as they scroll.
- Use native browser APIs to scrub a supplied MP4 by scroll position (no autoplay on desktop), keeping the animation smoothly in sync and transitioning into the existing interactive PlayCanvas viewer.
- Respect accessibility and mobile constraints by supporting `prefers-reduced-motion` and providing a mobile autoplay fallback that does not duplicate or replace the PlayCanvas model.

### Description
- Add a new reusable client component `src/components/pool/PoolBuildHero.tsx` implementing a ~200vh sticky hero with premium dark radial gradients, soft vignette and shadow, elegant typography, and the MP4 build animation as the visual centerpiece.
- Implement scroll-controlled playback driven by `requestAnimationFrame` with metadata preloading, `IntersectionObserver` activation, and throttled `video.currentTime` updates using an epsilon threshold to avoid churn and keep scrubbing smooth.
- Include motion polish (subtle scale from 96→100%, 20px upward translate, eased text fade-ins) driven by a progress easing function while keeping all effects lightweight and library-free (no GSAP or large animation libs).
- Add mobile and accessibility fallbacks where mobile autoplays once and pauses at the final frame, and `prefers-reduced-motion` jumps to the final frame immediately; wire the final CTA to smoothly scroll to the existing PlayCanvas viewer via an added `id="pool-interactive-model"` anchor so the existing model is reused.

### Testing
- Ran `npx tsc --noEmit` which completed successfully with no type errors.
- Ran `npm run lint` which completed successfully; it reported pre-existing unrelated warnings in other files but no critical errors.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a4bd35b0ae883248675d705af1ea54e)