### PR TITLE
Improve pool3d hero video, model viewer sizing, expand modal, and lighting

### DIFF
--- a/src/app/pool3d/page.tsx
+++ b/src/app/pool3d/page.tsx
@@ -109,8 +109,8 @@ export default function Pool3DPage() {
         </div>
       </section>
 
-      <section id="pool-interactive-model" aria-labelledby="pool-models-heading" className="scroll-mt-6 space-y-6">
-        <div className="max-w-4xl space-y-3 px-1">
+      <section id="pool-interactive-model" aria-labelledby="pool-models-heading" className="scroll-mt-28 space-y-6 xl:-mx-16 2xl:-mx-28">
+        <div className="max-w-4xl space-y-3 px-1 xl:px-16 2xl:px-28">
           <p className="text-sm font-semibold uppercase tracking-[0.22em] text-sky-700 dark:text-sky-300">
             Interactive sequence
           </p>

--- a/src/components/LazyPoolModelCard.tsx
+++ b/src/components/LazyPoolModelCard.tsx
@@ -1,9 +1,10 @@
 'use client';
 
-import { ArrowRight, Box } from 'lucide-react';
+import { ArrowRight, Box, Maximize2 } from 'lucide-react';
 import Image from 'next/image';
 import { useEffect, useState } from 'react';
 
+import PoolModelFullscreenModal from '@/components/PoolModelFullscreenModal';
 import PoolModelViewer from '@/components/PoolModelViewer';
 
 type PoolModelViewerSize = 'hero' | 'standard' | 'compact';
@@ -48,6 +49,7 @@ export default function LazyPoolModelCard({
   title,
 }: LazyPoolModelCardProps) {
   const [hasBeenActivated, setHasBeenActivated] = useState(isActive);
+  const [isFullscreen, setIsFullscreen] = useState(false);
 
   useEffect(() => {
     if (isActive) {
@@ -60,61 +62,92 @@ export default function LazyPoolModelCard({
     onActivate();
   };
 
+  const handleExpand = () => {
+    handleActivate();
+    setIsFullscreen(true);
+  };
+
   return (
     <article className="flex flex-col rounded-[2rem] border border-slate-200 bg-white/90 p-3 shadow-2xl shadow-sky-950/10 dark:border-white/10 dark:bg-slate-900/90 sm:p-4">
       {isActive ? (
-        <PoolModelViewer
-          modelSrc={modelSrc}
-          modelName={modelName}
-          loadingLabel={loadingLabel}
-          ariaLabel={ariaLabel}
-          autoSpin={autoSpin}
-          autoSpinSpeed={autoSpinSpeed}
-          size={size}
-        />
-      ) : (
-        <button
-          type="button"
-          onClick={handleActivate}
-          aria-label={`${ariaLabel}. Tap to view in 3D.`}
-          className="group relative block aspect-[4/3] w-full overflow-hidden rounded-3xl border border-white/10 bg-slate-950 text-left shadow-xl shadow-sky-950/20 outline-none transition-all duration-300 ease-out hover:-translate-y-1 hover:shadow-2xl hover:shadow-cyan-950/30 active:scale-[0.97] active:duration-150 focus-visible:ring-4 focus-visible:ring-sky-400/70"
-        >
-          <Image
-            src={thumbnailSrc}
-            alt={thumbnailAlt}
-            fill
-            sizes="(min-width: 768px) 33vw, 100vw"
-            className={`object-cover ${thumbnailPosition} transition-transform duration-500 ease-out group-hover:scale-105`}
-            priority={priority}
-            unoptimized
+        <div className="relative">
+          <PoolModelViewer
+            modelSrc={modelSrc}
+            modelName={modelName}
+            loadingLabel={loadingLabel}
+            ariaLabel={ariaLabel}
+            autoSpin={autoSpin}
+            autoSpinSpeed={autoSpinSpeed}
+            size={size}
           />
+          <button
+            type="button"
+            onClick={handleExpand}
+            aria-label={`Expand ${title} to full screen`}
+            className="absolute right-3 top-3 z-10 inline-flex items-center gap-1.5 rounded-full border border-white/20 bg-slate-950/70 px-3 py-2 text-xs font-semibold text-white shadow-lg backdrop-blur-md transition hover:bg-slate-950/90 focus:outline-none focus:ring-2 focus:ring-cyan-300"
+          >
+            <Maximize2 className="h-3.5 w-3.5" strokeWidth={2.5} />
+            <span className="hidden sm:inline">Full screen</span>
+          </button>
+        </div>
+      ) : (
+        <div className="group relative aspect-[4/3] w-full overflow-hidden rounded-3xl border border-white/10 bg-slate-950 shadow-xl shadow-sky-950/20 transition-all duration-300 ease-out hover:-translate-y-1 hover:shadow-2xl hover:shadow-cyan-950/30">
+          <button
+            type="button"
+            onClick={handleActivate}
+            aria-label={`${ariaLabel}. Tap to view in 3D.`}
+            className="absolute inset-0 block h-full w-full text-left outline-none active:scale-[0.97] active:duration-150 focus-visible:ring-4 focus-visible:ring-sky-400/70"
+          >
+            <Image
+              src={thumbnailSrc}
+              alt={thumbnailAlt}
+              fill
+              sizes="(min-width: 768px) 33vw, 100vw"
+              className={`object-cover ${thumbnailPosition} transition-transform duration-500 ease-out group-hover:scale-105`}
+              priority={priority}
+              unoptimized
+            />
 
-          <span className="pointer-events-none absolute inset-0 bg-gradient-to-t from-slate-950/95 via-slate-950/30 to-transparent" />
+            <span className="pointer-events-none absolute inset-0 bg-gradient-to-t from-slate-950/95 via-slate-950/30 to-transparent" />
 
-          <span className="pointer-events-none absolute right-3 top-3 flex h-9 w-9 items-center justify-center rounded-full bg-slate-950/60 text-cyan-100 shadow-lg ring-1 ring-white/25 backdrop-blur-md transition-transform duration-300 group-hover:scale-110">
-            <span className="absolute inset-0 rounded-full ring-2 ring-cyan-300/40 animate-ping" />
-            <Box className="relative h-4 w-4" strokeWidth={2} />
-          </span>
-
-          <span className="absolute inset-x-0 bottom-0 flex flex-col gap-1 p-4 sm:p-5">
-            <span className="text-lg font-bold leading-tight text-white drop-shadow-sm sm:text-xl">
-              {title}
+            <span className="pointer-events-none absolute right-3 top-3 flex h-9 w-9 items-center justify-center rounded-full bg-slate-950/60 text-cyan-100 shadow-lg ring-1 ring-white/25 backdrop-blur-md transition-transform duration-300 group-hover:scale-110">
+              <span className="absolute inset-0 rounded-full ring-2 ring-cyan-300/40 animate-ping" />
+              <Box className="relative h-4 w-4" strokeWidth={2} />
             </span>
-            <span className="text-xs text-slate-200 drop-shadow-sm sm:text-sm">{subtitle}</span>
-            <span className="mt-2 inline-flex w-fit items-center gap-1.5 rounded-full border border-white/25 bg-white/10 px-3 py-1 text-[11px] font-bold uppercase tracking-[0.14em] text-white backdrop-blur-md transition-colors duration-300 group-hover:border-cyan-200/70 group-hover:bg-white/20 sm:text-xs">
-              Tap to view in 3D
-              <ArrowRight
-                className="h-3.5 w-3.5 transition-transform duration-300 group-hover:translate-x-1"
-                strokeWidth={2.5}
-              />
-            </span>
-            {hasBeenActivated ? (
-              <span className="mt-1 w-fit rounded-full bg-white/90 px-2.5 py-0.5 text-[10px] font-bold uppercase tracking-[0.12em] text-slate-900">
-                Tap to reopen this view
+
+            <span className="absolute inset-x-0 bottom-0 flex flex-col gap-1 p-4 sm:p-5">
+              <span className="text-lg font-bold leading-tight text-white drop-shadow-sm sm:text-xl">
+                {title}
               </span>
-            ) : null}
-          </span>
-        </button>
+              <span className="text-xs text-slate-200 drop-shadow-sm sm:text-sm">{subtitle}</span>
+              <span className="mt-2 inline-flex w-fit items-center gap-1.5 rounded-full border border-white/25 bg-white/10 px-3 py-1 text-[11px] font-bold uppercase tracking-[0.14em] text-white backdrop-blur-md transition-colors duration-300 group-hover:border-cyan-200/70 group-hover:bg-white/20 sm:text-xs">
+                Tap to view in 3D
+                <ArrowRight
+                  className="h-3.5 w-3.5 transition-transform duration-300 group-hover:translate-x-1"
+                  strokeWidth={2.5}
+                />
+              </span>
+              {hasBeenActivated ? (
+                <span className="mt-1 w-fit rounded-full bg-white/90 px-2.5 py-0.5 text-[10px] font-bold uppercase tracking-[0.12em] text-slate-900">
+                  Tap to reopen this view
+                </span>
+              ) : null}
+            </span>
+          </button>
+
+          <button
+            type="button"
+            onClick={(event) => {
+              event.stopPropagation();
+              handleExpand();
+            }}
+            aria-label={`Expand ${title} to full screen`}
+            className="absolute left-3 top-3 z-10 inline-flex items-center gap-1.5 rounded-full border border-white/20 bg-slate-950/70 px-3 py-2 text-xs font-semibold text-white shadow-lg backdrop-blur-md transition hover:bg-slate-950/90 focus:outline-none focus:ring-2 focus:ring-cyan-300"
+          >
+            <Maximize2 className="h-3.5 w-3.5" strokeWidth={2.5} />
+            <span className="hidden sm:inline">Full screen</span>
+          </button>
+        </div>
       )}
 
       <div className="mt-4 px-1 sm:px-2">
@@ -125,6 +158,19 @@ export default function LazyPoolModelCard({
           </p>
         ) : null}
       </div>
+
+      {isFullscreen ? (
+        <PoolModelFullscreenModal
+          title={title}
+          modelSrc={modelSrc}
+          modelName={modelName}
+          loadingLabel={loadingLabel}
+          ariaLabel={ariaLabel}
+          autoSpin={autoSpin}
+          autoSpinSpeed={autoSpinSpeed}
+          onClose={() => setIsFullscreen(false)}
+        />
+      ) : null}
     </article>
   );
 }

--- a/src/components/PoolModelFullscreenModal.tsx
+++ b/src/components/PoolModelFullscreenModal.tsx
@@ -1,0 +1,78 @@
+'use client';
+
+import { X } from 'lucide-react';
+import { useEffect } from 'react';
+import { createPortal } from 'react-dom';
+
+import PoolModelViewer from '@/components/PoolModelViewer';
+
+type PoolModelFullscreenModalProps = {
+  ariaLabel: string;
+  autoSpin?: boolean;
+  autoSpinSpeed?: number;
+  loadingLabel: string;
+  modelName: string;
+  modelSrc: string;
+  onClose: () => void;
+  title: string;
+};
+
+export default function PoolModelFullscreenModal({
+  ariaLabel,
+  autoSpin,
+  autoSpinSpeed,
+  loadingLabel,
+  modelName,
+  modelSrc,
+  onClose,
+  title,
+}: PoolModelFullscreenModalProps) {
+  useEffect(() => {
+    const previousOverflow = document.body.style.overflow;
+    document.body.style.overflow = 'hidden';
+
+    const onKeyDown = (event: KeyboardEvent) => {
+      if (event.key === 'Escape') onClose();
+    };
+    window.addEventListener('keydown', onKeyDown);
+
+    return () => {
+      document.body.style.overflow = previousOverflow;
+      window.removeEventListener('keydown', onKeyDown);
+    };
+  }, [onClose]);
+
+  return createPortal(
+    <div
+      role="dialog"
+      aria-modal="true"
+      aria-label={`${title} — full screen view`}
+      className="fixed inset-0 z-[100] flex flex-col bg-slate-950/95 p-3 backdrop-blur-sm sm:p-6"
+    >
+      <div className="flex items-center justify-between gap-4 pb-3 sm:pb-4">
+        <h2 className="truncate text-sm font-bold uppercase tracking-[0.18em] text-cyan-100 sm:text-base">{title}</h2>
+        <button
+          type="button"
+          onClick={onClose}
+          autoFocus
+          className="inline-flex shrink-0 items-center gap-1.5 rounded-full border border-white/20 bg-white/10 px-4 py-2 text-sm font-semibold text-white backdrop-blur-md transition hover:bg-white/20 focus:outline-none focus:ring-2 focus:ring-cyan-300"
+        >
+          <X className="h-4 w-4" strokeWidth={2.5} />
+          Close
+        </button>
+      </div>
+      <div className="min-h-0 flex-1">
+        <PoolModelViewer
+          modelSrc={modelSrc}
+          modelName={modelName}
+          loadingLabel={loadingLabel}
+          ariaLabel={ariaLabel}
+          autoSpin={autoSpin}
+          autoSpinSpeed={autoSpinSpeed}
+          size="fullscreen"
+        />
+      </div>
+    </div>,
+    document.body,
+  );
+}

--- a/src/components/PoolModelSequence.tsx
+++ b/src/components/PoolModelSequence.tsx
@@ -65,7 +65,7 @@ export default function PoolModelSequence() {
   const [activeModelId, setActiveModelId] = useState<string | null>(null);
 
   return (
-    <div className="grid gap-6 md:grid-cols-3">
+    <div className="grid gap-6 xl:grid-cols-3">
       {poolModels.map((model) => (
         <LazyPoolModelCard
           key={model.id}

--- a/src/components/PoolModelViewer.tsx
+++ b/src/components/PoolModelViewer.tsx
@@ -16,7 +16,7 @@ type GlbContainerResource = {
   instantiateRenderEntity: (options?: { castShadows?: boolean }) => PlayCanvasEntity;
 };
 
-type PoolModelViewerSize = 'hero' | 'standard' | 'compact';
+type PoolModelViewerSize = 'hero' | 'standard' | 'compact' | 'fullscreen';
 
 const SUPPORTED_MODEL_EXTENSIONS = new Set(['glb', 'gltf']);
 const isDevelopment = process.env.NODE_ENV === 'development';
@@ -51,8 +51,9 @@ const checkModelUrl = async (modelSrc: string) => {
 
 const viewerHeightClasses: Record<PoolModelViewerSize, string> = {
   hero: 'h-[360px] sm:h-[520px] lg:h-[680px]',
-  standard: 'h-[320px] sm:h-[440px] lg:h-[560px]',
+  standard: 'h-[340px] sm:h-[460px] lg:h-[600px] xl:h-[460px] 2xl:h-[520px]',
   compact: 'h-[280px] sm:h-[380px] lg:h-[480px]',
+  fullscreen: 'h-full',
 };
 
 type PoolModelViewerProps = {
@@ -149,25 +150,34 @@ export default function PoolModelViewer({
           app.destroy();
         };
 
-        app.scene.ambientLight = new pc.Color(0.55, 0.62, 0.68);
-        app.scene.exposure = 1.28;
-        (app.scene as unknown as { toneMapping: number }).toneMapping = pc.TONEMAP_ACES;
+        // Neutral daylight setup with desaturated lights, a soft pale clear
+        // color and the Khronos "neutral" tonemapper for realistic exposure.
+        app.scene.ambientLight = new pc.Color(0.64, 0.65, 0.66);
+        app.scene.exposure = 1.05;
         app.start();
 
         const camera = new pc.Entity('Pool camera');
         camera.addComponent('camera', {
-          clearColor: new pc.Color(0.05, 0.06, 0.08),
+          clearColor: new pc.Color(0.78, 0.8, 0.82),
           farClip: 1000,
           fov: 42,
           nearClip: 0.08,
+          toneMapping: pc.TONEMAP_NEUTRAL,
         });
         app.root.addChild(camera);
+
+        // The window glass materials use the glTF KHR_materials_transmission
+        // extension (real refraction). Without a scene color grab pass, that
+        // shader has no background texture to sample and renders the glass
+        // as a flat, incorrect tint (seen here as a purple cast through the
+        // windows), so the scene color map must be requested explicitly.
+        camera.camera!.requestSceneColorMap(true);
 
         const keyLight = new pc.Entity('Main soft light');
         keyLight.addComponent('light', {
           type: 'directional',
-          color: new pc.Color(1, 0.96, 0.88),
-          intensity: 3.2,
+          color: new pc.Color(1, 0.98, 0.94),
+          intensity: 2.6,
           castShadows: true,
           shadowDistance: 35,
         });
@@ -177,8 +187,8 @@ export default function PoolModelViewer({
         const fillLight = new pc.Entity('Fill light');
         fillLight.addComponent('light', {
           type: 'directional',
-          color: new pc.Color(0.55, 0.7, 1),
-          intensity: 1.35,
+          color: new pc.Color(0.92, 0.94, 0.96),
+          intensity: 0.9,
         });
         fillLight.setEulerAngles(20, -135, 0);
         app.root.addChild(fillLight);
@@ -418,7 +428,7 @@ export default function PoolModelViewer({
   }, [autoSpin, autoSpinSpeed, introMotion, modelName, modelSrc]);
 
   return (
-    <div className="overflow-hidden rounded-3xl border border-slate-700 bg-slate-950 shadow-2xl shadow-sky-950/20">
+    <div className={`overflow-hidden rounded-3xl border border-slate-700 bg-slate-950 shadow-2xl shadow-sky-950/20 ${size === 'fullscreen' ? 'h-full' : ''}`}>
       <div className={`relative w-full ${viewerHeightClasses[size]}`}>
         <canvas
           ref={canvasRef}
@@ -427,7 +437,10 @@ export default function PoolModelViewer({
           className="h-full w-full touch-none bg-slate-950 outline-none"
         />
         {loadState !== 'ready' ? (
-          <div className="pointer-events-none absolute inset-0 flex items-center justify-center bg-slate-950/55 p-6 text-center text-sm font-semibold text-white">
+          <div className="pointer-events-none absolute inset-0 flex flex-col items-center justify-center gap-3 bg-slate-950/55 p-6 text-center text-sm font-semibold text-white">
+            {loadState === 'loading' ? (
+              <span className="h-8 w-8 animate-spin rounded-full border-2 border-white/25 border-t-cyan-300" aria-hidden="true" />
+            ) : null}
             {loadState === 'error' ? errorMessage : loadingLabel}
           </div>
         ) : null}

--- a/src/components/pool/PoolBuildHero.tsx
+++ b/src/components/pool/PoolBuildHero.tsx
@@ -3,34 +3,17 @@
 import { useCallback, useEffect, useRef, useState } from 'react';
 
 const VIDEO_SRC = '/images/pool/3D model.mp4';
-const SCROLL_EPSILON_SECONDS = 0.02;
+const REVERSE_END_THRESHOLD_SECONDS = 0.05;
 
-function clamp(value: number, min = 0, max = 1) {
-  return Math.min(Math.max(value, min), max);
-}
-
-function easeOutCubic(value: number) {
-  return 1 - Math.pow(1 - value, 3);
-}
+type PlaybackDirection = 'forward' | 'reverse';
 
 export default function PoolBuildHero() {
-  const sectionRef = useRef<HTMLElement | null>(null);
   const videoRef = useRef<HTMLVideoElement | null>(null);
-  const frameRef = useRef<number | null>(null);
-  const lastTimeRef = useRef(-1);
-  const [progress, setProgress] = useState(0);
-  const [duration, setDuration] = useState(0);
-  const [isMobile, setIsMobile] = useState(false);
-  const [reducedMotion, setReducedMotion] = useState(false);
+  const rafRef = useRef<number | null>(null);
+  const lastTimestampRef = useRef<number | null>(null);
+  const directionRef = useRef<PlaybackDirection>('forward');
   const [isReady, setIsReady] = useState(false);
-  const [hasEntered, setHasEntered] = useState(false);
-
-  const completeProgress = reducedMotion || isMobile ? 1 : progress;
-  const easedProgress = easeOutCubic(completeProgress);
-  const textOpacity = clamp((completeProgress - 0.58) / 0.28);
-  const finalOpacity = clamp((completeProgress - 0.82) / 0.16);
-  const videoScale = 0.96 + easedProgress * 0.04;
-  const videoTranslate = 20 - easedProgress * 20;
+  const [reducedMotion, setReducedMotion] = useState(false);
 
   const scrollToModel = useCallback(() => {
     document.getElementById('pool-interactive-model')?.scrollIntoView({
@@ -40,174 +23,125 @@ export default function PoolBuildHero() {
   }, [reducedMotion]);
 
   useEffect(() => {
-    const mobileQuery = window.matchMedia('(max-width: 767px)');
     const motionQuery = window.matchMedia('(prefers-reduced-motion: reduce)');
-
-    const syncQueries = () => {
-      setIsMobile(mobileQuery.matches);
-      setReducedMotion(motionQuery.matches);
-    };
-
-    syncQueries();
-    mobileQuery.addEventListener('change', syncQueries);
-    motionQuery.addEventListener('change', syncQueries);
-
-    return () => {
-      mobileQuery.removeEventListener('change', syncQueries);
-      motionQuery.removeEventListener('change', syncQueries);
-    };
+    const sync = () => setReducedMotion(motionQuery.matches);
+    sync();
+    motionQuery.addEventListener('change', sync);
+    return () => motionQuery.removeEventListener('change', sync);
   }, []);
+
+  // Native reverse playback (negative playbackRate) isn't supported reliably
+  // across browsers, so the reverse phase is driven by manually stepping
+  // currentTime backwards on each animation frame instead.
+  const stepReverse = useCallback((timestamp: number) => {
+    const video = videoRef.current;
+    if (!video) return;
+
+    if (lastTimestampRef.current === null) {
+      lastTimestampRef.current = timestamp;
+    }
+    const deltaSeconds = (timestamp - lastTimestampRef.current) / 1000;
+    lastTimestampRef.current = timestamp;
+
+    const nextTime = video.currentTime - deltaSeconds;
+
+    if (nextTime <= REVERSE_END_THRESHOLD_SECONDS) {
+      video.currentTime = 0;
+      lastTimestampRef.current = null;
+      directionRef.current = 'forward';
+      void video.play().catch(() => undefined);
+      return;
+    }
+
+    video.currentTime = nextTime;
+    rafRef.current = window.requestAnimationFrame(stepReverse);
+  }, []);
+
+  const startReverse = useCallback(() => {
+    const video = videoRef.current;
+    if (!video) return;
+    video.pause();
+    directionRef.current = 'reverse';
+    lastTimestampRef.current = null;
+    rafRef.current = window.requestAnimationFrame(stepReverse);
+  }, [stepReverse]);
 
   useEffect(() => {
     const video = videoRef.current;
     if (!video) return;
 
-    const onMetadata = () => {
-      setDuration(video.duration || 0);
-      setIsReady(true);
-      if (reducedMotion && Number.isFinite(video.duration)) {
-        video.currentTime = video.duration;
-        lastTimeRef.current = video.duration;
-        setProgress(1);
+    const handleLoadedData = () => setIsReady(true);
+    const handleEnded = () => {
+      if (directionRef.current === 'forward') {
+        startReverse();
       }
     };
 
-    if (video.readyState >= 1) onMetadata();
-    video.addEventListener('loadedmetadata', onMetadata);
-    return () => video.removeEventListener('loadedmetadata', onMetadata);
-  }, [reducedMotion]);
-
-  useEffect(() => {
-    const video = videoRef.current;
-    if (!video || !duration) return;
-
-    video.pause();
+    video.addEventListener('loadeddata', handleLoadedData);
+    video.addEventListener('ended', handleEnded);
+    if (video.readyState >= 2) setIsReady(true);
 
     if (reducedMotion) {
-      video.currentTime = duration;
-      lastTimeRef.current = duration;
-      setProgress(1);
-      return;
-    }
-
-    if (isMobile) {
+      video.pause();
       video.currentTime = 0;
-      lastTimeRef.current = 0;
-      setProgress(0);
+    } else {
+      directionRef.current = 'forward';
       const playPromise = video.play();
       playPromise?.catch(() => {
         video.muted = true;
         void video.play().catch(() => undefined);
       });
-      return;
     }
 
-    video.currentTime = 0;
-    lastTimeRef.current = 0;
-    setProgress(0);
-  }, [duration, isMobile, reducedMotion]);
-
-  useEffect(() => {
-    const section = sectionRef.current;
-    if (!section) return;
-
-    const observer = new IntersectionObserver(
-      ([entry]) => setHasEntered(entry.isIntersecting),
-      { threshold: 0.01 },
-    );
-
-    observer.observe(section);
-    return () => observer.disconnect();
-  }, []);
-
-  useEffect(() => {
-    if (!hasEntered || isMobile || reducedMotion || !duration) return;
-
-    const update = () => {
-      frameRef.current = null;
-      const section = sectionRef.current;
-      const video = videoRef.current;
-      if (!section || !video) return;
-
-      const rect = section.getBoundingClientRect();
-      const scrollable = Math.max(section.offsetHeight - window.innerHeight, 1);
-      const nextProgress = clamp(-rect.top / scrollable);
-      const nextTime = nextProgress * duration;
-
-      setProgress(nextProgress);
-      if (Math.abs(nextTime - lastTimeRef.current) >= SCROLL_EPSILON_SECONDS) {
-        video.currentTime = nextTime;
-        lastTimeRef.current = nextTime;
-      }
-    };
-
-    const requestUpdate = () => {
-      if (frameRef.current === null) {
-        frameRef.current = window.requestAnimationFrame(update);
-      }
-    };
-
-    requestUpdate();
-    window.addEventListener('scroll', requestUpdate, { passive: true });
-    window.addEventListener('resize', requestUpdate);
-
     return () => {
-      window.removeEventListener('scroll', requestUpdate);
-      window.removeEventListener('resize', requestUpdate);
-      if (frameRef.current !== null) window.cancelAnimationFrame(frameRef.current);
+      video.removeEventListener('loadeddata', handleLoadedData);
+      video.removeEventListener('ended', handleEnded);
+      if (rafRef.current !== null) window.cancelAnimationFrame(rafRef.current);
     };
-  }, [duration, hasEntered, isMobile, reducedMotion]);
+  }, [reducedMotion, startReverse]);
 
   return (
-    <section ref={sectionRef} className="relative -mx-3 h-auto overflow-clip bg-slate-950 text-white sm:-mx-5 md:h-[160vh] lg:-mx-[calc((100vw-80rem)/2)]" aria-labelledby="pool-build-hero-title">
-      <div className="relative flex flex-col items-center justify-center overflow-hidden bg-[radial-gradient(circle_at_50%_38%,rgba(56,189,248,0.20),transparent_34%),radial-gradient(circle_at_50%_115%,rgba(14,165,233,0.16),transparent_45%),linear-gradient(180deg,#020617_0%,#06111f_52%,#020617_100%)] px-5 py-10 sm:px-8 md:sticky md:top-0 md:h-screen md:py-8">
+    <section className="relative -mx-3 overflow-hidden bg-slate-950 text-white sm:-mx-5 lg:-mx-[calc((100vw-80rem)/2)]" aria-labelledby="pool-build-hero-title">
+      <div className="relative flex flex-col items-center justify-center gap-8 overflow-hidden bg-[radial-gradient(circle_at_50%_38%,rgba(56,189,248,0.20),transparent_34%),radial-gradient(circle_at_50%_115%,rgba(14,165,233,0.16),transparent_45%),linear-gradient(180deg,#020617_0%,#06111f_52%,#020617_100%)] px-5 py-10 sm:px-8 md:py-14">
         <div className="pointer-events-none absolute left-1/2 top-1/2 h-[42rem] w-[42rem] -translate-x-1/2 -translate-y-1/2 rounded-full bg-cyan-300/10 blur-3xl" />
-        <div className="pointer-events-none absolute inset-0 bg-[radial-gradient(circle_at_center,transparent_42%,rgba(2,6,23,0.72)_100%)]" />
 
-        <div className="relative z-10 flex h-full w-full max-w-6xl flex-col items-center justify-center gap-8">
-          <div className="text-center transition-opacity duration-700" style={{ opacity: isReady ? 1 : 0 }}>
-            <p className="text-xs font-semibold uppercase tracking-[0.34em] text-cyan-100/70">James Square</p>
-            <h1 id="pool-build-hero-title" className="mt-4 text-4xl font-semibold tracking-[-0.04em] text-white sm:text-6xl lg:text-7xl">
-              Swimming Pool 3D Model
-            </h1>
-            <p className="mt-5 text-sm font-medium text-slate-300 sm:text-base">Scroll to watch the digital model come to life.</p>
-          </div>
+        <div className="relative z-10 w-full max-w-6xl text-center">
+          <p className="text-xs font-semibold uppercase tracking-[0.34em] text-cyan-100/70">James Square</p>
+          <h1 id="pool-build-hero-title" className="mt-4 text-4xl font-semibold tracking-[-0.04em] text-white sm:text-6xl lg:text-7xl">
+            Swimming Pool 3D Model
+          </h1>
+        </div>
 
-          <div className="relative w-full max-w-5xl transition-transform duration-200 will-change-transform" style={{ transform: `translate3d(0, ${videoTranslate}px, 0) scale(${videoScale})` }}>
-            <div className="absolute -inset-8 rounded-[3rem] bg-cyan-200/10 blur-3xl" />
-            <div className="relative h-[300px] overflow-hidden rounded-[2rem] border border-white/10 shadow-[0_2rem_5rem_rgba(0,0,0,0.55)] sm:h-[420px] md:h-[480px] lg:h-[600px]">
-              <video
-                ref={videoRef}
-                className="h-full w-full object-cover"
-                src={VIDEO_SRC}
-                muted
-                playsInline
-                loop={isMobile}
-                preload={isMobile ? 'metadata' : 'auto'}
-                onEnded={() => {
-                  const video = videoRef.current;
-                  if (!video) return;
-                  video.pause();
-                  setProgress(1);
-                }}
-                aria-label="Scroll controlled animation showing the James Square swimming pool 3D model being constructed"
-              />
-              <div className="pointer-events-none absolute inset-0 bg-gradient-to-t from-slate-950/70 via-transparent to-slate-950/10" />
-              <div className="pointer-events-none absolute inset-0 bg-[radial-gradient(circle_at_center,transparent_58%,rgba(2,6,23,0.45)_100%)]" />
+        <div className="relative z-10 w-full max-w-5xl">
+          <div className="absolute -inset-8 rounded-[3rem] bg-cyan-200/10 blur-3xl" />
+          <div className="relative h-[260px] overflow-hidden rounded-[2rem] border border-white/10 shadow-[0_2rem_5rem_rgba(0,0,0,0.55)] sm:h-[380px] md:h-[460px] lg:h-[560px]">
+            <video
+              ref={videoRef}
+              className="h-full w-full object-cover transition-opacity duration-700"
+              style={{ opacity: isReady ? 1 : 0 }}
+              src={VIDEO_SRC}
+              muted
+              autoPlay
+              playsInline
+              preload="auto"
+              aria-label="Looping animation of the James Square swimming pool 3D model playing forward then in reverse"
+            />
+            <div className="pointer-events-none absolute inset-0 bg-gradient-to-t from-slate-950/70 via-transparent to-slate-950/10" />
+            <div className="pointer-events-none absolute inset-0 bg-[radial-gradient(circle_at_center,transparent_58%,rgba(2,6,23,0.45)_100%)]" />
+
+            <div className="pointer-events-none absolute inset-x-0 bottom-0 flex justify-center pb-5 sm:pb-7">
+              <span className="rounded-full border border-white/15 bg-slate-950/60 px-4 py-2 text-xs font-semibold uppercase tracking-[0.2em] text-cyan-100 backdrop-blur-md sm:text-sm">
+                Explore the Pool Area in 3D
+              </span>
             </div>
           </div>
+        </div>
 
-          <div className="max-w-2xl text-center transition duration-700" style={{ opacity: Math.max(textOpacity, reducedMotion ? 1 : 0), transform: `translateY(${(1 - textOpacity) * 12}px)` }}>
-            <p className="text-base leading-7 text-slate-300 sm:text-lg">
-              A clean construction sequence introduces the completed pool model before handing you directly into the interactive PlayCanvas viewer.
-            </p>
-            <div className="mt-6 flex flex-col items-center gap-3 sm:flex-row sm:justify-center" style={{ opacity: Math.max(finalOpacity, reducedMotion ? 1 : 0) }}>
-              <button type="button" onClick={scrollToModel} className="rounded-full bg-white px-6 py-3 text-sm font-semibold text-slate-950 shadow-2xl shadow-cyan-950/40 transition hover:-translate-y-0.5 hover:bg-cyan-50 focus:outline-none focus:ring-2 focus:ring-cyan-200 focus:ring-offset-2 focus:ring-offset-slate-950">
-                Explore the Model
-              </button>
-              <span className="text-xs font-semibold uppercase tracking-[0.22em] text-cyan-100/60">Interactive model below</span>
-            </div>
-          </div>
+        <div className="relative z-10 flex flex-col items-center gap-3 sm:flex-row">
+          <button type="button" onClick={scrollToModel} className="rounded-full bg-white px-6 py-3 text-sm font-semibold text-slate-950 shadow-2xl shadow-cyan-950/40 transition hover:-translate-y-0.5 hover:bg-cyan-50 focus:outline-none focus:ring-2 focus:ring-cyan-200 focus:ring-offset-2 focus:ring-offset-slate-950">
+            Explore the Model
+          </button>
+          <span className="text-xs font-semibold uppercase tracking-[0.22em] text-cyan-100/60">Interactive model below</span>
         </div>
       </div>
     </section>


### PR DESCRIPTION
- Replace scroll-jacked hero video with autoplay forward/reverse/forward
  looping, driven by JS currentTime stepping since native reverse playback
  isn't reliable. Title no longer waits on video readiness so it can't be
  blocked by a slow/failed video load.
- Give desktop model viewers a much larger inspection-panel footprint and
  add a full screen expand button (with close, orbit/zoom/pan) on each
  card via a new PoolModelFullscreenModal.
- Fix the purple window glow: the glTF window glass materials use
  KHR_materials_transmission, which needs a scene color grab pass to
  render correctly. Missing that (plus a broken scene.toneMapping call
  removed in this PlayCanvas version) caused the transmission shader to
  fall back to an incorrect tint. Move tonemapping onto the camera
  component, request the scene color map, and use neutral desaturated
  lighting/clear color for a realistic daylight look.
- Add a loading spinner to the model viewer overlay and bump the section's
  scroll-margin so the sticky header no longer covers content/buttons when
  jumping to the model section.