### PR TITLE
Update pool CCTV hotspot copy

### DIFF
--- a/src/app/pool-safety/PoolSafetyClient.tsx
+++ b/src/app/pool-safety/PoolSafetyClient.tsx
@@ -204,7 +204,7 @@ const hotspots: Hotspot[] = [
     x: 60,
     y: 42,
     tone: 'from-slate-500 to-slate-700',
-    body: 'There are two CCTV cameras: one to the right/north side of the pool pointing south across the pool hall, and one to the left of the internal entrance monitoring people entering and exiting. CCTV supports security and incident review, but does not imply constant live monitoring.',
+    body: 'There are two CCTV cameras: one mounted on the north wall overlooking the swimming pool and facing south across the pool hall, and one mounted beside the internal entrance monitoring people entering and leaving the pool hall. CCTV supports security and incident review, but does not imply constant live monitoring.',
   },
 ];
 


### PR DESCRIPTION
### Motivation
- Clarify the pool CCTV hotspot text to explicitly describe the location and coverage of both cameras while keeping the existing caveat that CCTV supports security and incident review but does not imply constant live monitoring.

### Description
- Updated the `body` text for the hotspot with `id: 'cctv'` in `src/app/pool-safety/PoolSafetyClient.tsx` to state there are two CCTV cameras — one mounted on the north wall overlooking the swimming pool and facing south across the pool hall, and one mounted beside the internal entrance monitoring people entering and leaving the pool hall — and retained the existing caveat about monitoring.

### Testing
- Ran `npm run lint`, which completed and reported only unrelated warnings in other files.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a501a27f4dc8324acbddf4173feaebb)