### PR TITLE
Fix pool 3D viewer canvas sizing and repair broken photo scan model

### DIFF
--- a/src/components/PoolModelViewer.tsx
+++ b/src/components/PoolModelViewer.tsx
@@ -125,8 +125,30 @@ export default function PoolModelViewer({
           app.destroy();
         };
 
-        app.setCanvasFillMode(pc.FILLMODE_FILL_WINDOW);
-        app.setCanvasResolution(pc.RESOLUTION_AUTO);
+        // Keep the canvas sized to its own container (set via CSS classes) rather than
+        // the browser window: FILLMODE_FILL_WINDOW forces canvas.style dimensions to
+        // window.innerWidth/innerHeight, which mismatches the card's fixed-height wrapper
+        // and distorts the camera's aspect ratio, especially on mobile.
+        app.setCanvasFillMode(pc.FILLMODE_NONE);
+
+        const resizeToContainer = () => {
+          const width = canvas.clientWidth;
+          const height = canvas.clientHeight;
+          if (width > 0 && height > 0) {
+            app.graphicsDevice.resizeCanvas(width, height);
+          }
+        };
+
+        resizeToContainer();
+
+        const resizeObserver = new ResizeObserver(resizeToContainer);
+        resizeObserver.observe(canvas);
+
+        cleanup = () => {
+          resizeObserver.disconnect();
+          app.destroy();
+        };
+
         app.scene.ambientLight = new pc.Color(0.55, 0.62, 0.68);
         app.scene.exposure = 1.28;
         (app.scene as unknown as { toneMapping: number }).toneMapping = pc.TONEMAP_ACES;
@@ -305,6 +327,7 @@ export default function PoolModelViewer({
           canvas.removeEventListener('contextmenu', onContextMenu);
           canvas.removeEventListener('touchmove', onTouchMove);
           window.removeEventListener('keydown', onKeyDown);
+          resizeObserver.disconnect();
           app.off('update', onUpdate);
           app.destroy();
         };


### PR DESCRIPTION
PoolModelViewer used FILLMODE_FILL_WINDOW, which forces the WebGL
canvas to the full browser window size regardless of its actual
container, distorting the camera aspect ratio and never re-syncing on
resize/orientation change. Switch to FILLMODE_NONE and drive the
render resolution from the canvas's own container size via a
ResizeObserver so the model fills its card correctly and stays in
sync on both desktop and mobile.

Also fix pool-photo-scan.glb: several bufferViews had byte offsets
that weren't 4-byte aligned, which threw "start offset of Float32Array
should be a multiple of 4" and made that model fail to load entirely.
Realigned the binary buffer views (and updated the affected offsets)
so the file conforms to the glTF spec.