### PR TITLE
Add CC/BCC inputs and confirmation dialog to admin email sender

### DIFF
--- a/src/app/admin/AdminEmailPanel.tsx
+++ b/src/app/admin/AdminEmailPanel.tsx
@@ -39,6 +39,15 @@ const senderOptions: SenderOption[] = [
 ];
 
 const confirmationPhrase = 'SEND TO ALL';
+const splitEmailList = (value: string) =>
+  value
+    .split(/[\n,;]+/)
+    .map((email) => email.trim().toLowerCase())
+    .filter(Boolean);
+
+const uniqueEmails = (emails: string[]) => Array.from(new Set(emails));
+
+const isValidEmail = (email: string) => /^[^\s@]+@[^\s@]+\.[^\s@]+$/.test(email);
 const availableGroups: Array<{ key: EmailGroupKey; label: string }> = [
   { key: 'committee', label: 'Send to Committee' },
   { key: 'myreside', label: 'Copy in Myreside' },
@@ -52,6 +61,8 @@ const AdminEmailPanel = () => {
   const [customEmail, setCustomEmail] = useState('');
   const [subject, setSubject] = useState('');
   const [message, setMessage] = useState('');
+  const [ccInput, setCcInput] = useState('');
+  const [bccInput, setBccInput] = useState('');
   const [status, setStatus] = useState<Status>({ tone: 'idle', message: '' });
   const [senderEmail, setSenderEmail] = useState(senderOptions[0]?.value ?? '');
   const [selectedGroups, setSelectedGroups] = useState<EmailGroupKey[]>([]);
@@ -104,8 +115,19 @@ const AdminEmailPanel = () => {
 
   const normalizedCustomEmail = useMemo(() => customEmail.trim().toLowerCase(), [customEmail]);
   const customEmailIsValid = useMemo(
-    () => /^[^\s@]+@[^\s@]+\.[^\s@]+$/.test(normalizedCustomEmail),
+    () => isValidEmail(normalizedCustomEmail),
     [normalizedCustomEmail],
+  );
+
+  const ccRecipients = useMemo(() => uniqueEmails(splitEmailList(ccInput)), [ccInput]);
+  const bccRecipients = useMemo(() => uniqueEmails(splitEmailList(bccInput)), [bccInput]);
+  const invalidCcRecipients = useMemo(
+    () => ccRecipients.filter((email) => !isValidEmail(email)),
+    [ccRecipients],
+  );
+  const invalidBccRecipients = useMemo(
+    () => bccRecipients.filter((email) => !isValidEmail(email)),
+    [bccRecipients],
   );
 
   const recipientCount = useMemo(() => {
@@ -143,9 +165,14 @@ const AdminEmailPanel = () => {
     [selectedGroups],
   );
 
+  const combinedBccRecipients = useMemo(
+    () => uniqueEmails([...bccRecipients, ...groupBccRecipients]),
+    [bccRecipients, groupBccRecipients],
+  );
+
   const totalRecipientCount = useMemo(
-    () => Array.from(new Set([...primaryRecipientEmails, ...groupBccRecipients])).length,
-    [primaryRecipientEmails, groupBccRecipients],
+    () => uniqueEmails([...primaryRecipientEmails, ...ccRecipients, ...combinedBccRecipients]).length,
+    [primaryRecipientEmails, ccRecipients, combinedBccRecipients],
   );
 
   const recipientTypeLabel = useMemo(() => {
@@ -154,7 +181,7 @@ const AdminEmailPanel = () => {
     return 'a group';
   }, [recipientCount, recipientMode]);
 
-  const shouldConfirmSend = recipientMode === 'all' || totalRecipientCount > 1;
+  const shouldConfirmSend = totalRecipientCount > 0;
   const isAllRecipients = recipientMode === 'all';
   const showCommitteeWarning =
     senderEmail === 'committee@james-square.com' && recipientCount > 1;
@@ -197,7 +224,15 @@ const AdminEmailPanel = () => {
       return null;
     }
 
-    if (buildRecipientEmails().length === 0 && groupBccRecipients.length === 0) {
+    if (invalidCcRecipients.length > 0 || invalidBccRecipients.length > 0) {
+      setStatus({
+        tone: 'error',
+        message: 'One or more CC or BCC email addresses are invalid.',
+      });
+      return null;
+    }
+
+    if (buildRecipientEmails().length === 0 && ccRecipients.length === 0 && combinedBccRecipients.length === 0) {
       setStatus({
         tone: 'error',
         message: 'Choose at least one recipient or select a BCC group.',
@@ -222,7 +257,8 @@ const AdminEmailPanel = () => {
           mode: recipientMode,
           emails: buildRecipientEmails(),
         },
-        bcc: groupBccRecipients,
+        cc: ccRecipients,
+        bcc: combinedBccRecipients,
       });
 
       setStatus({
@@ -233,6 +269,8 @@ const AdminEmailPanel = () => {
       setMessage('');
       setSelectedIds([]);
       setCustomEmail('');
+      setCcInput('');
+      setBccInput('');
       setSelectedGroups([]);
     } catch (error) {
       console.error('Failed to send admin email', error);
@@ -256,12 +294,7 @@ const AdminEmailPanel = () => {
     const currentUser = validateSend();
     if (!currentUser) return;
 
-    if (shouldConfirmSend) {
-      setConfirmOpen(true);
-      return;
-    }
-
-    await performSend();
+    setConfirmOpen(true);
   };
 
   const handleConfirmSend = async () => {
@@ -405,6 +438,46 @@ const AdminEmailPanel = () => {
         )}
 
         <div className="grid gap-3 sm:grid-cols-2">
+          <div>
+            <label className="block text-sm font-medium text-slate-700 dark:text-slate-200">
+              CC recipients (optional)
+            </label>
+            <textarea
+              value={ccInput}
+              onChange={(event) => setCcInput(event.target.value)}
+              rows={3}
+              className="mt-1 w-full rounded-xl border border-white/20 bg-white/5 px-3 py-2 text-sm text-slate-900 placeholder:text-slate-400 dark:border-white/10 dark:bg-white/5 dark:text-white"
+              placeholder="cc1@example.com, cc2@example.com"
+            />
+            <p className="mt-1 text-xs text-slate-500 dark:text-slate-400">
+              Separate multiple CC addresses with commas, semicolons, or new lines.
+            </p>
+            {invalidCcRecipients.length > 0 && (
+              <p className="mt-1 text-xs text-rose-400">
+                Invalid CC emails: {invalidCcRecipients.join(', ')}.
+              </p>
+            )}
+          </div>
+          <div>
+            <label className="block text-sm font-medium text-slate-700 dark:text-slate-200">
+              BCC recipients (optional)
+            </label>
+            <textarea
+              value={bccInput}
+              onChange={(event) => setBccInput(event.target.value)}
+              rows={3}
+              className="mt-1 w-full rounded-xl border border-white/20 bg-white/5 px-3 py-2 text-sm text-slate-900 placeholder:text-slate-400 dark:border-white/10 dark:bg-white/5 dark:text-white"
+              placeholder="bcc1@example.com, bcc2@example.com"
+            />
+            <p className="mt-1 text-xs text-slate-500 dark:text-slate-400">
+              Separate multiple BCC addresses with commas, semicolons, or new lines.
+            </p>
+            {invalidBccRecipients.length > 0 && (
+              <p className="mt-1 text-xs text-rose-400">
+                Invalid BCC emails: {invalidBccRecipients.join(', ')}.
+              </p>
+            )}
+          </div>
           <div className="sm:col-span-2">
             <label className="block text-sm font-medium text-slate-700 dark:text-slate-200">
               Subject
@@ -432,8 +505,9 @@ const AdminEmailPanel = () => {
         </div>
 
         <div className="rounded-xl border border-white/15 bg-white/5 px-4 py-3 text-sm text-slate-700 dark:border-white/10 dark:bg-white/5 dark:text-slate-300">
-          This email will be sent to <strong>{totalRecipientCount}</strong> recipients ({recipientTypeLabel}) using{' '}
-          <strong>{senderEmail}</strong>.
+          This email will be sent to <strong>{totalRecipientCount}</strong> total recipients ({recipientTypeLabel}) using{' '}
+          <strong>{senderEmail}</strong>. Primary: <strong>{primaryRecipientEmails.length}</strong>, CC:{' '}
+          <strong>{ccRecipients.length}</strong>, BCC: <strong>{combinedBccRecipients.length}</strong>.
         </div>
 
         <div className="grid gap-2 rounded-xl border border-white/15 bg-white/5 px-4 py-3 dark:border-white/10 dark:bg-white/5">
@@ -500,10 +574,12 @@ const AdminEmailPanel = () => {
                 <strong>
                   {isAllRecipients ? 'ALL users' : `${totalRecipientCount} recipients`}
                 </strong>. This
-                action cannot be undone. Are you sure you want to continue?
+                action cannot be undone. Are you sure you want to send this email?
               </p>
               <p className="text-sm text-slate-700 dark:text-slate-300">
-                This email will be sent using <strong>{senderEmail}</strong>.
+                This email will be sent using <strong>{senderEmail}</strong>. Primary:{' '}
+                <strong>{primaryRecipientEmails.length}</strong>, CC: <strong>{ccRecipients.length}</strong>,
+                BCC: <strong>{combinedBccRecipients.length}</strong>.
               </p>
               {selectedGroups.includes('committee') && (
                 <p className="text-sm text-slate-700 dark:text-slate-300">
@@ -544,7 +620,7 @@ const AdminEmailPanel = () => {
                   checked={confirmAcknowledged}
                   onChange={(event) => setConfirmAcknowledged(event.target.checked)}
                 />
-                I understand this email will reach multiple recipients.
+                Yes, I am sure I want to send this email.
               </label>
             )}
 

--- a/src/app/api/admin/send-email/route.ts
+++ b/src/app/api/admin/send-email/route.ts
@@ -18,6 +18,7 @@ type AdminEmailRequest = {
   message: string;
   sender?: string;
   recipients: RecipientSelection;
+  cc?: string[];
   bcc?: string[];
 };
 
@@ -123,6 +124,14 @@ export async function POST(req: NextRequest) {
       ),
     );
 
+    const ccEmails = Array.from(
+      new Set(
+        (Array.isArray(body.cc) ? body.cc : [])
+          .map((email) => (typeof email === "string" ? email.trim() : ""))
+          .filter((email) => email.length > 0),
+      ),
+    );
+
     const bccEmails = Array.from(
       new Set(
         (Array.isArray(body.bcc) ? body.bcc : [])
@@ -131,7 +140,7 @@ export async function POST(req: NextRequest) {
       ),
     );
 
-    const emails = Array.from(new Set([...primaryEmails, ...bccEmails]));
+    const emails = Array.from(new Set([...primaryEmails, ...ccEmails, ...bccEmails]));
 
     if (recipients.mode === "custom") {
       if (primaryEmails.length !== 1) {
@@ -149,7 +158,7 @@ export async function POST(req: NextRequest) {
       }
     }
 
-    if (primaryEmails.length === 0 && bccEmails.length === 0) {
+    if (primaryEmails.length === 0 && ccEmails.length === 0 && bccEmails.length === 0) {
       return NextResponse.json(
         { error: "No recipient emails found" },
         { status: 400 },
@@ -174,16 +183,16 @@ export async function POST(req: NextRequest) {
 
     const resend = getResendClient();
 
-    const batches = chunk(emails, MAX_RECIPIENTS_PER_BATCH);
+    const isBulkSend = primaryEmails.length > 1 || ["all", "owners", "selected"].includes(recipients.mode);
+    const batches = isBulkSend ? chunk(emails, MAX_RECIPIENTS_PER_BATCH) : [emails];
     let lastMessageId: string | null = null;
-
-    const isBulkSend = emails.length > 1;
 
     for (const batch of batches) {
       const { error, data } = await resend.emails.send({
         from: sender,
-        to: isBulkSend ? sender : batch[0],
-        bcc: isBulkSend ? batch : undefined,
+        to: isBulkSend ? sender : (primaryEmails[0] ?? sender),
+        cc: !isBulkSend && ccEmails.length > 0 ? ccEmails : undefined,
+        bcc: isBulkSend ? batch : bccEmails.length > 0 ? bccEmails : undefined,
         subject,
         html,
         text: stripHtml(html),
@@ -207,6 +216,9 @@ export async function POST(req: NextRequest) {
       adminUserId: decodedToken.uid,
       sender,
       recipientCount: emails.length,
+      primaryRecipientCount: primaryEmails.length,
+      ccRecipientCount: ccEmails.length,
+      bccRecipientCount: bccEmails.length,
       emailType,
     });
 

--- a/src/lib/client/sendAdminEmailRequest.ts
+++ b/src/lib/client/sendAdminEmailRequest.ts
@@ -13,6 +13,7 @@ export async function sendAdminEmailRequest(
       userIds?: string[];
       emails?: string[];
     };
+    cc?: string[];
     bcc?: string[];
   },
 ) {


### PR DESCRIPTION
### Motivation
- Provide admins a way to CC or BCC one or more additional recipients when sending administrative email.
- Require an explicit confirmation step to prevent accidental mass sends and make recipient counts and delivery mode visible.

### Description
- UI: added `CC` and `BCC` textarea inputs to `AdminEmailPanel` that accept comma/semicolon/newline-separated addresses, deduplicate entries, and show inline invalid-email feedback.
- Recipient handling: primary, CC and BCC recipients are merged for totals and the panel now displays counts for Primary/CC/BCC and overall recipients, with updated confirmation wording (`Are you sure you want to send this email?`).
- Client/server changes: extended the client payload (`src/lib/client/sendAdminEmailRequest.ts`) and the API (`src/app/api/admin/send-email/route.ts`) to accept `cc` and `bcc`, validate and deduplicate them, and update audit fields for `primaryRecipientCount`, `ccRecipientCount`, and `bccRecipientCount`.
- Delivery logic: when sending in bulk the implementation preserves recipient privacy by sending the message from the configured sender to the sender address with the recipients as `bcc`, while for single/non-bulk sends the `cc` list is applied directly.

### Testing
- Ran `npm run lint`, which completed successfully but left unrelated warnings in other files.
- Ran `npx tsc --noEmit`, which completed without type errors.
- Ran `npm run build`, which failed in this environment because Next.js could not fetch Google Fonts (`Geist` / `Geist Mono`) from `fonts.gstatic.com`, so a full production build could not be validated here.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a526d6ce9988324bad0f5413056372f)