### PR TITLE
Add public pool safety page and private RLSS report

### DIFF
--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -494,3 +494,21 @@ body::before {
   transform: scale(0.96);
   opacity: 0.88;
 }
+
+/* Hide site chrome when a page is printed / exported to PDF (e.g. the RLSS
+   safety report), so the export contains only the report content. */
+@media print {
+  .header-safe-wrapper,
+  footer {
+    display: none !important;
+  }
+  body {
+    background: #ffffff !important;
+    background-image: none !important;
+  }
+  main.site-content {
+    max-width: none !important;
+    margin: 0 !important;
+    padding: 0 !important;
+  }
+}

--- a/src/app/pool-safety/page.tsx
+++ b/src/app/pool-safety/page.tsx
@@ -55,6 +55,17 @@ const facilityPhotos = [
     alt: 'One of the changing rooms',
     caption: 'Changing rooms',
   },
+  {
+    src: '/images/pool/32-air-source-heatpump-to-heat-pool.jpeg',
+    alt: 'The air source heat pump used to heat the pool',
+    caption: 'Air source heat pump',
+  },
+];
+
+const openingHours = [
+  { area: 'Pool', hours: '5.30am – 11.00pm', note: 'closed 9.30–11.00am daily for cleaning · no booking required' },
+  { area: 'Gym', hours: '11.00am – 5.00pm', note: 'booking recommended' },
+  { area: 'Sauna', hours: '5.00pm – 11.00pm', note: 'booking recommended' },
 ];
 
 const waterQualityRanges = [
@@ -77,83 +88,104 @@ const emergencyEquipment = [
 const signagePhotos = [
   {
     src: '/images/pool/01-entrance-hallway.jpeg',
-    alt: 'Entrance signage: no eating or drinking, CCTV in operation, no outdoor footwear, hygiene notice and the resident booking QR code',
-    caption: 'Entrance notices: no eating/drinking, CCTV in operation, no outdoor footwear, hygiene reminder and the booking QR code',
+    alt: 'Entrance signage: no eating or drinking, CCTV in operation, no outdoor footwear and hygiene notices',
+    caption: 'Entrance notices: no eating/drinking, CCTV in operation, no outdoor footwear and hygiene reminder',
+  },
+  {
+    src: '/images/pool/05-remove-outer-footwear-sign.jpeg',
+    alt: 'No outdoor footwear sign',
+    caption: 'No outdoor footwear',
+  },
+  {
+    src: '/images/pool/10-covid-sign.jpeg',
+    alt: 'Visitor hygiene notice asking people to wash hands regularly',
+    caption: 'Visitor hygiene notice',
+  },
+  {
+    src: '/images/pool/29-shower-notice-sign.jpeg',
+    alt: 'Please shower before entering the pool and after using the sauna',
+    caption: 'Please shower before entering the pool',
+  },
+  {
+    src: '/images/pool/09-internal-door-11pm-alarm-sign.jpeg',
+    alt: 'Pool opening times and the 11pm vacate / alarm reminder notice',
+    caption: 'Pool opening times and 11pm vacate reminder',
+  },
+  {
+    src: '/images/pool/24-no-diving-signage.jpeg',
+    alt: 'No diving sign displayed poolside, next to a lifebuoy',
+    caption: 'No diving',
+  },
+  {
+    src: '/images/pool/16-deep-end-sign-no-running-sign.jpeg',
+    alt: 'Deep end depth marker (1.70m) and no running sign',
+    caption: 'Deep end depth marker & no running',
+  },
+  {
+    src: '/images/pool/28-shallow-end-sign-no-running-and-clock.jpeg',
+    alt: 'Shallow end depth marker (0.80m) and no running sign',
+    caption: 'Shallow end depth marker & no running',
+  },
+  {
+    src: '/images/pool/30-contamination-sign.jpeg',
+    alt: 'Warning: risk of cross contamination — all surfaces must be cleaned before and after use',
+    caption: 'Cross contamination warning',
+  },
+  {
+    src: '/images/pool/26-lifebuoy-number2.jpeg',
+    alt: 'Lifebuoy for emergency use only',
+    caption: 'Lifebuoy for emergency use only',
+  },
+  {
+    src: '/images/pool/20-fire-door.jpeg',
+    alt: 'Fire door keep closed sign and emergency exit break-glass notice',
+    caption: 'Fire door & emergency exit signage',
   },
   {
     src: '/images/pool/Pool-entrance.png',
-    alt: 'Lifebuoy for emergency use only, next to a fire alarm call point at the pool hall exit',
-    caption: 'Lifebuoy (“for emergency use only”) and fire alarm call point at the pool hall exit',
-  },
-  {
-    src: '/images/pool/Pool-facing-south.png',
-    alt: 'No diving sign displayed poolside',
-    caption: 'No diving sign, displayed poolside',
-  },
-  {
-    src: '/images/pool/05-sauna-entrance-door.jpeg',
-    alt: 'Hygiene notice and single-household changing room notice',
-    caption: 'Hygiene reminder and single-household changing room notice',
-  },
-  {
-    src: '/images/pool/03-gym-facing-south.jpeg',
-    alt: 'Hygiene and cross-contamination warning signage in the gym',
-    caption: 'Hygiene and cross-contamination warning notices',
+    alt: 'Fire alarm call point at the pool hall exit',
+    caption: 'Fire alarm call point',
   },
 ];
 
 const fullSignageList = [
-  { label: 'No outdoor footwear', photographed: true },
-  { label: 'CCTV in operation', photographed: true },
-  { label: 'No eating or drinking', photographed: true },
-  { label: 'Shower before entering the pool', photographed: false },
-  { label: 'Hand sanitising notice', photographed: true },
-  { label: 'Fire action notices', photographed: false },
-  { label: 'Pool opening hours', photographed: false },
-  { label: 'Building alarm reminder', photographed: false },
-  { label: 'Deep end depth marker (1.70m)', photographed: false },
-  { label: 'Shallow end depth marker (0.80m)', photographed: false },
-  { label: 'No running', photographed: false },
-  { label: 'Lifebuoy for emergency use only', photographed: true },
-  { label: 'Cross contamination warning', photographed: true },
-  { label: 'Fire door signage', photographed: false },
-  { label: 'Emergency exit signage', photographed: false },
+  'No outdoor footwear',
+  'CCTV in operation',
+  'No eating or drinking',
+  'Shower before entering the pool',
+  'Hand sanitising / visitor hygiene notice',
+  'Fire action notices',
+  'Pool opening hours',
+  'Building alarm reminder',
+  'Deep end depth marker (1.70m)',
+  'Shallow end depth marker (0.80m)',
+  'No running',
+  'Lifebuoy for emergency use only',
+  'Cross contamination warning',
+  'Fire door signage',
+  'Emergency exit signage',
 ];
 
-const poolRuleGroups = [
-  {
-    title: 'Supervision & who can use the pool',
-    items: [
-      'For the use of James Square residents and their invited guests only.',
-      'Children under 16 must be accompanied by a responsible adult at all times.',
-    ],
-  },
-  {
-    title: 'Hygiene',
-    items: [
-      'Please shower before entering the pool.',
-      'Please use hand sanitiser on entry.',
-      'No outdoor footwear beyond the entrance.',
-    ],
-  },
-  {
-    title: 'Safe use',
-    items: [
-      'No diving.',
-      'No running around the pool or wet areas.',
-      'No eating or drinking in the pool hall.',
-      'Take care using the sauna and follow the posted guidance for safe use.',
-    ],
-  },
-  {
-    title: 'Conduct & shared use',
-    items: [
-      'No alcohol and no smoking anywhere in the facility.',
-      'Please leave the pool area by 11pm.',
-      'Please do not obstruct or misuse lifebuoys, reach poles or other emergency equipment.',
-      'Please be considerate of other residents sharing the space.',
-    ],
-  },
+const poolRules = [
+  'All users must shower before entering the pool or sauna (this cuts down on chemical usage and is better for the environment).',
+  'No more than six people from any one flat may use the recreation facilities at any one time, and should be accompanied by the person responsible for anyone gaining entry with them.',
+  'The taking of glass or other breakable vessels into the recreation area is dangerous and strictly prohibited.',
+  'No alcohol to be consumed in the recreation area.',
+  'Smoking is strictly prohibited in the recreation area.',
+  'No unaccompanied children under 16 are permitted to use the recreation area.',
+  'Outdoor footwear must be removed before entering the area. Shoe covers are provided.',
+  'Swimming/sports attire must be worn at all times.',
+  'No ball games, and no items such as airbeds etc, to be taken into the pool or leisure area.',
+  'No animals are allowed.',
+  'Lifebelts are for emergency use only.',
+  'The emergency exit is only for use in a genuine emergency — on no account should it be used for access or exit at any other time.',
+  'Only fresh water, in very small quantities, is to be sprinkled on the coals in the sauna; pool water must not be used, as it will create toxic vapour.',
+  'Please switch off the sauna and showers after use.',
+  'Excessive noise is as unacceptable in these areas as anywhere else in the development.',
+  'Owners will at all times be held responsible for the health and safety of anyone they bring into the facility.',
+  'Any person causing damage will be required to pay the cost involved in repair or replacement.',
+  'No running.',
+  'No jumping into the pool.',
 ];
 
 export default function PoolSafetyPage() {
@@ -237,7 +269,27 @@ export default function PoolSafetyPage() {
             gym, changing rooms, showers and toilets
           </li>
         </ul>
-        <div className="grid grid-cols-2 gap-3 sm:grid-cols-4">
+        <div className="overflow-hidden rounded-2xl border border-slate-200 dark:border-white/10">
+          <table className="w-full text-left text-sm">
+            <thead className="bg-sky-50 text-xs font-semibold uppercase tracking-wide text-sky-800 dark:bg-sky-300/10 dark:text-sky-100">
+              <tr>
+                <th className="px-4 py-2.5">Area</th>
+                <th className="px-4 py-2.5">Opening hours</th>
+                <th className="px-4 py-2.5">Note</th>
+              </tr>
+            </thead>
+            <tbody className="divide-y divide-slate-200 dark:divide-white/10">
+              {openingHours.map((row) => (
+                <tr key={row.area} className="bg-white dark:bg-slate-900/60">
+                  <td className="px-4 py-2.5 font-medium text-slate-900 dark:text-white">{row.area}</td>
+                  <td className="px-4 py-2.5 text-slate-700 dark:text-slate-200">{row.hours}</td>
+                  <td className="px-4 py-2.5 text-xs text-slate-500 dark:text-slate-400">{row.note}</td>
+                </tr>
+              ))}
+            </tbody>
+          </table>
+        </div>
+        <div className="grid grid-cols-2 gap-3 sm:grid-cols-5">
           {facilityPhotos.map((photo) => (
             <figure
               key={photo.src}
@@ -284,8 +336,8 @@ export default function PoolSafetyPage() {
           <figure className="overflow-hidden rounded-2xl border border-slate-200 bg-white shadow-sm dark:border-white/10 dark:bg-slate-900">
             <div className="relative aspect-[4/3] w-full bg-slate-100 dark:bg-slate-800">
               <Image
-                src="/images/pool/01-entrance-hallway.jpeg"
-                alt="Booking information and QR code displayed at the pool entrance"
+                src="/images/pool/06-qr-booking-link-sign.jpeg"
+                alt="James Square pool, gym and sauna opening hours and booking QR code displayed at the entrance"
                 fill
                 loading="lazy"
                 sizes="(min-width: 640px) 40vw, 90vw"
@@ -293,7 +345,7 @@ export default function PoolSafetyPage() {
               />
             </div>
             <figcaption className="px-3 py-2 text-xs leading-tight text-slate-600 dark:text-slate-300">
-              Booking information and QR code, displayed at the entrance
+              Opening hours and booking QR code, displayed at the entrance
             </figcaption>
           </figure>
         </div>
@@ -336,8 +388,8 @@ export default function PoolSafetyPage() {
           <figure className="overflow-hidden rounded-2xl border border-slate-200 bg-white shadow-sm dark:border-white/10 dark:bg-slate-900">
             <div className="relative aspect-[4/3] w-full bg-slate-100 dark:bg-slate-800">
               <Image
-                src="/images/pool/IMG_4149.jpeg"
-                alt="Pool water filtration and dosing plant"
+                src="/images/pool/31-chlorine-and-pH-monitor.jpeg"
+                alt="Wallace and Tiernan Ezetrol touch automated chlorine and pH dosing and monitoring controller"
                 fill
                 loading="lazy"
                 sizes="(min-width: 640px) 40vw, 90vw"
@@ -345,7 +397,7 @@ export default function PoolSafetyPage() {
               />
             </div>
             <figcaption className="px-3 py-2 text-xs leading-tight text-slate-600 dark:text-slate-300">
-              Pool water filtration and dosing plant
+              Wallace &amp; Tiernan automated dosing and monitoring controller
             </figcaption>
           </figure>
         </div>
@@ -454,19 +506,10 @@ export default function PoolSafetyPage() {
         </div>
         <div className="rounded-2xl border border-slate-200 bg-white/80 px-4 py-4 dark:border-white/10 dark:bg-slate-900/60">
           <p className="text-sm font-semibold text-slate-900 dark:text-white">All signage currently in place</p>
-          <p className="mt-1 text-xs text-slate-500 dark:text-slate-400">
-            Close-up photographs of every individual sign are still being added — items marked below are already
-            shown in the photos above.
-          </p>
           <ul className="mt-3 grid grid-cols-1 gap-x-6 gap-y-1.5 text-sm text-slate-700 sm:grid-cols-2 dark:text-slate-200">
             {fullSignageList.map((sign) => (
-              <li key={sign.label} className="flex items-center justify-between gap-3 border-b border-slate-100 py-1 dark:border-white/5">
-                <span>{sign.label}</span>
-                {sign.photographed ? (
-                  <span className="shrink-0 text-xs font-semibold text-emerald-600 dark:text-emerald-400">Photographed</span>
-                ) : (
-                  <span className="shrink-0 text-xs text-slate-400 dark:text-slate-500">Photo to follow</span>
-                )}
+              <li key={sign} className="border-b border-slate-100 py-1 dark:border-white/5">
+                {sign}
               </li>
             ))}
           </ul>
@@ -478,23 +521,29 @@ export default function PoolSafetyPage() {
           Pool rules
         </h2>
         <p className="text-sm leading-7 text-slate-700 dark:text-slate-200 sm:text-base">
-          The full Pool &amp; Recreation Area Health &amp; Safety Rules are displayed at the main entrance. Key
-          points are summarised below.
+          The Pool &amp; Recreation Area Health &amp; Safety Rules below are displayed at the main entrance.
         </p>
-        <div className="grid gap-4 sm:grid-cols-2">
-          {poolRuleGroups.map((group) => (
-            <div
-              key={group.title}
-              className="rounded-2xl border border-slate-200 bg-white/80 px-4 py-4 dark:border-white/10 dark:bg-slate-900/60"
-            >
-              <p className="text-sm font-semibold text-slate-900 dark:text-white">{group.title}</p>
-              <ul className="mt-2 list-inside list-disc space-y-1 text-sm leading-6 text-slate-700 dark:text-slate-200">
-                {group.items.map((item) => (
-                  <li key={item}>{item}</li>
-                ))}
-              </ul>
+        <div className="grid gap-6 sm:grid-cols-[1.1fr,0.9fr] sm:items-start">
+          <ol className="list-decimal space-y-2 rounded-2xl border border-slate-200 bg-white/80 px-5 py-4 pl-9 text-sm leading-6 text-slate-700 marker:font-semibold marker:text-slate-400 dark:border-white/10 dark:bg-slate-900/60 dark:text-slate-200">
+            {poolRules.map((rule) => (
+              <li key={rule}>{rule}</li>
+            ))}
+          </ol>
+          <figure className="overflow-hidden rounded-2xl border border-slate-200 bg-white shadow-sm dark:border-white/10 dark:bg-slate-900">
+            <div className="relative aspect-[4/3] w-full bg-slate-100 dark:bg-slate-800">
+              <Image
+                src="/images/pool/11-health&saftey-rules-sign.jpeg"
+                alt="Pool and Recreation Area Health and Safety Rules, as displayed at the main entrance"
+                fill
+                loading="lazy"
+                sizes="(min-width: 640px) 40vw, 90vw"
+                className="object-cover"
+              />
             </div>
-          ))}
+            <figcaption className="px-3 py-2 text-xs leading-tight text-slate-600 dark:text-slate-300">
+              The rules poster displayed at the main entrance
+            </figcaption>
+          </figure>
         </div>
       </section>
 

--- a/src/app/pool-safety/page.tsx
+++ b/src/app/pool-safety/page.tsx
@@ -1,0 +1,533 @@
+import type { Metadata } from 'next';
+import Image from 'next/image';
+import Link from 'next/link';
+
+const OG_IMAGE = '/images/pool/BC0D4867-E841-4F44-B7B8-90030F8D2E6B.jpeg';
+
+export const metadata: Metadata = {
+  title: 'Swimming Pool — James Square Residents',
+  description:
+    "Information on our residents' pool: facility overview, water quality, safety signage and pool rules.",
+  openGraph: {
+    title: 'Swimming Pool — James Square Residents',
+    description:
+      "Information on our residents' pool: facility overview, water quality, safety signage and pool rules.",
+    images: [
+      {
+        url: OG_IMAGE,
+        width: 848,
+        height: 1060,
+        alt: 'The James Square residents’ swimming pool',
+      },
+    ],
+  },
+};
+
+const navLinks = [
+  { href: '#facility-overview', label: 'Overview' },
+  { href: '#how-to-use-it', label: 'How to use it' },
+  { href: '#water-quality', label: 'Water quality' },
+  { href: '#cleaning-maintenance', label: 'Cleaning' },
+  { href: '#emergency-equipment', label: 'Emergency equipment' },
+  { href: '#safety-signage', label: 'Signage' },
+  { href: '#pool-rules', label: 'Pool rules' },
+  { href: '#supervision', label: 'Supervision' },
+];
+
+const facilityPhotos = [
+  {
+    src: '/images/pool/Pool-facing-south.png',
+    alt: 'The heated indoor swimming pool, facing south',
+    caption: 'The heated pool',
+  },
+  {
+    src: '/images/pool/03-gym-facing-south.jpeg',
+    alt: 'The small gymnasium next to the pool',
+    caption: 'The gym',
+  },
+  {
+    src: '/images/pool/05-sauna-entrance-door.jpeg',
+    alt: 'The sauna entrance and adjoining changing room door',
+    caption: 'Sauna & changing rooms',
+  },
+  {
+    src: '/images/pool/06-male-changing-room.jpeg',
+    alt: 'One of the changing rooms',
+    caption: 'Changing rooms',
+  },
+];
+
+const waterQualityRanges = [
+  { parameter: 'pH', range: '7.40 – 7.80' },
+  { parameter: 'Chlorine', range: '0.80 – 4.30 ppm' },
+];
+
+const emergencyEquipment = [
+  { item: 'Lifebuoy (main entrance)', provided: true },
+  { item: 'Lifebuoy (east pool wall)', provided: true },
+  { item: 'Reach pole / pool net', provided: true },
+  { item: 'Fire alarm call point', provided: true },
+  { item: 'Fire action notices', provided: true },
+  { item: 'CCTV', provided: true },
+  { item: 'Intruder alarm', provided: true },
+  { item: 'First aid kit', provided: false },
+  { item: 'Defibrillator (AED)', provided: false, note: 'nearest public AED approx. 100m away' },
+];
+
+const signagePhotos = [
+  {
+    src: '/images/pool/01-entrance-hallway.jpeg',
+    alt: 'Entrance signage: no eating or drinking, CCTV in operation, no outdoor footwear, hygiene notice and the resident booking QR code',
+    caption: 'Entrance notices: no eating/drinking, CCTV in operation, no outdoor footwear, hygiene reminder and the booking QR code',
+  },
+  {
+    src: '/images/pool/Pool-entrance.png',
+    alt: 'Lifebuoy for emergency use only, next to a fire alarm call point at the pool hall exit',
+    caption: 'Lifebuoy (“for emergency use only”) and fire alarm call point at the pool hall exit',
+  },
+  {
+    src: '/images/pool/Pool-facing-south.png',
+    alt: 'No diving sign displayed poolside',
+    caption: 'No diving sign, displayed poolside',
+  },
+  {
+    src: '/images/pool/05-sauna-entrance-door.jpeg',
+    alt: 'Hygiene notice and single-household changing room notice',
+    caption: 'Hygiene reminder and single-household changing room notice',
+  },
+  {
+    src: '/images/pool/03-gym-facing-south.jpeg',
+    alt: 'Hygiene and cross-contamination warning signage in the gym',
+    caption: 'Hygiene and cross-contamination warning notices',
+  },
+];
+
+const fullSignageList = [
+  { label: 'No outdoor footwear', photographed: true },
+  { label: 'CCTV in operation', photographed: true },
+  { label: 'No eating or drinking', photographed: true },
+  { label: 'Shower before entering the pool', photographed: false },
+  { label: 'Hand sanitising notice', photographed: true },
+  { label: 'Fire action notices', photographed: false },
+  { label: 'Pool opening hours', photographed: false },
+  { label: 'Building alarm reminder', photographed: false },
+  { label: 'Deep end depth marker (1.70m)', photographed: false },
+  { label: 'Shallow end depth marker (0.80m)', photographed: false },
+  { label: 'No running', photographed: false },
+  { label: 'Lifebuoy for emergency use only', photographed: true },
+  { label: 'Cross contamination warning', photographed: true },
+  { label: 'Fire door signage', photographed: false },
+  { label: 'Emergency exit signage', photographed: false },
+];
+
+const poolRuleGroups = [
+  {
+    title: 'Supervision & who can use the pool',
+    items: [
+      'For the use of James Square residents and their invited guests only.',
+      'Children under 16 must be accompanied by a responsible adult at all times.',
+    ],
+  },
+  {
+    title: 'Hygiene',
+    items: [
+      'Please shower before entering the pool.',
+      'Please use hand sanitiser on entry.',
+      'No outdoor footwear beyond the entrance.',
+    ],
+  },
+  {
+    title: 'Safe use',
+    items: [
+      'No diving.',
+      'No running around the pool or wet areas.',
+      'No eating or drinking in the pool hall.',
+      'Take care using the sauna and follow the posted guidance for safe use.',
+    ],
+  },
+  {
+    title: 'Conduct & shared use',
+    items: [
+      'No alcohol and no smoking anywhere in the facility.',
+      'Please leave the pool area by 11pm.',
+      'Please do not obstruct or misuse lifebuoys, reach poles or other emergency equipment.',
+      'Please be considerate of other residents sharing the space.',
+    ],
+  },
+];
+
+export default function PoolSafetyPage() {
+  return (
+    <main className="mx-auto max-w-5xl space-y-10 px-3 pb-16 sm:px-5">
+      <section className="relative overflow-hidden rounded-[2rem] border border-sky-100 shadow-xl shadow-sky-950/10 dark:border-white/10">
+        <div className="relative aspect-[4/3] w-full sm:aspect-[16/9]">
+          <Image
+            src={OG_IMAGE}
+            alt="The James Square residents’ swimming pool"
+            fill
+            priority
+            sizes="(min-width: 1024px) 960px, 100vw"
+            className="object-cover"
+          />
+          <div className="absolute inset-0 bg-gradient-to-t from-slate-950/90 via-slate-950/40 to-slate-950/10" />
+        </div>
+        <div className="absolute inset-x-0 bottom-0 p-5 sm:p-8">
+          <p className="text-xs font-semibold uppercase tracking-[0.28em] text-cyan-100">James Square</p>
+          <h1 className="mt-3 max-w-2xl text-3xl font-bold tracking-tight text-white sm:text-4xl lg:text-5xl">
+            Our Swimming Pool — How It Works & Staying Safe
+          </h1>
+          <p className="mt-4 max-w-2xl text-sm leading-6 text-slate-100 sm:text-base sm:leading-7">
+            James Square&rsquo;s indoor pool is a private facility for residents and their invited guests. This page
+            explains how it operates day to day, the safety measures and signage in place, and the rules we ask
+            everyone to follow.
+          </p>
+          <div className="mt-5 flex flex-wrap gap-3">
+            <Link
+              href="/pool3d"
+              className="inline-flex items-center gap-1.5 rounded-full bg-white px-5 py-2.5 text-sm font-semibold text-slate-950 shadow-lg transition hover:-translate-y-0.5 hover:bg-cyan-50"
+            >
+              See the 3D model of the facility
+            </Link>
+          </div>
+        </div>
+      </section>
+
+      <nav
+        aria-label="Page sections"
+        className="sticky top-[70px] z-30 -mx-3 overflow-x-auto border-y border-slate-200 bg-white/95 px-3 py-2.5 backdrop-blur sm:mx-0 sm:rounded-2xl sm:border sm:px-3 dark:border-white/10 dark:bg-slate-950/95"
+      >
+        <ul className="flex w-max gap-2 sm:w-full sm:flex-wrap">
+          {navLinks.map((link) => (
+            <li key={link.href}>
+              <a
+                href={link.href}
+                className="inline-flex items-center whitespace-nowrap rounded-full border border-slate-200 px-3 py-1.5 text-xs font-semibold text-slate-700 transition hover:border-sky-300 hover:bg-sky-50 hover:text-sky-800 dark:border-white/10 dark:text-slate-200 dark:hover:bg-white/10"
+              >
+                {link.label}
+              </a>
+            </li>
+          ))}
+        </ul>
+      </nav>
+
+      <section id="facility-overview" aria-labelledby="facility-overview-heading" className="scroll-mt-[140px] space-y-4">
+        <h2 id="facility-overview-heading" className="text-2xl font-bold text-slate-950 dark:text-white">
+          Facility overview
+        </h2>
+        <p className="text-sm leading-7 text-slate-700 dark:text-slate-200 sm:text-base">
+          James Square is a private residential development in Edinburgh of 103 properties. Residents have access to a
+          communal indoor leisure facility comprising a heated swimming pool, an infrared sauna, a small gymnasium,
+          male and female changing rooms, showers and toilets.
+        </p>
+        <ul className="grid gap-2 text-sm leading-6 text-slate-700 dark:text-slate-200 sm:grid-cols-2 sm:text-base">
+          <li className="rounded-2xl border border-slate-200 bg-white/80 px-4 py-3 dark:border-white/10 dark:bg-slate-900/60">
+            <span className="font-semibold text-slate-950 dark:text-white">Pool size:</span> approx. 11m long by
+            4.5m wide
+          </li>
+          <li className="rounded-2xl border border-slate-200 bg-white/80 px-4 py-3 dark:border-white/10 dark:bg-slate-900/60">
+            <span className="font-semibold text-slate-950 dark:text-white">Depth:</span> 0.80m at the shallow end to
+            1.70m at the deep end
+          </li>
+          <li className="rounded-2xl border border-slate-200 bg-white/80 px-4 py-3 dark:border-white/10 dark:bg-slate-900/60">
+            <span className="font-semibold text-slate-950 dark:text-white">Water temperature:</span> normally kept
+            between 28°C and 30°C, using an air source heat pump installed in 2025
+          </li>
+          <li className="rounded-2xl border border-slate-200 bg-white/80 px-4 py-3 dark:border-white/10 dark:bg-slate-900/60">
+            <span className="font-semibold text-slate-950 dark:text-white">Also on site:</span> infrared sauna, small
+            gym, changing rooms, showers and toilets
+          </li>
+        </ul>
+        <div className="grid grid-cols-2 gap-3 sm:grid-cols-4">
+          {facilityPhotos.map((photo) => (
+            <figure
+              key={photo.src}
+              className="overflow-hidden rounded-2xl border border-slate-200 bg-white shadow-sm dark:border-white/10 dark:bg-slate-900"
+            >
+              <div className="relative aspect-square w-full bg-slate-100 dark:bg-slate-800">
+                <Image
+                  src={photo.src}
+                  alt={photo.alt}
+                  fill
+                  loading="lazy"
+                  sizes="(min-width: 640px) 22vw, 45vw"
+                  className="object-cover"
+                />
+              </div>
+              <figcaption className="px-2.5 py-2 text-[11px] font-medium leading-tight text-slate-600 dark:text-slate-300">
+                {photo.caption}
+              </figcaption>
+            </figure>
+          ))}
+        </div>
+      </section>
+
+      <section id="how-to-use-it" aria-labelledby="how-to-use-it-heading" className="scroll-mt-[140px] space-y-4">
+        <h2 id="how-to-use-it-heading" className="text-2xl font-bold text-slate-950 dark:text-white">
+          How to use it
+        </h2>
+        <div className="grid gap-6 sm:grid-cols-[1.1fr,0.9fr] sm:items-start">
+          <div className="space-y-3 text-sm leading-7 text-slate-700 dark:text-slate-200 sm:text-base">
+            <p>
+              The pool is for James Square residents and their invited guests only — it is not open to the general
+              public. Use of the facility is generally low, at fewer than 25 individual users a week.
+            </p>
+            <p>
+              An online booking system, introduced during the COVID-19 pandemic to manage occupancy, remains in
+              operation and residents are encouraged to reserve the facility before use. While booking isn&rsquo;t
+              strictly enforced, residents generally cooperate, and in practice the facility is normally used by a
+              single household at any one time.
+            </p>
+            <p>
+              Access is controlled and the facility is covered by CCTV.
+            </p>
+          </div>
+          <figure className="overflow-hidden rounded-2xl border border-slate-200 bg-white shadow-sm dark:border-white/10 dark:bg-slate-900">
+            <div className="relative aspect-[4/3] w-full bg-slate-100 dark:bg-slate-800">
+              <Image
+                src="/images/pool/01-entrance-hallway.jpeg"
+                alt="Booking information and QR code displayed at the pool entrance"
+                fill
+                loading="lazy"
+                sizes="(min-width: 640px) 40vw, 90vw"
+                className="object-cover"
+              />
+            </div>
+            <figcaption className="px-3 py-2 text-xs leading-tight text-slate-600 dark:text-slate-300">
+              Booking information and QR code, displayed at the entrance
+            </figcaption>
+          </figure>
+        </div>
+      </section>
+
+      <section id="water-quality" aria-labelledby="water-quality-heading" className="scroll-mt-[140px] space-y-4">
+        <h2 id="water-quality-heading" className="text-2xl font-bold text-slate-950 dark:text-white">
+          Water quality
+        </h2>
+        <div className="grid gap-6 sm:grid-cols-[1.1fr,0.9fr] sm:items-start">
+          <div className="space-y-3 text-sm leading-7 text-slate-700 dark:text-slate-200 sm:text-base">
+            <p>
+              Water chemistry is managed by an automated Wallace &amp; Tiernan dosing and monitoring system, which
+              continuously tracks free chlorine and pH. Readings are recorded daily, and independent manual testing
+              is carried out weekly to double-check the automated system stays correctly calibrated.
+            </p>
+            <div className="overflow-hidden rounded-2xl border border-slate-200 dark:border-white/10">
+              <table className="w-full text-left text-sm">
+                <thead className="bg-sky-50 text-xs font-semibold uppercase tracking-wide text-sky-800 dark:bg-sky-300/10 dark:text-sky-100">
+                  <tr>
+                    <th className="px-4 py-2.5">Parameter</th>
+                    <th className="px-4 py-2.5">Target range</th>
+                  </tr>
+                </thead>
+                <tbody className="divide-y divide-slate-200 dark:divide-white/10">
+                  {waterQualityRanges.map((row) => (
+                    <tr key={row.parameter} className="bg-white dark:bg-slate-900/60">
+                      <td className="px-4 py-2.5 font-medium text-slate-900 dark:text-white">{row.parameter}</td>
+                      <td className="px-4 py-2.5 text-slate-700 dark:text-slate-200">{row.range}</td>
+                    </tr>
+                  ))}
+                </tbody>
+              </table>
+            </div>
+            <p className="text-xs text-slate-500 dark:text-slate-400">
+              Specialist servicing of the dosing equipment is provided by Aquatech, who installed the majority of the
+              pool plant.
+            </p>
+          </div>
+          <figure className="overflow-hidden rounded-2xl border border-slate-200 bg-white shadow-sm dark:border-white/10 dark:bg-slate-900">
+            <div className="relative aspect-[4/3] w-full bg-slate-100 dark:bg-slate-800">
+              <Image
+                src="/images/pool/IMG_4149.jpeg"
+                alt="Pool water filtration and dosing plant"
+                fill
+                loading="lazy"
+                sizes="(min-width: 640px) 40vw, 90vw"
+                className="object-cover"
+              />
+            </div>
+            <figcaption className="px-3 py-2 text-xs leading-tight text-slate-600 dark:text-slate-300">
+              Pool water filtration and dosing plant
+            </figcaption>
+          </figure>
+        </div>
+      </section>
+
+      <section id="cleaning-maintenance" aria-labelledby="cleaning-maintenance-heading" className="scroll-mt-[140px] space-y-3">
+        <h2 id="cleaning-maintenance-heading" className="text-2xl font-bold text-slate-950 dark:text-white">
+          Cleaning &amp; maintenance
+        </h2>
+        <ul className="space-y-2 text-sm leading-7 text-slate-700 dark:text-slate-200 sm:text-base">
+          <li>The leisure facility is cleaned each weekday morning by cleaning contractors appointed by Myreside Management.</li>
+          <li>The caretaker carries out routine visual inspections and monitors plant operation during normal working hours.</li>
+          <li>Specialist servicing of pool equipment is carried out by Aquatech when required.</li>
+        </ul>
+      </section>
+
+      <section id="emergency-equipment" aria-labelledby="emergency-equipment-heading" className="scroll-mt-[140px] space-y-4">
+        <h2 id="emergency-equipment-heading" className="text-2xl font-bold text-slate-950 dark:text-white">
+          Emergency equipment — good to know
+        </h2>
+        <div className="grid gap-6 sm:grid-cols-[1fr,1fr] sm:items-start">
+          <div className="overflow-hidden rounded-2xl border border-slate-200 dark:border-white/10">
+            <table className="w-full text-left text-sm">
+              <tbody className="divide-y divide-slate-200 dark:divide-white/10">
+                {emergencyEquipment.map((row) => (
+                  <tr key={row.item} className="bg-white dark:bg-slate-900/60">
+                    <td className="px-4 py-2.5 text-slate-800 dark:text-slate-100">
+                      {row.item}
+                      {row.note ? (
+                        <span className="block text-xs text-slate-500 dark:text-slate-400">{row.note}</span>
+                      ) : null}
+                    </td>
+                    <td className="px-4 py-2.5 text-right">
+                      <span
+                        className={`inline-flex items-center rounded-full px-2.5 py-0.5 text-xs font-semibold ${
+                          row.provided
+                            ? 'bg-emerald-50 text-emerald-700 dark:bg-emerald-400/10 dark:text-emerald-300'
+                            : 'bg-amber-50 text-amber-700 dark:bg-amber-400/10 dark:text-amber-300'
+                        }`}
+                      >
+                        {row.provided ? 'Provided' : 'Not on site'}
+                      </span>
+                    </td>
+                  </tr>
+                ))}
+              </tbody>
+            </table>
+          </div>
+          <figure className="overflow-hidden rounded-2xl border border-slate-200 bg-white shadow-sm dark:border-white/10 dark:bg-slate-900">
+            <div className="relative aspect-[4/3] w-full bg-slate-100 dark:bg-slate-800">
+              <Image
+                src="/images/pool/Pool-entrance.png"
+                alt="Lifebuoy and fire alarm call point at the pool hall exit"
+                fill
+                loading="lazy"
+                sizes="(min-width: 640px) 40vw, 90vw"
+                className="object-cover"
+              />
+            </div>
+            <figcaption className="px-3 py-2 text-xs leading-tight text-slate-600 dark:text-slate-300">
+              Lifebuoy and fire alarm call point at the pool hall exit
+            </figcaption>
+          </figure>
+        </div>
+        <div className="rounded-2xl border border-sky-100 bg-sky-50/70 px-4 py-4 text-sm leading-6 text-sky-900 dark:border-sky-300/20 dark:bg-sky-300/10 dark:text-sky-100">
+          <p className="font-semibold">Nearest public defibrillators (AEDs)</p>
+          <ul className="mt-1.5 space-y-1">
+            <li>St Bride&rsquo;s Community Centre, Orwell Terrace — approx. 100m from the pool building</li>
+            <li>Dalry Leisure Centre, Caledonian Crescent</li>
+          </ul>
+          <p className="mt-2 text-xs text-sky-800/90 dark:text-sky-100/80">
+            In a medical emergency, always call 999 first.
+          </p>
+        </div>
+      </section>
+
+      <section id="safety-signage" aria-labelledby="safety-signage-heading" className="scroll-mt-[140px] space-y-4">
+        <h2 id="safety-signage-heading" className="text-2xl font-bold text-slate-950 dark:text-white">
+          Safety signage
+        </h2>
+        <p className="text-sm leading-7 text-slate-700 dark:text-slate-200 sm:text-base">
+          Signage is displayed throughout the leisure facility to encourage safe use of the pool and its surrounding
+          areas.
+        </p>
+        <div className="grid grid-cols-1 gap-4 sm:grid-cols-2 lg:grid-cols-3">
+          {signagePhotos.map((photo) => (
+            <figure
+              key={`${photo.src}-${photo.caption}`}
+              className="overflow-hidden rounded-2xl border border-slate-200 bg-white shadow-sm dark:border-white/10 dark:bg-slate-900"
+            >
+              <div className="relative aspect-[4/3] w-full bg-slate-100 dark:bg-slate-800">
+                <Image
+                  src={photo.src}
+                  alt={photo.alt}
+                  fill
+                  loading="lazy"
+                  sizes="(min-width: 1024px) 30vw, (min-width: 640px) 45vw, 90vw"
+                  className="object-cover"
+                />
+              </div>
+              <figcaption className="px-3 py-2.5 text-xs leading-snug text-slate-600 dark:text-slate-300">
+                {photo.caption}
+              </figcaption>
+            </figure>
+          ))}
+        </div>
+        <div className="rounded-2xl border border-slate-200 bg-white/80 px-4 py-4 dark:border-white/10 dark:bg-slate-900/60">
+          <p className="text-sm font-semibold text-slate-900 dark:text-white">All signage currently in place</p>
+          <p className="mt-1 text-xs text-slate-500 dark:text-slate-400">
+            Close-up photographs of every individual sign are still being added — items marked below are already
+            shown in the photos above.
+          </p>
+          <ul className="mt-3 grid grid-cols-1 gap-x-6 gap-y-1.5 text-sm text-slate-700 sm:grid-cols-2 dark:text-slate-200">
+            {fullSignageList.map((sign) => (
+              <li key={sign.label} className="flex items-center justify-between gap-3 border-b border-slate-100 py-1 dark:border-white/5">
+                <span>{sign.label}</span>
+                {sign.photographed ? (
+                  <span className="shrink-0 text-xs font-semibold text-emerald-600 dark:text-emerald-400">Photographed</span>
+                ) : (
+                  <span className="shrink-0 text-xs text-slate-400 dark:text-slate-500">Photo to follow</span>
+                )}
+              </li>
+            ))}
+          </ul>
+        </div>
+      </section>
+
+      <section id="pool-rules" aria-labelledby="pool-rules-heading" className="scroll-mt-[140px] space-y-4">
+        <h2 id="pool-rules-heading" className="text-2xl font-bold text-slate-950 dark:text-white">
+          Pool rules
+        </h2>
+        <p className="text-sm leading-7 text-slate-700 dark:text-slate-200 sm:text-base">
+          The full Pool &amp; Recreation Area Health &amp; Safety Rules are displayed at the main entrance. Key
+          points are summarised below.
+        </p>
+        <div className="grid gap-4 sm:grid-cols-2">
+          {poolRuleGroups.map((group) => (
+            <div
+              key={group.title}
+              className="rounded-2xl border border-slate-200 bg-white/80 px-4 py-4 dark:border-white/10 dark:bg-slate-900/60"
+            >
+              <p className="text-sm font-semibold text-slate-900 dark:text-white">{group.title}</p>
+              <ul className="mt-2 list-inside list-disc space-y-1 text-sm leading-6 text-slate-700 dark:text-slate-200">
+                {group.items.map((item) => (
+                  <li key={item}>{item}</li>
+                ))}
+              </ul>
+            </div>
+          ))}
+        </div>
+      </section>
+
+      <section
+        id="supervision"
+        aria-labelledby="supervision-heading"
+        className="scroll-mt-[140px] space-y-3 rounded-2xl border border-amber-200 bg-amber-50/70 px-5 py-5 dark:border-amber-300/20 dark:bg-amber-300/10"
+      >
+        <h2 id="supervision-heading" className="text-xl font-bold text-amber-950 dark:text-amber-100">
+          Please note: this is an unsupervised facility
+        </h2>
+        <p className="text-sm leading-7 text-amber-900 dark:text-amber-100/90 sm:text-base">
+          There is no qualified lifeguard on duty at any time. A CCTV feed exists in the caretaker&rsquo;s office, but
+          it is not continuously monitored and should not be relied on as active supervision. The caretaker is
+          normally on site Monday to Friday, roughly 6am to 2pm, but is not responsible for supervising pool users.
+        </p>
+        <p className="text-sm leading-7 text-amber-900 dark:text-amber-100/90 sm:text-base">
+          Residents and their guests are expected to exercise personal responsibility and follow the pool rules at
+          all times. Children under 16 must be accompanied by a responsible adult at all times.
+        </p>
+      </section>
+
+      <section className="flex flex-col items-start gap-3 rounded-2xl border border-slate-200 bg-white/80 px-5 py-5 sm:flex-row sm:items-center sm:justify-between dark:border-white/10 dark:bg-slate-900/60">
+        <p className="text-sm text-slate-700 dark:text-slate-200">
+          Want to see the layout for yourself? Explore the interactive 3D model of the pool area.
+        </p>
+        <Link
+          href="/pool3d"
+          className="inline-flex shrink-0 items-center gap-1.5 rounded-full bg-slate-950 px-5 py-2.5 text-sm font-semibold text-white shadow-lg transition hover:-translate-y-0.5 hover:bg-slate-800 dark:bg-white dark:text-slate-950 dark:hover:bg-cyan-50"
+        >
+          See the 3D model of the facility
+        </Link>
+      </section>
+    </main>
+  );
+}

--- a/src/app/pool-safety/rlss-report/page.tsx
+++ b/src/app/pool-safety/rlss-report/page.tsx
@@ -7,6 +7,12 @@ export const metadata: Metadata = {
   robots: { index: false, follow: false, nocache: true },
 };
 
+const openingHours = [
+  { area: 'Pool', hours: '5.30am – 11.00pm', note: 'closed 9.30–11.00am daily for cleaning · no booking required' },
+  { area: 'Gym', hours: '11.00am – 5.00pm', note: 'booking recommended' },
+  { area: 'Sauna', hours: '5.00pm – 11.00pm', note: 'booking recommended' },
+];
+
 const waterQualityRanges = [
   { parameter: 'pH', range: '7.40 – 7.80' },
   { parameter: 'Chlorine', range: '0.80 – 4.30 ppm' },
@@ -39,6 +45,28 @@ const fullSignageList = [
   'Cross contamination warning',
   'Fire door signage',
   'Emergency exit signage',
+];
+
+const poolRules = [
+  'All users must shower before entering the pool or sauna (this cuts down on chemical usage and is better for the environment).',
+  'No more than six people from any one flat may use the recreation facilities at any one time, and should be accompanied by the fob holder, who will be responsible for anyone gaining entry with his/her entry card.',
+  'The taking of glass or other breakable vessels into the recreation area is dangerous and strictly prohibited.',
+  'No alcohol to be consumed in the recreation area.',
+  'Smoking is strictly prohibited in the recreation area.',
+  'No unaccompanied children under 16 are permitted to use the recreation area.',
+  'Outdoor footwear must be removed before entering the area. Shoe covers are provided.',
+  'Swimming/sports attire must be worn at all times.',
+  'No ball games, and no items such as airbeds etc, to be taken into the pool or leisure area.',
+  'No animals are allowed.',
+  'Lifebelts are for emergency use only.',
+  'The emergency exit is only for use in a genuine emergency — on no account should it be used for access or exit at any other time.',
+  'Only fresh water, in very small quantities, is to be sprinkled on the coals in the sauna; pool water must not be used, as it will create toxic vapour.',
+  'Please switch off the sauna and showers after use.',
+  'Excessive noise is as unacceptable in these areas as anywhere else in the development.',
+  'Owners will at all times be held responsible for the health and safety of anyone gaining entry with their fob.',
+  'Any person causing damage will be required to pay the cost involved in repair or replacement.',
+  'No running.',
+  'No jumping into the pool.',
 ];
 
 const areasForReview = [
@@ -142,6 +170,29 @@ export default function RlssReportPage() {
           Aquatech, who installed the majority of the pool equipment and provide specialist servicing and technical
           support when required.
         </p>
+        <table className="w-full border-collapse text-left text-[13px]">
+          <thead>
+            <tr className="border-b border-slate-300 bg-slate-50">
+              <th className="px-3 py-1.5 font-semibold">Area</th>
+              <th className="px-3 py-1.5 font-semibold">Opening hours</th>
+              <th className="px-3 py-1.5 font-semibold">Note</th>
+            </tr>
+          </thead>
+          <tbody>
+            {openingHours.map((row) => (
+              <tr key={row.area} className="border-b border-slate-200">
+                <td className="px-3 py-1.5">{row.area}</td>
+                <td className="px-3 py-1.5">{row.hours}</td>
+                <td className="px-3 py-1.5 text-xs text-slate-500">{row.note}</td>
+              </tr>
+            ))}
+          </tbody>
+        </table>
+        <Figure
+          src="/images/pool/32-air-source-heatpump-to-heat-pool.jpeg"
+          alt="Air source heat pump used to heat the pool"
+          caption="Air source heat pump"
+        />
       </Section>
 
       <Section number="3" title="Pool Operation">
@@ -178,9 +229,19 @@ export default function RlssReportPage() {
         </ul>
         <div className="grid grid-cols-2 gap-3">
           <Figure
-            src="/images/pool/02-exterior-entrance-door.jpeg"
-            alt="External entrance to the pool building with combination keypad lock"
-            caption="External entrance to the pool building, with combination keypad lock"
+            src="/images/pool/01-exterior-door-entrance.jpeg"
+            alt="External entrance to the pool building"
+            caption="External entrance to the pool building"
+          />
+          <Figure
+            src="/images/pool/03-door-number-comination-lock.jpeg"
+            alt="Combination keypad lock on the external door"
+            caption="Combination keypad lock on the external door"
+          />
+          <Figure
+            src="/images/pool/07-door-fob-pad-and-fire-action-sing-and-alarm.jpeg"
+            alt="Internal fob-controlled door reader, fire action notice and fire alarm call point"
+            caption="Internal fob-controlled door reader, fire action notice and fire alarm call point"
           />
           <Figure
             src="/images/pool/01-entrance-hallway.jpeg"
@@ -220,15 +281,28 @@ export default function RlssReportPage() {
           full coverage of the swimming pool itself. Residents are advised that the pool closes at 2300 hours and
           signage reminds users to vacate the premises before the alarm system becomes active.
         </p>
-        <Figure
-          src="/images/pool/Pool-entrance.png"
-          alt="Fire alarm call point and 11pm vacate / alarm reminder notice near the pool hall exit"
-          caption="Fire alarm call point and 11pm vacate / alarm reminder notice, near the pool hall exit"
-        />
-        <p className="text-xs italic text-slate-500">
-          Dedicated close-up photographs of the CCTV cameras, motion sensor and fob-controlled exit release button
-          are not yet available and should be added before circulation to the assessor.
-        </p>
+        <div className="grid grid-cols-2 gap-3">
+          <Figure
+            src="/images/pool/18-cctc-camera-1.jpeg"
+            alt="CCTV camera covering the main entrance and deep end of the pool, deep end depth marker visible below"
+            caption="CCTV camera covering the main entrance and deep end"
+          />
+          <Figure
+            src="/images/pool/19-cctv-camera1-view.jpeg"
+            alt="Second CCTV camera providing full coverage of the swimming pool"
+            caption="Second CCTV camera — full pool coverage"
+          />
+          <Figure
+            src="/images/pool/17-motion-detection-device.jpeg"
+            alt="Motion detection sensor"
+            caption="Motion detection sensor"
+          />
+          <Figure
+            src="/images/pool/14-11pm-warning-sign-and-fire-alarm.jpeg"
+            alt="Fob-controlled exit release button, motion sensor and 11pm vacate / alarm reminder notice"
+            caption="Fob-controlled exit release button and 11pm vacate / alarm reminder notice"
+          />
+        </div>
       </Section>
 
       <Section number="7" title="Water Quality Management">
@@ -255,11 +329,18 @@ export default function RlssReportPage() {
           maintenance of the dosing equipment is provided by Aquatech and equipment is used predominantly by the
           caretaker or appointed Myreside Management cleaning team leader when the caretaker is absent.
         </p>
-        <Figure
-          src="/images/pool/IMG_4149.jpeg"
-          alt="Pool water filtration and dosing plant"
-          caption="Wallace & Tiernan Ezetrol touch automated dosing and monitoring controller area"
-        />
+        <div className="grid grid-cols-2 gap-3">
+          <Figure
+            src="/images/pool/31-chlorine-and-pH-monitor.jpeg"
+            alt="Wallace and Tiernan Ezetrol touch automated dosing and monitoring controller, showing live chlorine and pH readings"
+            caption="Wallace & Tiernan Ezetrol touch automated dosing and monitoring controller"
+          />
+          <Figure
+            src="/images/pool/IMG_4149.jpeg"
+            alt="Pool water filtration plant"
+            caption="Pool water filtration plant"
+          />
+        </div>
       </Section>
 
       <Section number="8" title="Cleaning & Maintenance">
@@ -295,14 +376,14 @@ export default function RlssReportPage() {
         </p>
         <div className="grid grid-cols-2 gap-3">
           <Figure
-            src="/images/pool/Pool-entrance.png"
+            src="/images/pool/15-life-buoy-ring.jpeg"
             alt="Lifebuoy at the main entrance"
             caption="Lifebuoy — main entrance"
           />
           <Figure
-            src="/images/pool/Pool-facing-south.png"
-            alt="Lifebuoy positioned near the pool"
-            caption="Lifebuoy — positioned near the pool"
+            src="/images/pool/27-lifebouy-number2-placement-near-ladders.jpeg"
+            alt="Second lifebuoy positioned near the pool ladders"
+            caption="Lifebuoy — positioned near the pool ladders"
           />
         </div>
       </Section>
@@ -324,13 +405,20 @@ export default function RlssReportPage() {
             <li key={item}>{item}</li>
           ))}
         </ul>
-        <p>Photographs of signage currently documented are included below; the remainder are in place but not yet individually photographed.</p>
+        <p>Photographs of signage currently documented are included below.</p>
         <div className="grid grid-cols-3 gap-3">
-          <Figure src="/images/pool/01-entrance-hallway.jpeg" alt="Entrance signage" caption="Entrance signage: no eating/drinking, CCTV in operation, no outdoor footwear, hygiene notice" />
-          <Figure src="/images/pool/Pool-entrance.png" alt="Lifebuoy for emergency use only signage" caption="Lifebuoy for emergency use only, and fire call point" />
-          <Figure src="/images/pool/Pool-facing-south.png" alt="No diving sign" caption="No diving sign, displayed poolside" />
-          <Figure src="/images/pool/05-sauna-entrance-door.jpeg" alt="Hygiene and single-household changing room notice" caption="Hygiene reminder and single-household changing room notice" />
-          <Figure src="/images/pool/03-gym-facing-south.jpeg" alt="Cross contamination warning" caption="Hygiene and cross-contamination warning notices" />
+          <Figure src="/images/pool/01-entrance-hallway.jpeg" alt="Entrance signage" caption="Entrance: no eating/drinking, CCTV in operation, no outdoor footwear, hygiene notice" />
+          <Figure src="/images/pool/05-remove-outer-footwear-sign.jpeg" alt="No outdoor footwear sign" caption="No outdoor footwear" />
+          <Figure src="/images/pool/10-covid-sign.jpeg" alt="Visitor hygiene notice" caption="Visitor hygiene notice" />
+          <Figure src="/images/pool/29-shower-notice-sign.jpeg" alt="Please shower before entering the pool" caption="Please shower before entering the pool" />
+          <Figure src="/images/pool/09-internal-door-11pm-alarm-sign.jpeg" alt="Pool opening times and 11pm vacate reminder" caption="Pool opening times and 11pm vacate reminder" />
+          <Figure src="/images/pool/24-no-diving-signage.jpeg" alt="No diving sign" caption="No diving" />
+          <Figure src="/images/pool/16-deep-end-sign-no-running-sign.jpeg" alt="Deep end depth marker and no running sign" caption="Deep end depth marker & no running" />
+          <Figure src="/images/pool/28-shallow-end-sign-no-running-and-clock.jpeg" alt="Shallow end depth marker and no running sign" caption="Shallow end depth marker & no running" />
+          <Figure src="/images/pool/30-contamination-sign.jpeg" alt="Cross contamination warning" caption="Cross contamination warning" />
+          <Figure src="/images/pool/26-lifebuoy-number2.jpeg" alt="Lifebuoy for emergency use only signage" caption="Lifebuoy for emergency use only" />
+          <Figure src="/images/pool/20-fire-door.jpeg" alt="Fire door and emergency exit signage" caption="Fire door & emergency exit signage" />
+          <Figure src="/images/pool/Pool-entrance.png" alt="Fire alarm call point" caption="Fire alarm call point" />
         </div>
       </Section>
 
@@ -349,28 +437,40 @@ export default function RlssReportPage() {
           options are considered. This incident forms part of the ongoing refurbishment project and is not
           considered representative of normal pool operation.
         </p>
-        <Figure
-          src="/images/pool/08-ceiling-damage.jpeg"
-          alt="Ceiling finishes damaged following the 2026 plant room electrical failure"
-          caption="Ceiling finishes requiring repair, following the 2026 plant room electrical failure"
-        />
+        <div className="grid grid-cols-3 gap-3">
+          <Figure
+            src="/images/pool/08-ceiling-damage.jpeg"
+            alt="Ceiling finishes damaged following the 2026 plant room electrical failure"
+            caption="Ceiling finishes requiring repair"
+          />
+          <Figure
+            src="/images/pool/22-dehumidifier-ventilation-control-unit.jpeg"
+            alt="Dehumidification / ventilation control unit"
+            caption="Dehumidification / ventilation control unit"
+          />
+          <Figure
+            src="/images/pool/23-control-pannel-screen.jpeg"
+            alt="Control panel showing elevated humidity of 66.8 percent and a service reminder"
+            caption="Control panel showing elevated humidity (66.8%) and service reminder"
+          />
+        </div>
       </Section>
 
       <Section number="13" title="Existing Rules">
-        <p>The full Pool &amp; Recreation Area Health &amp; Safety Rules are displayed at the main entrance. These rules cover:</p>
-        <ul className="list-disc space-y-0.5 pl-5">
-          <li>Supervision of children</li>
-          <li>Maximum occupancy</li>
-          <li>Hygiene requirements</li>
-          <li>Prohibited activities</li>
-          <li>Alcohol and smoking</li>
-          <li>Appropriate footwear</li>
-          <li>Appropriate clothing</li>
-          <li>Safe use of the sauna</li>
-          <li>Responsibility of residents</li>
-          <li>Protection of emergency equipment</li>
-          <li>Behaviour within the facility</li>
-        </ul>
+        <p>
+          The Pool &amp; Recreation Area Health &amp; Safety Rules below are reproduced from the poster displayed at
+          the main entrance.
+        </p>
+        <ol className="list-decimal space-y-1 pl-5">
+          {poolRules.map((rule) => (
+            <li key={rule}>{rule}</li>
+          ))}
+        </ol>
+        <Figure
+          src="/images/pool/11-health&saftey-rules-sign.jpeg"
+          alt="Pool and Recreation Area Health and Safety Rules, as displayed at the main entrance"
+          caption="Pool & Recreation Area Health & Safety Rules, as displayed at the main entrance"
+        />
       </Section>
 
       <Section number="14" title="Areas for Independent Review">

--- a/src/app/pool-safety/rlss-report/page.tsx
+++ b/src/app/pool-safety/rlss-report/page.tsx
@@ -1,0 +1,386 @@
+import type { Metadata } from 'next';
+import Image from 'next/image';
+
+export const metadata: Metadata = {
+  title: 'James Square — Pool Operations & Preliminary Safety Pack',
+  description: 'Internal document prepared to support an independent RLSS safety review. Not for public distribution.',
+  robots: { index: false, follow: false, nocache: true },
+};
+
+const waterQualityRanges = [
+  { parameter: 'pH', range: '7.40 – 7.80' },
+  { parameter: 'Chlorine', range: '0.80 – 4.30 ppm' },
+];
+
+const emergencyEquipment = [
+  { item: 'Lifebuoy (Main Entrance)', provided: true },
+  { item: 'Lifebuoy (East Pool Wall)', provided: true },
+  { item: 'Reach Pole / Pool Net', provided: true },
+  { item: 'Fire Alarm Call Point', provided: true },
+  { item: 'Fire Action Notices', provided: true },
+  { item: 'CCTV', provided: true },
+  { item: 'Intruder Alarm', provided: true },
+  { item: 'First Aid Kit', provided: false },
+  { item: 'Defibrillator (AED)', provided: false, note: 'nearest public AED approximately 100 metres away' },
+];
+
+const fullSignageList = [
+  'No outdoor footwear',
+  'CCTV in operation',
+  'No eating or drinking',
+  'Shower before entering the pool',
+  'Hand sanitising notice',
+  'Fire action notices',
+  'Pool opening hours',
+  'Building alarm reminder',
+  'Deep end depth marker',
+  'No running',
+  'Lifebuoy for emergency use only',
+  'Cross contamination warning',
+  'Fire door signage',
+  'Emergency exit signage',
+];
+
+const areasForReview = [
+  'Suitability of operating the pool as an unsupervised residential facility.',
+  'Adequacy of existing rescue equipment.',
+  'Adequacy of current signage.',
+  'First aid provision.',
+  'Requirement for an on-site Automated External Defibrillator (AED).',
+  'Development of an Emergency Action Plan (EAP).',
+  'Recommended operating procedures for residents.',
+  'Water quality management procedures.',
+  'Emergency response arrangements.',
+  'Any additional recommendations considered appropriate under current guidance and recognised best practice.',
+];
+
+function Figure({ src, alt, caption }: { src: string; alt: string; caption: string }) {
+  return (
+    <figure className="overflow-hidden rounded-lg border border-slate-300 break-inside-avoid">
+      <div className="relative aspect-[4/3] w-full bg-slate-100">
+        <Image src={src} alt={alt} fill sizes="400px" className="object-cover" />
+      </div>
+      <figcaption className="border-t border-slate-200 px-2 py-1.5 text-[11px] leading-tight text-slate-600">
+        {caption}
+      </figcaption>
+    </figure>
+  );
+}
+
+function Section({
+  number,
+  title,
+  children,
+  breakBefore = true,
+}: {
+  number: string;
+  title: string;
+  children: React.ReactNode;
+  breakBefore?: boolean;
+}) {
+  return (
+    <section className={`space-y-3 ${breakBefore ? 'break-before-page' : ''}`}>
+      <h2 className="text-lg font-bold text-slate-950">
+        {number}. {title}
+      </h2>
+      <div className="space-y-3 text-[13px] leading-6 text-slate-800">{children}</div>
+    </section>
+  );
+}
+
+export default function RlssReportPage() {
+  return (
+    <article
+      className="mx-auto w-full max-w-[52rem] space-y-8 px-3 pb-16 pt-4 text-slate-900 print:px-0"
+      style={{ backgroundColor: '#ffffff' }}
+    >
+      <header className="space-y-1 border-b border-slate-300 pb-4">
+        <p className="text-xs font-semibold uppercase tracking-[0.2em] text-slate-500">
+          Not for public distribution — prepared for independent review
+        </p>
+        <h1 className="text-2xl font-bold text-slate-950">
+          James Square — Pool Operations &amp; Preliminary Safety Pack
+        </h1>
+        <p className="text-sm text-slate-600">
+          Prepared to support an independent safety review by the Royal Life Saving Society (RLSS)
+        </p>
+      </header>
+
+      <Section number="1" title="Purpose of this Document" breakBefore={false}>
+        <p>
+          This document has been prepared to provide an overview of the James Square residential swimming pool and
+          leisure facilities in advance of an independent safety review by the Royal Life Saving Society (RLSS).
+        </p>
+        <p>
+          The intention is to provide the assessor with sufficient background information regarding the building,
+          pool operation, access arrangements, existing safety measures and current management procedures to assist
+          with an initial desktop assessment before any site visit.
+        </p>
+        <p>
+          Where appropriate, photographs have been included throughout this document to demonstrate the existing
+          layout, equipment and safety signage currently installed within the facility.
+        </p>
+        <p>This document is intended to support, rather than replace, a formal professional risk assessment.</p>
+      </Section>
+
+      <Section number="2" title="Facility Overview">
+        <p>
+          James Square is a private residential development located in Edinburgh consisting of 103 residential
+          properties. Residents have access to a communal indoor leisure facility comprising a heated indoor
+          swimming pool, infrared sauna, small gymnasium, male changing room, female changing room, shower facilities
+          and toilet facilities.
+        </p>
+        <p>
+          The swimming pool measures approximately 11 metres long by 4.5 metres wide. Water depth varies from 0.80
+          metres at the shallow end to 1.70 metres at the deep end. The water temperature is normally maintained
+          between 28°C and 30°C using an air source heat pump installed during 2025.
+        </p>
+        <p>
+          Water chemistry is managed using an automated Wallace &amp; Tiernan dosing system which continuously
+          monitors chlorine and pH levels. Daily readings are recorded by the caretaker and manual water testing is
+          carried out weekly to verify the automated monitoring system. The swimming pool plant is maintained by
+          Aquatech, who installed the majority of the pool equipment and provide specialist servicing and technical
+          support when required.
+        </p>
+      </Section>
+
+      <Section number="3" title="Pool Operation">
+        <p>
+          The facility is intended solely for residents of James Square and their invited guests. The swimming pool
+          is not open to the general public. Use of the facility is generally low, with an estimated fewer than 25
+          individual users each week.
+        </p>
+        <p>
+          An online booking system was introduced during the COVID-19 pandemic to manage occupancy and reduce
+          overcrowding. The booking system remains in operation and residents are encouraged to reserve the facility
+          before use. Although the booking system is not technically enforced, residents generally cooperate and the
+          facility is normally occupied by a single household at any one time.
+        </p>
+        <Figure
+          src="/images/pool/01-entrance-hallway.jpeg"
+          alt="Booking information and QR code displayed at the entrance"
+          caption="James Square booking information and QR code, displayed at the entrance"
+        />
+      </Section>
+
+      <Section number="4" title="Access Control">
+        <p>Access to the swimming pool is controlled through several security measures.</p>
+        <ul className="list-disc space-y-1 pl-5">
+          <li>Residents must first gain access to the James Square development using their property key.</li>
+          <li>The pool building is then accessed through an external entrance secured by a combination keypad.</li>
+          <li>Entry into the main pool hall is controlled using an electronic proximity fob system.</li>
+          <li>Only authorised residents possess active fobs.</li>
+          <li>Access permissions can be added or removed where necessary.</li>
+          <li>
+            The plant room is secured behind two locked doors and access is restricted to the caretaker and
+            committee members for maintenance or emergency purposes.
+          </li>
+        </ul>
+        <div className="grid grid-cols-2 gap-3">
+          <Figure
+            src="/images/pool/02-exterior-entrance-door.jpeg"
+            alt="External entrance to the pool building with combination keypad lock"
+            caption="External entrance to the pool building, with combination keypad lock"
+          />
+          <Figure
+            src="/images/pool/01-entrance-hallway.jpeg"
+            alt="Entrance hallway and signage, including notice that visits are recorded by swipe card and CCTV"
+            caption="Entrance hallway and signage — visits are recorded by swipe card and CCTV"
+          />
+        </div>
+      </Section>
+
+      <Section number="5" title="Supervision">
+        <p>The swimming pool operates as an unsupervised residential facility. No qualified lifeguard is present during normal operation.</p>
+        <p>
+          A live CCTV feed is available within the caretaker&rsquo;s office; however, this is not continuously
+          monitored and should not be regarded as providing active supervision. The caretaker is normally on site
+          Monday to Friday between approximately 0600 and 1400 hours but is not responsible for supervising pool
+          users during swimming activities.
+        </p>
+        <p>
+          Residents are therefore expected to exercise personal responsibility and comply with the pool rules
+          displayed throughout the facility. Children under the age of 16 must be accompanied by a responsible adult
+          at all times.
+        </p>
+      </Section>
+
+      <Section number="6" title="Security Measures">
+        <p>Security within the leisure facility includes:</p>
+        <ul className="list-disc space-y-1 pl-5">
+          <li>Electronic fob-controlled access</li>
+          <li>External keypad entry</li>
+          <li>Two internal CCTV cameras covering the pool hall</li>
+          <li>Motion detection system</li>
+          <li>Intruder alarm activated after 2300 hours</li>
+          <li>Automatic alarm activation if movement is detected after approximately 2315 hours</li>
+        </ul>
+        <p>
+          One CCTV camera monitors the main entrance and deep end of the swimming pool. The second camera provides
+          full coverage of the swimming pool itself. Residents are advised that the pool closes at 2300 hours and
+          signage reminds users to vacate the premises before the alarm system becomes active.
+        </p>
+        <Figure
+          src="/images/pool/Pool-entrance.png"
+          alt="Fire alarm call point and 11pm vacate / alarm reminder notice near the pool hall exit"
+          caption="Fire alarm call point and 11pm vacate / alarm reminder notice, near the pool hall exit"
+        />
+        <p className="text-xs italic text-slate-500">
+          Dedicated close-up photographs of the CCTV cameras, motion sensor and fob-controlled exit release button
+          are not yet available and should be added before circulation to the assessor.
+        </p>
+      </Section>
+
+      <Section number="7" title="Water Quality Management">
+        <p>Water quality is managed using an automated Wallace &amp; Tiernan dosing and monitoring system. The system continuously monitors free chlorine and pH.</p>
+        <table className="w-full border-collapse text-left text-[13px]">
+          <thead>
+            <tr className="border-b border-slate-300 bg-slate-50">
+              <th className="px-3 py-1.5 font-semibold">Parameter</th>
+              <th className="px-3 py-1.5 font-semibold">Target Range</th>
+            </tr>
+          </thead>
+          <tbody>
+            {waterQualityRanges.map((row) => (
+              <tr key={row.parameter} className="border-b border-slate-200">
+                <td className="px-3 py-1.5">{row.parameter}</td>
+                <td className="px-3 py-1.5">{row.range}</td>
+              </tr>
+            ))}
+          </tbody>
+        </table>
+        <p>
+          Water quality readings are recorded daily. Weekly manual testing is also undertaken using independent
+          testing equipment to verify that the automated monitoring system remains correctly calibrated. Specialist
+          maintenance of the dosing equipment is provided by Aquatech and equipment is used predominantly by the
+          caretaker or appointed Myreside Management cleaning team leader when the caretaker is absent.
+        </p>
+        <Figure
+          src="/images/pool/IMG_4149.jpeg"
+          alt="Pool water filtration and dosing plant"
+          caption="Wallace & Tiernan Ezetrol touch automated dosing and monitoring controller area"
+        />
+      </Section>
+
+      <Section number="8" title="Cleaning & Maintenance">
+        <p>The leisure facility is cleaned each weekday morning by cleaning contractors appointed by Myreside Management.</p>
+        <p>The caretaker also undertakes routine visual inspections of the facility and monitors plant operation during normal working hours.</p>
+        <p>Specialist servicing of pool equipment is undertaken by Aquatech when required.</p>
+      </Section>
+
+      <Section number="9" title="Emergency Equipment">
+        <table className="w-full border-collapse text-left text-[13px]">
+          <thead>
+            <tr className="border-b border-slate-300 bg-slate-50">
+              <th className="px-3 py-1.5 font-semibold">Equipment</th>
+              <th className="px-3 py-1.5 font-semibold">Provision</th>
+            </tr>
+          </thead>
+          <tbody>
+            {emergencyEquipment.map((row) => (
+              <tr key={row.item} className="border-b border-slate-200">
+                <td className="px-3 py-1.5">
+                  {row.item}
+                  {row.note ? <span className="block text-xs text-slate-500">{row.note}</span> : null}
+                </td>
+                <td className="px-3 py-1.5">{row.provided ? 'Yes' : 'No'}</td>
+              </tr>
+            ))}
+          </tbody>
+        </table>
+        <p>
+          The nearest publicly accessible Automated External Defibrillator (AED) is located outside St Bride&rsquo;s
+          Community Centre on Orwell Terrace, approximately 100 metres from the pool building. A second publicly
+          accessible AED is located at Dalry Leisure Centre on Caledonian Crescent.
+        </p>
+        <div className="grid grid-cols-2 gap-3">
+          <Figure
+            src="/images/pool/Pool-entrance.png"
+            alt="Lifebuoy at the main entrance"
+            caption="Lifebuoy — main entrance"
+          />
+          <Figure
+            src="/images/pool/Pool-facing-south.png"
+            alt="Lifebuoy positioned near the pool"
+            caption="Lifebuoy — positioned near the pool"
+          />
+        </div>
+      </Section>
+
+      <Section number="10" title="Emergency Procedures">
+        <p>In the event of a medical emergency, residents are expected to contact the emergency services by dialling 999.</p>
+        <p>Emergency exits, fire alarm call points and fire action notices are provided throughout the building.</p>
+        <p className="rounded-md border border-amber-300 bg-amber-50 px-3 py-2 font-medium text-amber-900">
+          At the time of writing, no formal written Emergency Action Plan (EAP) has been produced specifically for
+          the swimming pool facility. The production of a documented Emergency Action Plan is considered an area for
+          independent review and guidance.
+        </p>
+      </Section>
+
+      <Section number="11" title="Existing Safety Signage">
+        <p>Safety signage is installed throughout the leisure facility to encourage safe use of the swimming pool and associated facilities. Signage currently includes:</p>
+        <ul className="grid grid-cols-2 gap-x-4 gap-y-0.5 list-disc pl-5">
+          {fullSignageList.map((item) => (
+            <li key={item}>{item}</li>
+          ))}
+        </ul>
+        <p>Photographs of signage currently documented are included below; the remainder are in place but not yet individually photographed.</p>
+        <div className="grid grid-cols-3 gap-3">
+          <Figure src="/images/pool/01-entrance-hallway.jpeg" alt="Entrance signage" caption="Entrance signage: no eating/drinking, CCTV in operation, no outdoor footwear, hygiene notice" />
+          <Figure src="/images/pool/Pool-entrance.png" alt="Lifebuoy for emergency use only signage" caption="Lifebuoy for emergency use only, and fire call point" />
+          <Figure src="/images/pool/Pool-facing-south.png" alt="No diving sign" caption="No diving sign, displayed poolside" />
+          <Figure src="/images/pool/05-sauna-entrance-door.jpeg" alt="Hygiene and single-household changing room notice" caption="Hygiene reminder and single-household changing room notice" />
+          <Figure src="/images/pool/03-gym-facing-south.jpeg" alt="Cross contamination warning" caption="Hygiene and cross-contamination warning notices" />
+        </div>
+      </Section>
+
+      <Section number="12" title="Historical Incidents">
+        <p className="font-semibold">Broken Glass Incident</p>
+        <p>
+          Several years ago, glass was broken within the pool hall. As a precaution the swimming pool was completely
+          drained, professionally cleaned and recommissioned before reopening. No injuries were reported.
+        </p>
+        <p className="font-semibold">Plant Room Electrical Failure (2026)</p>
+        <p>
+          During 2026, a leak within the plant room resulted in water entering electrical equipment, causing failure
+          of the dehumidification system. Although the dehumidifier was subsequently repaired, the prolonged period
+          of elevated humidity resulted in damage to sections of the ceiling, decorative cornicing and internal
+          finishes. The swimming pool has remained temporarily closed whilst surveys, investigations and repair
+          options are considered. This incident forms part of the ongoing refurbishment project and is not
+          considered representative of normal pool operation.
+        </p>
+        <Figure
+          src="/images/pool/08-ceiling-damage.jpeg"
+          alt="Ceiling finishes damaged following the 2026 plant room electrical failure"
+          caption="Ceiling finishes requiring repair, following the 2026 plant room electrical failure"
+        />
+      </Section>
+
+      <Section number="13" title="Existing Rules">
+        <p>The full Pool &amp; Recreation Area Health &amp; Safety Rules are displayed at the main entrance. These rules cover:</p>
+        <ul className="list-disc space-y-0.5 pl-5">
+          <li>Supervision of children</li>
+          <li>Maximum occupancy</li>
+          <li>Hygiene requirements</li>
+          <li>Prohibited activities</li>
+          <li>Alcohol and smoking</li>
+          <li>Appropriate footwear</li>
+          <li>Appropriate clothing</li>
+          <li>Safe use of the sauna</li>
+          <li>Responsibility of residents</li>
+          <li>Protection of emergency equipment</li>
+          <li>Behaviour within the facility</li>
+        </ul>
+      </Section>
+
+      <Section number="14" title="Areas for Independent Review">
+        <p>James Square welcomes independent advice from the Royal Life Saving Society regarding the continued safe operation of the facility. Particular areas where guidance would be appreciated include:</p>
+        <ul className="list-disc space-y-0.5 pl-5">
+          {areasForReview.map((item) => (
+            <li key={item}>{item}</li>
+          ))}
+        </ul>
+      </Section>
+    </article>
+  );
+}

--- a/src/app/pool3d/page.tsx
+++ b/src/app/pool3d/page.tsx
@@ -1,5 +1,6 @@
 import type { Metadata } from 'next';
 import Image from 'next/image';
+import Link from 'next/link';
 
 import PoolModelSequence from '@/components/PoolModelSequence';
 import PoolBuildHero from '@/components/pool/PoolBuildHero';
@@ -105,6 +106,14 @@ export default function Pool3DPage() {
           </div>
           <div className="mt-6 inline-flex rounded-2xl border border-amber-200 bg-amber-50 px-4 py-3 text-sm font-semibold text-amber-900 shadow-sm dark:border-amber-300/30 dark:bg-amber-300/10 dark:text-amber-100">
             Pool currently closed pending repairs and further assessment.
+          </div>
+          <div className="mt-4">
+            <Link
+              href="/pool-safety"
+              className="inline-flex items-center gap-1.5 text-sm font-semibold text-sky-700 underline underline-offset-4 hover:text-sky-900 dark:text-sky-300 dark:hover:text-sky-100"
+            >
+              How the pool operates &amp; staying safe →
+            </Link>
           </div>
         </div>
       </section>

--- a/src/app/sitemap.ts
+++ b/src/app/sitemap.ts
@@ -1,0 +1,23 @@
+import type { MetadataRoute } from 'next';
+
+const BASE_URL = 'https://james-square.com';
+
+export default function sitemap(): MetadataRoute.Sitemap {
+  return [
+    {
+      url: `${BASE_URL}/`,
+      changeFrequency: 'weekly',
+      priority: 1,
+    },
+    {
+      url: `${BASE_URL}/pool-safety`,
+      changeFrequency: 'monthly',
+      priority: 0.8,
+    },
+    {
+      url: `${BASE_URL}/pool3d`,
+      changeFrequency: 'monthly',
+      priority: 0.6,
+    },
+  ];
+}


### PR DESCRIPTION
## Summary
- New public `/pool-safety` page — "Our Swimming Pool — How It Works & Staying Safe": facility overview, opening hours, how to use it, water quality, cleaning & maintenance, emergency equipment, a 12-photo signage gallery, the verbatim pool rules, and a supervision fair-notice section. Sticky in-page nav, lazy-loaded images, mobile-first (signage gallery collapses to one column). Linked to/from `/pool3d`, added to `sitemap.xml`.
- New unlisted, `noindex` `/pool-safety/rlss-report` page mirroring the full 14-section operations pack (including access control, security measures and historical incidents) for the RLSS assessor — not linked from any public page or the sitemap. Print CSS added so it exports cleanly to a 17-page A4 PDF with header/footer and page numbers.
- Every photo used was individually inspected before placement so access-control mechanics (keypad, fob) and security specifics (camera positions, motion sensor, alarm timing) stay out of the public page and only appear in the private report.
- Also includes the earlier pool3d hero video / model-viewer / lighting work from this branch.

## Verification
- `npx tsc --noEmit` and `npx eslint` clean
- `npm run build` succeeds
- Production server checked: all `<img>` sources on both pages resolve 200, no forbidden access-control/security terms present in the public page's rendered HTML, no duplicate footer, sitemap includes the public page and excludes the private report
- RLSS PDF regenerated and spot-checked page by page (cover, access control, security measures, historical incidents, rules, closing page)

🤖 Generated with [Claude Code](https://claude.com/claude-code)


---
_Generated by [Claude Code](https://claude.ai/code/session_016QzgLYmB2q1pyhkZuXbHdg)_