### PR TITLE
Update pool rescue pole hotspot copy

### DIFF
--- a/src/app/pool-safety/PoolSafetyClient.tsx
+++ b/src/app/pool-safety/PoolSafetyClient.tsx
@@ -132,7 +132,7 @@ const hotspots: Hotspot[] = [
     x: 60,
     y: 31,
     tone: 'from-amber-500 to-orange-500',
-    body: 'A reach pole is stored poolside for use in a water rescue. It lets a rescuer reach a swimmer in difficulty without entering the water themselves.',
+    body: 'The reach pole is positioned beside the timber seating area between the swimming pool and gym so it can be accessed rapidly during a water-rescue emergency. It lets a rescuer reach someone in difficulty without entering the water themselves.',
   },
   {
     id: 'lifebuoy-1',


### PR DESCRIPTION
### Motivation
- Clarify the location of the reach pole on the floor plan so it is clear it sits beside the timber seating area between the swimming pool and gym and can be accessed rapidly in a water‑rescue emergency.

### Description
- Update the `body` text for hotspot `rescue-pole` in `src/app/pool-safety/PoolSafetyClient.tsx` to specify the pole’s position beside the timber seating area between the swimming pool and gym while preserving the existing safety meaning that it allows a rescuer to reach someone in difficulty without entering the water.

### Testing
- Ran `npm run lint`, which completed successfully with the repository’s existing unrelated warnings and introduced no new lint errors.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a500d174254832489154a3dc7a15930)