### PR TITLE
Implement GDPR consent platform and close critical security gaps

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -51,3 +51,8 @@ serviceAccountKey.json
 .env.local
 .env.production
 .env.development
+
+# Firebase emulator logs
+firestore-debug.log
+ui-debug.log
+firebase-debug.log

--- a/docs/gdpr-audit-2026.md
+++ b/docs/gdpr-audit-2026.md
@@ -1,0 +1,256 @@
+# James Square — UK GDPR, PECR, Privacy & Security Audit
+
+**Date:** 26 July 2026
+**Scope:** the whole of james-square.com — Next.js application, Firebase Authentication, Cloud Firestore security rules, Cloud Functions, API routes, Server Actions, forms, email systems, admin tooling, client bundles and legal documents.
+**Verification:** 29 automated Firestore security-rules tests, 22 automated consent and accessibility checks, client-bundle secret scanning, XSS payload tests against the sanitiser, and manual review of every API route and form.
+
+---
+
+## 1. Executive summary
+
+The site was **not** compliant, and the problems were not cosmetic. Four issues were exploitable by any anonymous visitor with a browser console, and one allowed complete privilege escalation to administrator.
+
+Specifically, before this work:
+
+- Every resident's **name, email address, flat number and resident type** could be downloaded by anyone, signed in or not.
+- Any resident could make themselves a **site administrator** by editing their own profile document.
+- Any signed-in resident could send **email from a james-square.com address** to any recipient list they chose.
+- **Anyone at all**, with no account, could send email as `committee@james-square.com`.
+- The Owners and Committee area **access codes were plain text in the JavaScript** served to every visitor.
+- Committee members' **personal email addresses** were compiled into the public client bundle.
+- There was **no cookie consent mechanism of any kind**, and no Cookie Policy.
+
+All of the above are fixed. 15 of the 29 rules tests fail against the previous rules and pass against the new ones, so the fixes are demonstrated rather than asserted.
+
+The one piece of good news from the audit: the site runs **no analytics, advertising or tracking scripts whatsoever**. There was no unlawful tracking to unwind, and a browser loading the site now makes **zero third-party requests** before consent (verified).
+
+Two significant items remain and require decisions that are not ours to make — see §6.
+
+---
+
+## 2. Findings
+
+Risk ratings combine likelihood and impact in the context of a residential community website holding ~150 households' contact details.
+
+### Critical
+
+| ID | Finding | Detail | Status |
+|----|---------|--------|--------|
+| **S-01** | **Privilege escalation to administrator** | `firestore.rules` contained `allow update ... if request.auth.uid == userId` with no field restrictions, while `isAdmin()` fell back to reading `isAdmin` from that same document. Any resident could run one line in the browser console to set `isAdmin: true` on their own profile and gain full administrative access — reading all resident data, deleting bookings, sending mail as the site. | **Fixed** |
+| **P-01** | **All resident personal data world-readable** | `match /users/{userId} { allow read: if true; }` — with a comment acknowledging it (*"adjust if you want privacy"*). Full name, email address, username, flat number, resident type, admin status and login timestamps for every resident, retrievable by any anonymous visitor. A UK GDPR Article 32 failure and a reportable personal-data breach risk. | **Fixed** |
+| **S-02** | **Admin email endpoint had no admin check** | `/api/admin/send-email` verified the caller's Firebase ID token but never checked whether they were an administrator. Any signed-in resident could send email from `no-reply@`, `committee@` or `support@james-square.com` to arbitrary recipients — a ready-made phishing capability against their own neighbours, with the Association's domain reputation attached. | **Fixed** |
+| **S-03** | **Committee email endpoint had optional authentication** | `/api/committee/send-email` wrapped its token check in `if (token) { ... }`. A request with **no** `Authorization` header skipped verification entirely and proceeded to send. Anyone on the internet could send mail as `committee@james-square.com` to any address list, subject only to a 100-recipient daily cap. | **Fixed** |
+
+### High
+
+| ID | Finding | Detail | Status |
+|----|---------|--------|--------|
+| **S-04** | **Shared access codes hard-coded in client components** | `const OWNERS_ACCESS_CODE = '3579'` in `src/app/owners/page.tsx` and `const PASSCODE = '9753'` in `CommitteeGate.tsx`. Both were compiled into the JavaScript bundle downloaded by every visitor, so the "private" Owners and Committee areas were effectively public. Gating was also client-side only: setting one `sessionStorage` key bypassed it. | **Partly fixed** — codes moved server-side; see §6.1 |
+| **P-02** | **Confidential building documents publicly fetchable** | `public/docs/survey/` contains the elevations and roof condition reports, the 2026 AGM agenda and minutes, and the Factor's Report — the latter covering development debt, sinking fund balances and named financial transfers. Anything under `public/` is served with no authentication, so all of it is retrievable by direct URL and indexable by search engines. | **Mitigated only** — see §6.2 |
+| **P-03** | **Booking records exposed every resident's email address** | `match /bookings/... { allow read: if true; }`, and each booking document stores the booker's email in `user`. The UI masked this ("Booked by another user"), but the raw address was in the payload. Anyone could harvest the full resident address book plus a timestamped record of when individuals use the pool, gym and sauna. | **Fixed** |
+| **P-04** | **Message board publicly readable** | `allow read: if true` on `messageBoard` and its comments and replies. Residents' names and the content of internal community discussion were readable by anyone and indexable by search engines. | **Fixed** |
+| **P-05** | **Ballot secrecy broken** | `voting_votes` was world-readable and each document contains `userName`, `voterName`, `flat`, `userId` and `optionId`. Anyone could reconstruct exactly how each named household voted on every question. | **Partly fixed** — see §6.3 |
+| **S-05** | **Committee members' personal emails in the public bundle** | `src/lib/emailGroups.ts` held six committee members' personal addresses (Gmail, AOL, iCloud, BT, Outlook) and two Myreside business addresses, and was imported by the client component `AdminEmailPanel.tsx` — publishing all eight to every visitor. Unnecessary disclosure of personal data and a spear-phishing target list. | **Fixed** |
+| **S-06** | **Anonymous creation of community votes** | `voting_questions` allowed `create` with no authentication at all. Any internet user could inject arbitrary voting questions into the community voting system. | **Fixed** |
+| **S-07** | **Exploitable HTML sanitiser** | `sanitizeHtml()` used an unanchored allow-list regex, so `iframe` passed by matching the `i` of the italic tag; stripped event handlers only when quoted, so `<div onerror=alert(1)>` survived; and never validated URL schemes, so `javascript:` hrefs passed through. Output is rendered into committee emails and re-rendered in the committee archive via `dangerouslySetInnerHTML`. | **Fixed** |
+| **S-08** | **No security headers** | No CSP, HSTS, `X-Content-Type-Options`, `Referrer-Policy`, `Permissions-Policy` or framing protection on any response. The site could be framed for clickjacking, and there was no defence-in-depth against script injection. | **Fixed** |
+
+### Medium
+
+| ID | Finding | Detail | Status |
+|----|---------|--------|--------|
+| **L-01** | **No cookie consent mechanism and no Cookie Policy** | Nothing asked, nothing recorded, nothing to withdraw, and no document listing what was stored. A PECR Regulation 6 failure. Mitigating factor: no non-essential cookies were actually being set, so nothing unlawful was *stored* — but the mechanism, the record and the disclosure were all absent. | **Fixed** |
+| **L-02** | **Privacy Policy did not match the site** | Generic, named no data controller, listed no processors (Google, Vercel, Resend), gave no retention periods, gave no contact address for privacy enquiries, cited "legitimate interests" for processing that is plainly contractual, and stated cookies were used without a Cookie Policy. Insufficient under Articles 13–14. | **Fixed** |
+| **L-03** | **No Acceptable Use or Data Retention policy** | Both were requested and neither existed. Retention in particular was unstated, so there was no defensible answer to "how long do you keep this?". | **Fixed** |
+| **S-09** | **No rate limiting anywhere** | Login, password reset, the 4-digit access codes, and both mail endpoints were unthrottled. A 4-digit code is 10,000 guesses — minutes of scripted effort. | **Fixed** |
+| **S-10** | **Unauthenticated Admin-SDK read endpoint** | `/api/message-board` read the `posts` collection with the Admin SDK, which bypasses security rules, with no authentication and an attacker-controlled unbounded `limit` parameter (`?limit=999999`). | **Fixed** |
+| **S-11** | **Owner authorisation depends on an inconsistent signal** | `isOwner()` requires the `owner` custom claim or `roles.owner`, but owners actually reach the Owners area via the shared access code, so many owners have neither. Owner-gated collections are therefore inaccessible to genuine owners, while the access code admits anyone who has it. Vote creation could only be tightened to "signed in", not "is an owner", as a result. | **Documented** — see §6.1 |
+| **S-12** | **Audit log and feedback collections had no rules** | `activityLogs`, `feedback`, `committeeSentEmails` and `rateLimits` were absent from `firestore.rules`. They defaulted to deny, so the admin panel's writes to `activityLogs` were silently failing — meaning **the administrative audit trail was not being written**. This also indicates the deployed rules may differ from the rules in the repository. | **Fixed** — but verify, §6.4 |
+| **S-13** | **Content Security Policy not enforced** | A CSP is now shipped, but in `Report-Only` mode: a wrong CSP breaks pages silently, and this one cannot be verified against every route from a development environment. | **Deliberate** — see §6.5 |
+
+### Low
+
+| ID | Finding | Detail | Status |
+|----|---------|--------|--------|
+| **S-14** | **Three divergent Firebase Admin initialisers** | `firebaseAdmin.ts`, `firebase-admin.ts` and an inline initialiser in `api/message-board/route.ts`, reading three different environment variables (`FIREBASE_ADMIN_CREDENTIALS`, `FIREBASE_ADMIN_JSON`, `FIREBASE_SERVICE_ACCOUNT_KEY`). Credential handling should have exactly one path. | **Documented** |
+| **S-15** | **Dead admin endpoint** | `/api/admin/find-user-by-email` authenticates via a `__session` cookie that nothing in the codebase ever creates, so it always returns 401. It fails closed, but it is misleading dead code. | **Documented** |
+| **S-16** | **Firestore rules not wired into deployment config** | `firebase.json` had no `firestore` section, so `firebase deploy` never deployed the rules — they had to be applied by hand, which is how a repository and a live project drift apart. | **Fixed** |
+| **S-17** | **`owner_votes` could not be deleted** | The rule required `request.resource.data.keys().hasAll([...])` for `create, update, delete`. `request.resource` does not exist on a delete, so deletion always failed. | **Fixed** |
+| **P-06** | **Factor's business emails in a client bundle** | `owners/secure/page.tsx` embeds quoted email correspondence including Myreside staff addresses, compiled into the client bundle for that route. Business rather than personal addresses, and a genuine correspondence record — flagged for awareness rather than as a defect. | **Documented** |
+| **A-01** | **No skip link, and consent choice 63 tab stops away** | The site had no skip-to-content link. On first implementation, the consent banner sat last in the DOM, requiring 63 tab presses to reach. | **Fixed** — now 5 |
+
+---
+
+## 3. What was implemented
+
+### 3.1 Consent management platform
+
+A real CMP, not a banner.
+
+- **`src/lib/consent/types.ts`** — five categories (essential, functional, analytics, performance, marketing), a versioned consent record, and strict normalisation of anything read back from storage. Consent expires after **182 days** so an old decision is never treated as permanent.
+- **`src/lib/consent/store.ts`** — the decision store. Written to `localStorage` and mirrored to a `SameSite=Lax` first-party cookie so server-rendered pages and future edge logic can read it without JavaScript. Nothing is sent to our servers.
+- **`src/lib/consent/registry.ts`** — the future-proofing mechanism. A service declares its category and how to switch itself on and off; the registry guarantees it never activates before consent, activates exactly once, and tears down the moment consent is withdrawn — clearing the service's own cookies and storage on the exact host, the host domain and the registrable domain. A `scriptService()` helper covers the common "inject a vendor `<script>`" case.
+- **`src/lib/consent/services.ts`** — the registration point, currently **empty**, with worked examples for Google Analytics 4 (IP anonymisation and ad signals off) and notes on Clarity's session-replay risk. Adding GA4 later is a single registration; the banner, the panel, the policy and the withdrawal path all pick it up with no further changes.
+- **`ConsentGate`** — wraps embeds (maps, Vimeo, social, a future AI assistant) so the iframe is **never inserted**, and therefore the third party is never contacted, until consent exists. Shows a glass placeholder offering to enable it.
+- **Default-deny** — `DEFAULT_DECISIONS` is essential-only, and it is what both server rendering and pre-hydration client code read, so there is no window in which an optional script could run.
+
+### 3.2 Consent interface
+
+Built from the site's existing Liquid Glass tokens (`--glass-bg-light`, `--glass-border`, `--glass-shadow-lift`, `--glass-highlight`), with the same `cubic-bezier(0.16, 1, 0.3, 1)` easing and `useReducedMotion()` pattern already used across the site.
+
+- **Floating banner** — a `.consent-surface` card with 26px backdrop blur, the specular top edge the site's other cards share, a soft fade-and-rise entrance, and a hand-drawn cookie mark whose crumbs drift on a 6-second cycle. Appears only when there is no valid decision on file.
+- **Not a modal.** It is a labelled `role="region"`, does not trap focus and does not block the page. Forcing a choice before the site can be read is the pattern the ICO objects to.
+- **No dark patterns.** *Accept All* leads through depth and gradient, not through misleading wording or a hidden reject. *Essential Only* is an equally prominent single click — not buried behind the preferences panel. Withdrawal is one click from any page footer.
+- **Preferences panel** — a proper `aria-modal` dialog: focus moved in on open and restored on close, Tab contained, Escape closes, background scroll locked without the scrollbar-width layout shift. Each category states in plain English what it does, three concrete examples, whether it stores personal information, whether it is required, and how long it lasts. Bottom sheet on phones, centred card from `sm` up.
+- **Footer** — a permanent *Cookie Settings* control alongside all five legal documents and a privacy enquiries address.
+
+### 3.3 Security hardening
+
+**Firestore rules** — rewritten with a **default-deny catch-all**, so any future collection fails closed unless a rule is written for it. Field-level `diff().affectedKeys()` checks stop privilege escalation while deliberately still permitting the self-service the dashboard relies on (residents self-declare resident type; only an admin can set `isAdmin`, `roles`, `disabled`, `isFlagged` or the admin confirmation fields). Ballots are readable only by the owner who cast them and by admins. The audit log is append-only, so it cannot be quietly rewritten.
+
+**Authorisation** — one shared module, `src/lib/security/requireAuth.ts`, with `requireUser`, `requireAdmin` and `requireCommittee`. Every privileged route funnels through it, so "verified the token" and "checked they are an admin" cannot drift apart again. Tokens are verified with `checkRevoked: true`, so a disabled account loses access immediately.
+
+**Two new server routes** replace what used to require dangerous client permissions:
+- `/api/availability` — serves the public schedule while resolving identities server-side. An anonymous caller learns only that a slot is taken; the caller sees their own bookings; admins see all. This keeps the schedule public *and* closes P-03.
+- `/api/auth/resolve-identifier` — resolves a username to a sign-in email for login and password reset, so `/users` can stay locked down. Rate-limited, and returns only the email address, never the profile.
+
+**Access codes** moved to a Server Action (`src/app/actions/accessCodes.ts`) with bcrypt comparison against `OWNERS_ACCESS_CODE_HASH` / `COMMITTEE_ACCESS_CODE_HASH`, constant-time fallback, and IP-based throttling at 8 attempts per 10 minutes.
+
+**Also:** rate limiting on every sensitive endpoint; the sanitiser rewritten as a strict allow-list with URL-scheme validation (verified against 12 XSS payloads, all neutralised); re-sanitisation at render time in the committee archive, because archives outlive the code that wrote them; recipient caps on mail sends; `emailGroups.ts` marked `server-only` so the build fails if it is ever imported client-side again; security headers on every response; and `robots.ts` keeping private areas out of search indexes.
+
+### 3.4 Legal documents
+
+Five documents, all linked from the footer, sharing one glass shell, each opening with a plain-English "In short" summary:
+
+**Privacy Policy** (rewritten) — names the controller and a contact address, tabulates every category of data against its purpose *and* lawful basis, names all three processors with transfer safeguards, states who can see what, and sets out rights including the honest limits on erasure where a counted vote is involved.
+
+**Cookie Policy** (new) — generated from the same category definitions the preferences panel renders, so the two can never contradict each other. Tabulates every cookie actually set, with an in-page control to reopen preferences.
+
+**Terms of Use** (updated), **Acceptable Use Policy** (new — including a good-faith security research clause), **Data Retention Policy** (new — a period and a justification for all fourteen data types, and exactly what happens when an account is closed).
+
+### 3.5 Accessibility and performance
+
+WCAG 2.2 AA: semantic landmarks, real `<input type="checkbox">` controls behind the toggle skins (so they are announced and keyboard-operable), 2px focus outlines, `prefers-reduced-motion` honoured throughout, and a skip link added to the whole site.
+
+Performance: **zero** new JavaScript before hydration, **zero** third-party requests before consent, **CLS of 0** (measured), no render-blocking anything. The panel is portalled and only mounts when opened. Legal pages are static, 176 B each.
+
+---
+
+## 4. Verification
+
+```
+npm run test:rules      # 29/29 pass (15 of these fail against the previous rules)
+npm run build           # clean
+```
+
+| Check | Result |
+|-------|--------|
+| Firestore rules tests | **29/29 pass**; 15 fail on the previous rules |
+| Consent & accessibility checks | **22/22 pass** |
+| XSS payloads against the sanitiser | 12/12 neutralised |
+| Access codes `3579` / `9753` in client bundle | **0 occurrences** |
+| Committee personal addresses in client bundle | **0 occurrences** |
+| Third-party requests before consent | **0** |
+| Cumulative Layout Shift | **0** |
+| Tab stops to reach the consent choice | **5** (was 63) |
+| Security headers present | verified on live responses |
+
+---
+
+## 5. Behaviour changes to be aware of
+
+These are intentional, and two of them change what anonymous visitors can see. Flagging them explicitly because they are product decisions as much as security ones — say the word and any can be revisited.
+
+1. **The message board now requires a login.** It carries residents' names and was previously readable by anyone and indexable by Google.
+2. **Community voting results now require a login.** Individual ballots were world-readable; requiring a login was the change that could be made without rebuilding the tally system (see §6.3).
+3. **The facility schedule is still public**, deliberately — it is served through `/api/availability` instead of a direct database read, so guests keep the schedule and residents keep their email addresses.
+4. **Login by username** now makes a round trip to a server route rather than querying the database from the browser.
+
+---
+
+## 6. Remaining recommendations
+
+### 6.1 Replace the shared access codes with role-based access — **High**
+
+The codes are no longer in the browser bundle and are throttled, but a shared 4-digit code passed between neighbours is not authentication, and the gate behind it is still client-side `sessionStorage` — anyone can set that key by hand.
+
+The fix is to use what already exists: sign-in with `roles.owner`, granted by the admin panel, plus a server-rendered check. This also resolves **S-11**, where `isOwner()` and the actual route to the Owners area disagree.
+
+**In the meantime:** set `OWNERS_ACCESS_CODE_HASH` and `COMMITTEE_ACCESS_CODE_HASH` and **rotate both codes** — they have been public in the JavaScript bundle for as long as those files have been deployed, so they should be treated as compromised.
+
+```bash
+node -e "console.log(require('bcryptjs').hashSync('NEW-CODE', 12))"
+```
+
+### 6.2 Move the private documents behind authentication — **High**
+
+The building surveys, AGM minutes and Factor's Report in `public/docs/survey/` are still fetchable by direct URL. `X-Robots-Tag: noindex` and `robots.txt` now discourage indexing, but that is discouragement, not access control, and the Factor's Report contains the development's financial position.
+
+The fix: move them out of `public/` to private storage (Firebase Storage with rules, or outside the web root) and serve them through an authenticated route that checks owner status. Until then, assume they are public — and note that search engines may already have cached them.
+
+### 6.3 Make ballots properly secret — **Medium**
+
+`voting_votes` documents pair a choice with a name and a flat, and the results page tallies them by reading every vote in the browser. Requiring a login narrows exposure from "the internet" to "any signed-in resident", but a resident can still see how their neighbours voted.
+
+The fix: maintain `voteTotals` on the question document from a Cloud Function triggered on ballot write, have the results page read only those totals, and restrict ballot reads to the voter and admins. The `voteTotals` field already exists and is initialised to zeros — the increment side was never built.
+
+### 6.4 Confirm the deployed rules match the repository — **Medium**
+
+The admin panel writes to `activityLogs`, which had no rule and therefore defaulted to deny. Either those writes were failing silently — meaning **the audit trail has gaps** — or the live project is running rules that differ from this repository. Both are worth knowing.
+
+```bash
+firebase deploy --only firestore:rules   # firebase.json now wires this up
+```
+
+Please confirm the admin panel still works end-to-end after deploying, and check whether `activityLogs` contains recent entries.
+
+### 6.5 Promote the CSP from Report-Only to enforced — **Medium**
+
+Watch the browser console (or add a `report-uri`) across the pool 3D viewer, the voting pages and any page with an embed, then set `CSP_ENFORCED = true` in `next.config.ts`. A nonce-based policy would let `'unsafe-inline'` be dropped from `script-src`, which is where most of the remaining value is.
+
+### 6.6 Smaller items
+
+- **Consolidate the three Firebase Admin initialisers** (S-14) into one, with a single documented environment variable.
+- **Delete `/api/admin/find-user-by-email`** (S-15) or implement the session cookie it expects.
+- **Automate retention.** The Data Retention Policy states periods that are currently enforced by hand. A scheduled Cloud Function pruning expired bookings, votes and logs would make the policy true rather than aspirational.
+- **Build a self-service data export and account deletion flow**, so subject access and erasure requests are not manual work.
+- **Enable Firebase App Check**, so the Firebase config in the client bundle can only be used by your own site.
+- **Turn on Firebase Auth email enumeration protection** and consider requiring email verification at registration.
+
+---
+
+## 7. Items requiring legal or committee review
+
+The engineering is done; these are decisions and factual confirmations only a human can make. **Nothing here has been signed off by a lawyer, and this report is not legal advice.**
+
+1. **Who is the data controller?** The documents now name the James Square Proprietors' Association, replacing the previous "a resident volunteer". This matters: an unincorporated association's members can carry personal liability. Please confirm this is right, and consider ICO registration (most likely exempt, but worth confirming — there is a screening tool on ico.org.uk).
+
+2. **`privacy@james-square.com` must exist.** The address is now published in the footer and all five documents. If it does not yet route to someone who will action requests within the one-month statutory deadline, that is a compliance gap created by publishing it.
+
+3. **Confirm the processor list.** Google, Vercel and Resend are named from the codebase. If anything else touches personal data — a mailing list, a form service, a backup — it belongs in the Privacy Policy.
+
+4. **Confirm the retention periods.** Every period in the Data Retention Policy is a reasoned proposal, not an established practice. The 6-year figure for committee correspondence and the 2-year booking history in particular should reflect what the Association actually wants.
+
+5. **Ratify the Acceptable Use Policy.** It describes moderation powers — restricting accounts, removing content, reporting to authorities. The committee should agree those powers before they are relied upon.
+
+6. **Decide whether to notify residents.** Findings P-01, P-03 and P-04 mean resident contact details were accessible to anyone for an unknown period. Whether this is a reportable breach under Article 33 depends on evidence of actual access, which we cannot determine from the code alone. **We recommend the committee take a view on this, with advice, rather than treating it as closed** — ICO guidance is at ico.org.uk/for-organisations/report-a-breach/. Reviewing Firebase usage logs for anomalous read volumes would inform that decision.
+
+7. **Consider a DPIA.** Not strictly required at this scale, but the site processes contact details, occupancy patterns and voting records for an entire residential development. A short one would be proportionate.
+
+---
+
+## 8. Compliance statement
+
+As far as is technically achievable within this codebase, james-square.com now follows UK GDPR and PECR best practice:
+
+- **PECR Regulation 6** — no non-essential storage before consent; consent freely given, specific, informed and granular; withdrawal as easy as giving it; a durable record with a timestamp and the method used; re-asked every 182 days. Verified: zero third-party requests before consent.
+- **GDPR Articles 5, 13, 14** — data minimisation reviewed form by form; purposes, lawful bases, processors, transfers, retention periods and rights all disclosed in accessible language.
+- **GDPR Article 25** — privacy by design and by default: default-deny security rules, essential-only consent defaults, identities resolved server-side rather than filtered in the browser, a registry that makes it structurally difficult to add a tracker without gating it.
+- **GDPR Article 32** — authentication and authorisation enforced server-side, field-level protection against privilege escalation, rate limiting, input validation, output sanitisation, security headers, an append-only audit trail, and secrets held server-side.
+- **WCAG 2.2 AA** — for the consent interface, verified by automated checks.
+
+Two caveats, stated plainly: the residual risks in §6.1 and §6.2 are real, and they are architectural rather than code-level — the shared access codes and the publicly-fetchable documents both need a decision about how owner access should work before they can be properly closed. Compliance is a state that has to be maintained, not a box that has been ticked; §6 is the list that keeps it true.
+
+---
+
+*Prepared as part of the GDPR, privacy and security review of james-square.com, 26 July 2026.*

--- a/firebase.json
+++ b/firebase.json
@@ -2,5 +2,16 @@
   "functions": {
     "source": "functions",
     "runtime": "nodejs20"
+  },
+  "firestore": {
+    "rules": "firestore.rules"
+  },
+  "emulators": {
+    "firestore": {
+      "port": 8080
+    },
+    "ui": {
+      "enabled": false
+    }
   }
 }

--- a/firestore.rules
+++ b/firestore.rules
@@ -1,4 +1,21 @@
 rules_version = '2';
+
+// ─────────────────────────────────────────────────────────────────────────────
+// James Square — Firestore Security Rules
+//
+// Principles applied throughout:
+//   1. Resident personal data is never world-readable. Anything containing a
+//      name, email address or flat number requires authentication, and where
+//      possible requires that the reader is the subject or an admin.
+//   2. A user can never grant themselves a role. Role fields (isAdmin, roles,
+//      disabled, isFlagged) are writable by admins only, enforced by field-level
+//      diff checks rather than by trusting the client.
+//   3. Rules validate shape as well as identity, so a compromised client cannot
+//      write arbitrary documents into a collection it is allowed to touch.
+//   4. Collections written only by trusted server code (Admin SDK) are closed to
+//      clients entirely — the Admin SDK bypasses these rules by design.
+// ─────────────────────────────────────────────────────────────────────────────
+
 service cloud.firestore {
   match /databases/{database}/documents {
 
@@ -7,149 +24,219 @@ service cloud.firestore {
       return request.auth != null;
     }
 
-    // Admin: allow either custom claim `admin: true` OR users doc flag `isAdmin == true`
+    function userDoc() {
+      return get(/databases/$(database)/documents/users/$(request.auth.uid)).data;
+    }
+
+    // Admin: custom claim `admin: true` OR users doc flag `isAdmin == true`.
+    // The claim is preferred; the doc flag is retained for existing admins whose
+    // claims have not yet been synced by the syncAdminClaims function.
     function isAdmin() {
       return isSignedIn() && (
         request.auth.token.admin == true ||
-        get(/databases/$(database)/documents/users/$(request.auth.uid)).data.isAdmin == true
+        (
+          exists(/databases/$(database)/documents/users/$(request.auth.uid)) &&
+          userDoc().isAdmin == true
+        )
       );
     }
 
-    // Owner: allow either custom claim `owner: true` OR users doc flag `roles.owner == true`
+    // Owner: custom claim `owner: true` OR users doc flag `roles.owner == true`.
     function isOwner() {
       return isSignedIn() && (
         request.auth.token.owner == true ||
         (
           exists(/databases/$(database)/documents/users/$(request.auth.uid)) &&
-          get(/databases/$(database)/documents/users/$(request.auth.uid)).data.roles.owner == true
+          userDoc().roles.owner == true
         )
       );
     }
 
-    // ────────────── USERS (UNCHANGED LOGIC) ──────────────
-    match /users/{userId} {
-      // Anyone can read user profiles (adjust if you want privacy)
-      allow read: if true;
-
-      // A user can create their own profile
-      allow create: if isSignedIn() && request.auth.uid == userId;
-
-      // Allow users to update only their own lastSeenMessageBoardAt timestamp
-      allow update: if isSignedIn()
-        && request.auth.uid == userId
-        && request.resource.data.diff(resource.data).changedKeys().hasOnly(['lastSeenMessageBoardAt']);
-
-      // User can update/delete their own profile OR admin can manage anyone's profile
-      allow update, delete: if isSignedIn() && (
-        request.auth.uid == userId ||
-        isAdmin()
-      );
+    // Fields that decide what someone is allowed to do, or that record an
+    // administrator's decision. Only an admin may change these.
+    //
+    // Deliberately NOT included: residentType, residentTypeLabel,
+    // requiresResidentTypeConfirmation and userRole. Residents self-declare those
+    // from their dashboard, and the declaration is then confirmed by an admin via
+    // the residentTypeConfirmed* fields below. None of them grant access — owner
+    // access is decided by `roles.owner` or the `owner` custom claim.
+    function privilegedUserFields() {
+      return [
+        'isAdmin', 'roles', 'disabled', 'isFlagged',
+        'residentTypeConfirmedAt', 'residentTypeConfirmedBy'
+      ];
     }
 
-    // ────────────── BOOKINGS (UNCHANGED LOGIC) ──────────────
-    match /bookings/{bookingId} {
-      // Everyone can view bookings (so guests see schedule)
-      allow read: if true;
+    function changedKeys() {
+      return request.resource.data.diff(resource.data).affectedKeys();
+    }
 
-      // Logged-in user can create a booking only if `user` matches their email
-      // and the booking ID does not already exist
+    function touchesPrivilegedFields() {
+      return changedKeys().hasAny(privilegedUserFields());
+    }
+
+    // A user may keep their profile email in step with their verified sign-in
+    // address, but may not set it to somebody else's.
+    function emailChangeIsValid() {
+      return !changedKeys().hasAny(['email']) ||
+        request.resource.data.email == request.auth.token.email;
+    }
+
+    // ────────────── USERS ──────────────
+    // Contains full name, email address, flat number and resident type: the most
+    // sensitive collection on the site. Previously world-readable.
+    match /users/{userId} {
+      // A signed-in user may read their own profile. Admins may read any profile.
+      // Cross-resident profile lookups (username -> email at login, display names)
+      // are served by server routes using the Admin SDK instead, so no client
+      // needs to enumerate this collection.
+      allow get: if isSignedIn() && (request.auth.uid == userId || isAdmin());
+      allow list: if isAdmin();
+
+      // A user creates their own profile at registration. They may not arrive
+      // pre-loaded with privileges, and the email must match the verified token.
+      allow create: if isSignedIn()
+        && request.auth.uid == userId
+        && request.resource.data.get('isAdmin', false) == false
+        && !request.resource.data.keys().hasAny(['roles', 'disabled', 'isFlagged'])
+        && (
+          !('email' in request.resource.data) ||
+          request.resource.data.email == request.auth.token.email
+        );
+
+      // A user may edit their own profile but cannot escalate.
+      //
+      // The previous rules contained an `allow update ... if request.auth.uid ==
+      // userId` with no field restrictions, which meant any resident could set
+      // `isAdmin: true` on their own document and — because isAdmin() falls back
+      // to that flag — immediately gain full administrative access.
+      allow update: if isSignedIn() && (
+        (
+          request.auth.uid == userId &&
+          !touchesPrivilegedFields() &&
+          emailChangeIsValid()
+        ) ||
+        isAdmin()
+      );
+
+      // Account deletion: the account holder (right to erasure) or an admin.
+      allow delete: if isSignedIn() && (request.auth.uid == userId || isAdmin());
+    }
+
+    // Public username -> uid directory. Holds no personal data beyond a chosen
+    // username, and exists so login-by-username works without exposing /users.
+    // Written by server code only.
+    match /usernames/{username} {
+      allow read: if false;
+      allow write: if false;
+    }
+
+    // ────────────── BOOKINGS ──────────────
+    // Booking documents carry the booker's email address. The public schedule is
+    // served from /api/availability, which strips identities server-side, so the
+    // collection itself no longer needs to be world-readable.
+    match /bookings/{bookingId} {
+      allow get: if isSignedIn() && (
+        resource.data.user == request.auth.token.email || isAdmin()
+      );
+
+      // Every document a query returns is checked, so an unconstrained query
+      // (e.g. "all bookings on this date") fails for anyone but an admin. In
+      // practice clients must query `where('user', '==', <own email>)`.
+      allow list: if isSignedIn() && (
+        isAdmin() || resource.data.user == request.auth.token.email
+      );
+
       allow create: if isSignedIn()
         && request.resource.data.user == request.auth.token.email
+        && request.resource.data.keys().hasAll(['facility', 'date', 'time', 'user'])
+        && request.resource.data.facility is string
+        && request.resource.data.date is string
+        && request.resource.data.time is string
         && !exists(/databases/$(database)/documents/bookings/$(bookingId));
 
-      // A user can cancel their own booking, or an admin can cancel any booking
       allow delete: if isSignedIn() && (
-        resource.data.user == request.auth.token.email ||
-        isAdmin()
+        resource.data.user == request.auth.token.email || isAdmin()
       );
 
-      // No updates — must cancel + re-book
+      // No updates — cancel and re-book, so history stays honest.
       allow update: if false;
     }
 
-    // ────────────── MAINTENANCE WINDOWS (UNCHANGED LOGIC) ──────────────
+    // ────────────── MAINTENANCE WINDOWS ──────────────
+    // Facility closures. No personal data, and needed by the public schedule.
     match /maintenanceWindows/{docId} {
-      // Everyone can see maintenance
       allow read: if true;
-
-      // Only admins can create/update/delete
-      allow create, update, delete: if isSignedIn() && isAdmin();
+      allow create, update, delete: if isAdmin();
     }
 
-    // ────────────── MESSAGE BOARD POSTS (UNCHANGED LOGIC) ──────────────
+    // ────────────── MESSAGE BOARD ──────────────
+    // A residents' board. Posts carry author names, so reading requires a login;
+    // this also removes the board from search-engine and scraper reach.
     match /messageBoard/{postId} {
-      // Public board
-      allow read: if true;
+      allow read: if isSignedIn();
 
-      // Logged-in users can post
-      allow create: if isSignedIn();
+      allow create: if isSignedIn()
+        && request.resource.data.authorId == request.auth.uid
+        && request.resource.data.get('content', '') is string
+        && request.resource.data.get('content', '').size() <= 10000;
 
-      // Author or admin can edit/delete
       allow update, delete: if isSignedIn() && (
-        resource.data.authorId == request.auth.uid ||
-        isAdmin()
+        resource.data.authorId == request.auth.uid || isAdmin()
       );
+
+      match /reactions/{uid} {
+        allow read: if isSignedIn();
+        allow create, update, delete: if isSignedIn() && request.auth.uid == uid;
+      }
+
+      match /comments/{commentId} {
+        allow read: if isSignedIn();
+        allow create: if isSignedIn()
+          && request.resource.data.authorId == request.auth.uid;
+        allow update, delete: if isSignedIn() && (
+          resource.data.authorId == request.auth.uid || isAdmin()
+        );
+
+        match /replies/{replyId} {
+          allow read: if isSignedIn();
+          allow create: if isSignedIn()
+            && request.resource.data.authorId == request.auth.uid;
+          allow delete: if isSignedIn() && (
+            resource.data.authorId == request.auth.uid || isAdmin()
+          );
+          allow update: if false;
+        }
+      }
     }
 
-    // Reactions on posts
-    match /messageBoard/{postId}/reactions/{uid} {
-      allow read: if true; // counts & my reaction
-      // user can set/update/delete only their own reaction doc
-      allow create, update, delete: if isSignedIn() && request.auth.uid == uid;
-    }
-
-    // Replies under comments
-    match /messageBoard/{postId}/comments/{commentId}/replies/{replyId} {
-      allow read: if true;
-      allow create: if isSignedIn(); // (client should include authorId == uid in data)
-      allow delete: if isSignedIn() && (
-        resource.data.authorId == request.auth.uid ||
-        isAdmin()
-      );
-      allow update: if false;
-    }
-
-    // Reports (admin will review later)
+    // Moderation reports. Reporters must be identifiable to the admin reviewing
+    // them, but reports are never readable by other residents.
     match /reports/{reportId} {
-      allow create: if isSignedIn(); // any signed-in user can report
-      allow read, update, delete: if isSignedIn() && isAdmin();
-    }
-
-    // ────────────── MESSAGE BOARD COMMENTS (UNCHANGED LOGIC) ──────────────
-    match /messageBoard/{postId}/comments/{commentId} {
-      allow read: if true;
       allow create: if isSignedIn();
-      allow update, delete: if isSignedIn() && (
-        resource.data.authorId == request.auth.uid ||
-        isAdmin()
-      );
+      allow read, update, delete: if isAdmin();
     }
 
-    // ────────────── OWNERS-ONLY AREAS (NEW) ──────────────
+    // ────────────── OWNERS-ONLY AREAS ──────────────
 
-    // 1) Owners Discussions (threads + messages)
+    // 1) Owners discussions (threads + messages)
     match /owners_discussions/{threadId} {
-      // Only owners can read the list and thread docs
       allow read: if isOwner();
 
-      // Create a thread (owners only) with minimal shape validation
       allow create: if isOwner()
         && request.resource.data.keys().hasAll(['title', 'createdBy', 'createdAt'])
         && request.resource.data.title is string
+        && request.resource.data.title.size() <= 200
         && request.resource.data.createdBy == request.auth.uid;
 
-      // Update: creator or admin
       allow update: if isOwner()
         && (resource.data.createdBy == request.auth.uid || isAdmin());
 
-      // Delete: admins only
       allow delete: if isAdmin();
 
-      // Messages subcollection
       match /messages/{msgId} {
         allow read: if isOwner();
 
-        // Create: author must be caller; basic length guard
         allow create: if isOwner()
           && request.resource.data.keys().hasAll(['text', 'authorUid', 'createdAt'])
           && request.resource.data.authorUid == request.auth.uid
@@ -157,38 +244,37 @@ service cloud.firestore {
           && request.resource.data.text.size() > 0
           && request.resource.data.text.size() <= 5000;
 
-        // Update: only original author or admin; keep authorUid immutable
         allow update: if isOwner()
           && (resource.data.authorUid == request.auth.uid || isAdmin())
           && request.resource.data.authorUid == resource.data.authorUid;
 
-        // Delete: author or admin
         allow delete: if (isOwner() && resource.data.authorUid == request.auth.uid) || isAdmin();
       }
     }
 
-    // 2) Owners Votes (vote docs + ballots subcollection)
+    // 2) Owners votes (vote docs + ballots)
     match /owner_votes/{voteId} {
-      // Owners can see votes
       allow read: if isOwner();
 
-      // Create/update/delete a vote: admins only, with basic shape/status checks
-      allow create, update, delete: if isAdmin()
+      // Split from delete: `request.resource` does not exist on a delete, so the
+      // shape checks below would previously make deletion impossible.
+      allow create, update: if isAdmin()
         && request.resource.data.keys().hasAll(['question', 'options', 'status', 'createdAt'])
         && request.resource.data.status in ['open', 'closed'];
+      allow delete: if isAdmin();
 
-      // Ballots: each owner writes their own ballot doc (id == uid) while vote is open
       match /ballots/{ballotUid} {
-        allow read: if isOwner();
+        // A ballot is secret: only the owner who cast it, and admins running the
+        // count, may read it. Other owners see totals, not individual choices.
+        allow get: if isSignedIn() && (ballotUid == request.auth.uid || isAdmin());
+        allow list: if isAdmin();
 
-        // Create/Update own ballot only if the parent vote is open
         allow create, update: if isOwner()
           && ballotUid == request.auth.uid
           && get(/databases/$(database)/documents/owner_votes/$(voteId)).data.status == 'open'
           && request.resource.data.keys().hasOnly(['optionId', 'castAt'])
           && request.resource.data.optionId is string;
 
-        // Delete own ballot while open; admin can always delete
         allow delete: if (
             isOwner() &&
             ballotUid == request.auth.uid &&
@@ -197,50 +283,94 @@ service cloud.firestore {
       }
     }
 
-    // 3) Owners Meta (keep fully private; never read/write from client)
+    // 3) Owners meta — never touched from a client.
     match /owners_meta/{doc} {
       allow read, write: if false;
     }
 
-    // ────────────── PUBLIC VOTING (EVERYONE) ──────────────
+    // ────────────── COMMUNITY VOTING ──────────────
     match /voting_questions/{questionId} {
-      // Anyone can read questions/results
+      // Questions themselves contain no personal data and drive the public page.
       allow read: if true;
 
-      // Anyone can create; basic shape and status validation
-      allow create: if request.resource.data.keys().hasAll(['title', 'status', 'createdAt', 'options'])
+      // Previously any anonymous visitor on the internet could create a question.
+      // Now a login is required. This should be tightened further to isOwner()
+      // once every owner has the `roles.owner` flag set — see the audit report,
+      // finding S-11.
+      allow create: if isSignedIn()
+        && request.resource.data.keys().hasAll(['title', 'status', 'createdAt', 'options'])
         && request.resource.data.title is string
+        && request.resource.data.title.size() > 0
+        && request.resource.data.title.size() <= 300
         && request.resource.data.status in ['open', 'closed', 'scheduled']
         && request.resource.data.options is list
-        && (!('startsAt' in request.resource.data) || request.resource.data.startsAt is timestamp)
-        && (!('expiresAt' in request.resource.data) || request.resource.data.expiresAt is timestamp)
-        && (!('voteTotals' in request.resource.data) || request.resource.data.voteTotals is map);
+        && request.resource.data.options.size() <= 20;
 
-      // Admins can update/delete questions
       allow update, delete: if isAdmin();
     }
 
     match /voting_votes/{voteId} {
-      // Anyone can read votes to power public results (names are not surfaced in UI)
-      allow read: if true;
+      // A vote document records the voter's name and flat alongside their choice.
+      // Reading is limited to signed-in residents so ballots are not harvestable
+      // by anonymous visitors or search engines. Individual voters remain
+      // identifiable to signed-in residents, which is a known limitation of the
+      // current tally-on-the-client design — see docs/gdpr-audit-2026.md.
+      allow read: if isSignedIn();
 
-      // Only authenticated users can cast a vote, and it must be tied to their UID
       allow create: if isSignedIn()
         && request.resource.data.keys().hasOnly(['questionId', 'optionId', 'userName', 'userNameLower', 'voterName', 'flat', 'userId', 'createdAt'])
         && request.resource.data.keys().hasAll(['questionId', 'optionId', 'userName', 'flat', 'userId', 'createdAt'])
         && request.resource.data.questionId is string
         && request.resource.data.optionId is string
         && request.resource.data.userName is string
+        && request.resource.data.userName.size() <= 120
         && (!('userNameLower' in request.resource.data) || request.resource.data.userNameLower is string)
         && (!('voterName' in request.resource.data) || request.resource.data.voterName is string)
         && request.resource.data.flat is string
         && request.resource.data.flat.size() > 0
+        && request.resource.data.flat.size() <= 20
         && request.resource.data.userId is string
         && request.resource.data.userId == request.auth.uid
         && request.resource.data.createdAt is timestamp;
 
-      // Only admins can edit/remove votes
       allow update, delete: if isAdmin();
+    }
+
+    // ────────────── ADMIN / AUDIT COLLECTIONS ──────────────
+    // Activity logs record which admin did what to whom. Admin-only, and
+    // append-only so an audit trail cannot be quietly rewritten.
+    match /activityLogs/{logId} {
+      allow read: if isAdmin();
+      allow create: if isAdmin();
+      allow update, delete: if false;
+    }
+
+    // Resident feedback. Readable by admins; a resident may submit but not read
+    // other people's submissions.
+    match /feedback/{feedbackId} {
+      allow read: if isAdmin();
+      allow create: if isSignedIn()
+        && request.resource.data.get('message', '') is string
+        && request.resource.data.get('message', '').size() <= 5000;
+      allow update, delete: if isAdmin();
+    }
+
+    // Written and read exclusively by server routes via the Admin SDK. Contains
+    // the rendered body and recipient counts of committee mailings.
+    match /committeeSentEmails/{docId} {
+      allow read, write: if false;
+    }
+
+    // Rate-limit counters, written by server code only.
+    match /rateLimits/{docId} {
+      allow read, write: if false;
+    }
+
+    // ────────────── DEFAULT DENY ──────────────
+    // Any collection not named above is inaccessible from a client. New features
+    // must add an explicit rule, which is the safe direction to fail in.
+    match /{document=**} {
+      allow read, write: if false;
     }
   }
 }

--- a/next.config.ts
+++ b/next.config.ts
@@ -1,8 +1,114 @@
 import type { NextConfig } from "next";
 import withPWA from "next-pwa";
 
+/**
+ * Content Security Policy.
+ *
+ * Shipped in **Report-Only** mode deliberately. The policy below is believed to
+ * cover everything the site legitimately loads, but a CSP that is even slightly
+ * wrong silently breaks pages, and this one cannot be verified against every
+ * route from here. Watch the browser console (or wire up `report-uri`) for a
+ * week, then promote the header to `Content-Security-Policy` by flipping
+ * CSP_ENFORCED below. See finding S-13 in docs/gdpr-audit-2026.md.
+ *
+ * `'unsafe-inline'` on script-src is required by Next.js's inline hydration
+ * bootstrap; removing it needs the nonce-based approach documented in the audit.
+ */
+const CSP_ENFORCED = false;
+
+const contentSecurityPolicy = [
+  "default-src 'self'",
+  // 'wasm-unsafe-eval' is needed by the PlayCanvas pool model viewer.
+  "script-src 'self' 'unsafe-inline' 'wasm-unsafe-eval'",
+  // Tailwind and Framer Motion both set element styles at runtime.
+  "style-src 'self' 'unsafe-inline'",
+  "img-src 'self' data: blob: https:",
+  "font-src 'self' data:",
+  "media-src 'self' blob:",
+  // Firebase Auth, Firestore (including its streaming transport) and Storage.
+  [
+    "connect-src 'self'",
+    "https://*.googleapis.com",
+    "https://*.firebaseio.com",
+    "wss://*.firebaseio.com",
+    "https://*.cloudfunctions.net",
+    "https://firebaseinstallations.googleapis.com",
+  ].join(" "),
+  // Vimeo player, Google Maps embeds and Microsoft Forms are embedded in places.
+  "frame-src 'self' https://player.vimeo.com https://www.google.com https://forms.office.com",
+  "worker-src 'self' blob:",
+  "manifest-src 'self'",
+  "base-uri 'self'",
+  "form-action 'self'",
+  // Stops any other site from framing James Square (clickjacking).
+  "frame-ancestors 'self'",
+  "object-src 'none'",
+  "upgrade-insecure-requests",
+].join("; ");
+
+/** Applied to every response. */
+const securityHeaders = [
+  // Stop MIME sniffing turning an upload into an executable script.
+  { key: "X-Content-Type-Options", value: "nosniff" },
+  // Legacy equivalent of frame-ancestors, for older browsers.
+  { key: "X-Frame-Options", value: "SAMEORIGIN" },
+  // Send the origin, never the full path, to third parties.
+  { key: "Referrer-Policy", value: "strict-origin-when-cross-origin" },
+  // Deny device APIs the site has no use for.
+  {
+    key: "Permissions-Policy",
+    value: [
+      "camera=()",
+      "microphone=()",
+      "geolocation=()",
+      "payment=()",
+      "usb=()",
+      "interest-cohort=()",
+    ].join(", "),
+  },
+  // Two years, subdomains included: james-square.com should never be reachable
+  // over plain HTTP.
+  {
+    key: "Strict-Transport-Security",
+    value: "max-age=63072000; includeSubDomains; preload",
+  },
+  // Isolate the browsing context so cross-origin pages cannot poke at ours.
+  { key: "Cross-Origin-Opener-Policy", value: "same-origin" },
+  { key: "X-DNS-Prefetch-Control", value: "off" },
+  {
+    key: CSP_ENFORCED ? "Content-Security-Policy" : "Content-Security-Policy-Report-Only",
+    value: contentSecurityPolicy,
+  },
+];
+
 const nextConfig: NextConfig = {
   reactStrictMode: true,
+  // Do not advertise the framework version to scanners.
+  poweredByHeader: false,
+  async headers() {
+    return [
+      {
+        source: "/:path*",
+        headers: securityHeaders,
+      },
+      {
+        // Building surveys, AGM minutes and factor reports. These are owner
+        // material rather than public documents, so at minimum keep them out of
+        // search indexes. Note this is discouragement, not access control — the
+        // files are still directly fetchable by URL. See finding P-02.
+        source: "/docs/:path*",
+        headers: [{ key: "X-Robots-Tag", value: "noindex, nofollow, noarchive" }],
+      },
+      {
+        // Never let a proxy or CDN cache an authenticated API response.
+        source: "/api/:path*",
+        headers: [
+          { key: "Cache-Control", value: "no-store, max-age=0" },
+          { key: "X-Robots-Tag", value: "noindex, nofollow" },
+        ],
+      },
+    ];
+  },
   async redirects() {
     return [
       {

--- a/package.json
+++ b/package.json
@@ -7,7 +7,8 @@
     "build": "next build",
     "start": "next start",
     "lint": "next lint",
-    "reset:voting": "node scripts/resetVoting.js"
+    "reset:voting": "node scripts/resetVoting.js",
+    "test:rules": "firebase emulators:exec --only firestore \"node scripts/testFirestoreRules.mjs\""
   },
   "dependencies": {
     "@google/genai": "^1.34.0",
@@ -31,6 +32,8 @@
   },
   "devDependencies": {
     "@eslint/eslintrc": "^3",
+    "@firebase/rules-unit-testing": "^4.0.1",
+    "firebase-tools": "^13.35.1",
     "@tailwindcss/node": "^4.1.13",
     "@tailwindcss/postcss": "^4.1.13",
     "@types/luxon": "^3.6.2",

--- a/scripts/testFirestoreRules.mjs
+++ b/scripts/testFirestoreRules.mjs
@@ -1,0 +1,275 @@
+/**
+ * Security-rules tests for the James Square Firestore rules.
+ *
+ * Run against the emulator:
+ *
+ *   npx firebase emulators:exec --only firestore \
+ *     --project jamessquarebookings "node scripts/testFirestoreRules.mjs"
+ *
+ * Each case below corresponds to a finding in docs/gdpr-audit-2026.md, so a
+ * regression in the rules shows up as a named failure rather than as a quiet
+ * loosening of access.
+ */
+
+import assert from 'node:assert/strict';
+
+import {
+  initializeTestEnvironment,
+  assertFails,
+  assertSucceeds,
+} from '@firebase/rules-unit-testing';
+import { doc, getDoc, setDoc, updateDoc, collection, getDocs, query, where } from 'firebase/firestore';
+
+const PROJECT_ID = process.env.GCLOUD_PROJECT ?? 'jamessquarebookings';
+
+const results = [];
+
+async function check(name, fn) {
+  try {
+    await fn();
+    results.push({ name, ok: true });
+  } catch (error) {
+    results.push({ name, ok: false, error: error?.message ?? String(error) });
+  }
+}
+
+const testEnv = await initializeTestEnvironment({
+  projectId: PROJECT_ID,
+  firestore: { host: '127.0.0.1', port: 8080 },
+});
+
+// Seed data with rules disabled, so the fixtures themselves are not a test.
+await testEnv.withSecurityRulesDisabled(async (context) => {
+  const db = context.firestore();
+  await setDoc(doc(db, 'users/resident-a'), {
+    email: 'a@example.com',
+    fullName: 'Resident A',
+    username: 'residenta',
+    property: '39/1',
+    residentType: 'renter',
+    isAdmin: false,
+  });
+  await setDoc(doc(db, 'users/resident-b'), {
+    email: 'b@example.com',
+    fullName: 'Resident B',
+    username: 'residentb',
+    property: '45/2',
+    isAdmin: false,
+  });
+  // Separate subject for the "admin can grant admin" case, so promoting it does
+  // not turn another test's actor into an administrator part-way through the run.
+  await setDoc(doc(db, 'users/resident-c'), {
+    email: 'c@example.com',
+    fullName: 'Resident C',
+    isAdmin: false,
+  });
+  await setDoc(doc(db, 'users/admin-1'), {
+    email: 'admin@example.com',
+    fullName: 'Admin',
+    isAdmin: true,
+  });
+  await setDoc(doc(db, 'bookings/b1'), {
+    facility: 'pool',
+    date: '2026-08-01',
+    time: '10:00',
+    user: 'a@example.com',
+  });
+  await setDoc(doc(db, 'messageBoard/p1'), {
+    title: 'Hello',
+    body: 'Post body',
+    authorId: 'resident-a',
+  });
+  await setDoc(doc(db, 'voting_votes/v1'), {
+    questionId: 'q1',
+    optionId: 'o1',
+    userName: 'Resident A',
+    flat: '39/1',
+    userId: 'resident-a',
+    createdAt: new Date(),
+  });
+  await setDoc(doc(db, 'activityLogs/l1'), { action: 'test', admin: 'admin@example.com' });
+  await setDoc(doc(db, 'committeeSentEmails/e1'), { subject: 'Test', renderedHtml: '<p>x</p>' });
+});
+
+const anon = testEnv.unauthenticatedContext().firestore();
+const residentA = testEnv
+  .authenticatedContext('resident-a', { email: 'a@example.com' })
+  .firestore();
+const residentB = testEnv
+  .authenticatedContext('resident-b', { email: 'b@example.com' })
+  .firestore();
+const admin = testEnv
+  .authenticatedContext('admin-1', { email: 'admin@example.com', admin: true })
+  .firestore();
+
+// ── P-01: resident profiles were world-readable ──────────────────────────────
+await check('anonymous cannot read a resident profile', () =>
+  assertFails(getDoc(doc(anon, 'users/resident-a'))),
+);
+
+await check('anonymous cannot list the users collection', () =>
+  assertFails(getDocs(collection(anon, 'users'))),
+);
+
+await check('a resident cannot read another resident profile', () =>
+  assertFails(getDoc(doc(residentB, 'users/resident-a'))),
+);
+
+await check('a resident can read their own profile', () =>
+  assertSucceeds(getDoc(doc(residentA, 'users/resident-a'))),
+);
+
+await check('an admin can list resident profiles', () =>
+  assertSucceeds(getDocs(collection(admin, 'users'))),
+);
+
+await check('a resident cannot query users by email', () =>
+  assertFails(
+    getDocs(query(collection(residentB, 'users'), where('email', '==', 'a@example.com'))),
+  ),
+);
+
+// ── S-01: privilege escalation via self-update ───────────────────────────────
+await check('a resident cannot make themselves an admin', () =>
+  assertFails(updateDoc(doc(residentA, 'users/resident-a'), { isAdmin: true })),
+);
+
+await check('a resident cannot grant themselves the owner role', () =>
+  assertFails(updateDoc(doc(residentA, 'users/resident-a'), { roles: { owner: true } })),
+);
+
+await check('a resident cannot clear their own disabled flag', () =>
+  assertFails(updateDoc(doc(residentA, 'users/resident-a'), { disabled: false })),
+);
+
+await check('a resident cannot forge an admin resident-type confirmation', () =>
+  assertFails(
+    updateDoc(doc(residentA, 'users/resident-a'), { residentTypeConfirmedBy: 'admin@example.com' }),
+  ),
+);
+
+await check('a resident can still edit their own username and property', () =>
+  assertSucceeds(
+    updateDoc(doc(residentA, 'users/resident-a'), { username: 'newname', property: '39/2' }),
+  ),
+);
+
+await check('a resident can still self-declare their resident type', () =>
+  assertSucceeds(
+    updateDoc(doc(residentA, 'users/resident-a'), {
+      residentType: 'owner',
+      residentTypeLabel: 'Owner',
+      requiresResidentTypeConfirmation: true,
+    }),
+  ),
+);
+
+await check('a resident cannot edit another resident profile', () =>
+  assertFails(updateDoc(doc(residentB, 'users/resident-a'), { fullName: 'Hacked' })),
+);
+
+await check('an admin can set the admin flag', () =>
+  assertSucceeds(updateDoc(doc(admin, 'users/resident-c'), { isAdmin: true })),
+);
+
+// ── P-03: bookings exposed resident email addresses ──────────────────────────
+await check('anonymous cannot read bookings', () =>
+  assertFails(getDoc(doc(anon, 'bookings/b1'))),
+);
+
+await check('a resident cannot read another resident booking', () =>
+  assertFails(getDoc(doc(residentB, 'bookings/b1'))),
+);
+
+await check('a resident can read their own booking', () =>
+  assertSucceeds(getDoc(doc(residentA, 'bookings/b1'))),
+);
+
+await check('a resident can query their own bookings', () =>
+  assertSucceeds(
+    getDocs(query(collection(residentA, 'bookings'), where('user', '==', 'a@example.com'))),
+  ),
+);
+
+await check('a resident cannot query all bookings for a date', () =>
+  assertFails(
+    getDocs(query(collection(residentA, 'bookings'), where('date', '==', '2026-08-01'))),
+  ),
+);
+
+await check('a resident cannot create a booking in someone else name', () =>
+  assertFails(
+    setDoc(doc(residentB, 'bookings/b2'), {
+      facility: 'pool',
+      date: '2026-08-02',
+      time: '11:00',
+      user: 'a@example.com',
+    }),
+  ),
+);
+
+// ── P-04: message board was world-readable ───────────────────────────────────
+await check('anonymous cannot read the message board', () =>
+  assertFails(getDoc(doc(anon, 'messageBoard/p1'))),
+);
+
+await check('a signed-in resident can read the message board', () =>
+  assertSucceeds(getDoc(doc(residentA, 'messageBoard/p1'))),
+);
+
+await check('a resident cannot post as another author', () =>
+  assertFails(
+    setDoc(doc(residentB, 'messageBoard/p2'), {
+      title: 'Spoof',
+      body: 'x',
+      authorId: 'resident-a',
+    }),
+  ),
+);
+
+// ── P-05: ballots were world-readable ────────────────────────────────────────
+await check('anonymous cannot read individual votes', () =>
+  assertFails(getDoc(doc(anon, 'voting_votes/v1'))),
+);
+
+// ── S-11: anonymous question creation ────────────────────────────────────────
+await check('anonymous cannot create a voting question', () =>
+  assertFails(
+    setDoc(doc(anon, 'voting_questions/q2'), {
+      title: 'Spam',
+      status: 'open',
+      createdAt: new Date(),
+      options: [],
+    }),
+  ),
+);
+
+// ── Admin-only and server-only collections ───────────────────────────────────
+await check('a resident cannot read the admin activity log', () =>
+  assertFails(getDoc(doc(residentA, 'activityLogs/l1'))),
+);
+
+await check('an admin cannot rewrite the activity log', () =>
+  assertFails(updateDoc(doc(admin, 'activityLogs/l1'), { action: 'tampered' })),
+);
+
+await check('nobody can read the committee email archive from a client', () =>
+  assertFails(getDoc(doc(admin, 'committeeSentEmails/e1'))),
+);
+
+await check('an undeclared collection is denied by default', () =>
+  assertFails(getDoc(doc(residentA, 'someFutureCollection/x'))),
+);
+
+await testEnv.cleanup();
+
+const failures = results.filter((result) => !result.ok);
+
+for (const result of results) {
+  console.log(`${result.ok ? 'PASS' : 'FAIL'}  ${result.name}`);
+  if (!result.ok) console.log(`      ${result.error}`);
+}
+
+console.log(`\n${results.length - failures.length}/${results.length} passed`);
+
+assert.equal(failures.length, 0, `${failures.length} rule test(s) failed`);

--- a/src/app/acceptable-use/page.tsx
+++ b/src/app/acceptable-use/page.tsx
@@ -1,0 +1,159 @@
+import type { Metadata } from 'next';
+import Link from 'next/link';
+
+import {
+  LEGAL_CONTACT_EMAIL,
+  LegalList,
+  LegalPage,
+  LegalSection,
+} from '@/components/legal/LegalPage';
+
+export const metadata: Metadata = {
+  title: 'Acceptable Use Policy | James Square',
+  description:
+    'What is and is not acceptable on the James Square community website, and how moderation decisions are made.',
+};
+
+const lastUpdated = '26 July 2026';
+
+export default function AcceptableUsePage() {
+  return (
+    <LegalPage
+      currentPath="/acceptable-use"
+      lastUpdated={lastUpdated}
+      summary="Be civil, keep other residents' personal details private, book facilities fairly, and do not attempt to break or probe the site. Disagreement is fine — it is a shared building and people will not always agree. Personal attacks, harassment and publishing other people's information are not."
+      title="Acceptable Use Policy"
+    >
+      <LegalSection title="Why this exists">
+        <p>
+          James Square is a small community, and this website is one of the few places where all of
+          it meets. This policy sets out plainly what is expected, so that moderation decisions are
+          predictable rather than arbitrary. It applies to the message board, votes, feedback,
+          bookings and any email sent through the site.
+        </p>
+      </LegalSection>
+
+      <LegalSection title="What we expect">
+        <LegalList
+          items={[
+            'Treat other residents with courtesy, including when you disagree strongly with them.',
+            'Criticise decisions, proposals and work — not people’s character.',
+            'Post accurately. If you are passing on something you heard, say so.',
+            'Keep discussion relevant to the building and the community.',
+            'Respect the privacy of your neighbours, including their flat numbers, contact details and personal circumstances.',
+          ]}
+        />
+      </LegalSection>
+
+      <LegalSection title="What is not allowed">
+        <p>Do not use the site to:</p>
+        <LegalList
+          items={[
+            'Harass, bully, threaten or intimidate anyone, or encourage others to do so.',
+            'Post content that is abusive, discriminatory, defamatory, obscene or unlawful.',
+            'Publish another person’s personal information — their contact details, flat number, tenancy or ownership status, financial position, health or family circumstances — without their agreement.',
+            'Post photographs or recordings of identifiable people, or of the inside of anyone’s home, without their agreement.',
+            'Impersonate another resident, the committee, the factor or any official body.',
+            'Advertise, sell or promote a business, or send unsolicited marketing to residents.',
+            'Make repeated or vexatious complaints about the same matter after it has been answered.',
+            'Discuss ongoing legal proceedings or insurance claims in a way that could prejudice them.',
+          ]}
+        />
+      </LegalSection>
+
+      <LegalSection title="Bookings">
+        <LegalList
+          items={[
+            'Book only slots you intend to use, and cancel promptly if your plans change.',
+            'Do not book on someone else’s behalf using your account in order to get around fair-use limits.',
+            'Do not make repeated bookings across accounts, or hold the same peak slot every day, to the exclusion of others.',
+            'Follow the pool, gym and sauna safety rules, including supervision requirements for children.',
+          ]}
+        />
+      </LegalSection>
+
+      <LegalSection title="Voting">
+        <LegalList
+          items={[
+            'One vote per household, cast by an eligible owner.',
+            'Do not attempt to vote more than once, or to vote on behalf of another owner without authority.',
+            'Do not pressure or mislead other owners about how to vote.',
+          ]}
+        />
+      </LegalSection>
+
+      <LegalSection title="Security and technical use">
+        <p>Do not:</p>
+        <LegalList
+          items={[
+            'Attempt to access another resident’s account, or any area you have not been given access to.',
+            'Share the Owners or Committee access codes outside those groups.',
+            'Probe, scan or test the site’s security without written permission, or attempt to bypass its controls.',
+            'Extract data from the site in bulk, whether by automated scraping or by hand.',
+            'Upload or link to malicious files, or attempt to interfere with the site’s availability.',
+          ]}
+        />
+        <p>
+          Genuine security research is welcome if you tell us first. Report anything you find to{' '}
+          <a className="underline underline-offset-2" href={`mailto:${LEGAL_CONTACT_EMAIL}`}>
+            {LEGAL_CONTACT_EMAIL}
+          </a>{' '}
+          and give us a fair chance to fix it. We will not pursue anyone who reports a real problem
+          in good faith and does not exploit it.
+        </p>
+      </LegalSection>
+
+      <LegalSection title="Reporting something">
+        <p>
+          Every post, comment and reply has a &ldquo;Report&rdquo; option. Use it if you see
+          something that breaches this policy. Reports go only to site administrators, and the person
+          you report is not told who reported them.
+        </p>
+        <p>
+          If a matter is urgent or concerns your safety, contact the emergency services first, then
+          let the committee know.
+        </p>
+      </LegalSection>
+
+      <LegalSection title="How we respond">
+        <p>Depending on what has happened, we may:</p>
+        <LegalList
+          items={[
+            'Leave the content up and take no action, if it does not actually breach this policy.',
+            'Ask the author to edit or remove it themselves.',
+            'Remove or hide the content, and tell the author why.',
+            'Temporarily restrict an account’s ability to post or book.',
+            'Suspend or close an account, in serious or repeated cases.',
+            'Report the matter to the factor, the police or another authority where there is a risk to safety or a possible crime.',
+          ]}
+        />
+        <p>
+          Moderation actions are recorded in an internal audit log. If you think a decision about
+          your content or account was wrong, email{' '}
+          <a className="underline underline-offset-2" href={`mailto:${LEGAL_CONTACT_EMAIL}`}>
+            {LEGAL_CONTACT_EMAIL}
+          </a>{' '}
+          and ask for it to be reviewed by the committee.
+        </p>
+      </LegalSection>
+
+      <LegalSection title="Related documents">
+        <p>
+          This policy sits alongside the{' '}
+          <Link className="underline underline-offset-2" href="/terms">
+            Terms of Use
+          </Link>
+          ,{' '}
+          <Link className="underline underline-offset-2" href="/privacy">
+            Privacy Policy
+          </Link>{' '}
+          and{' '}
+          <Link className="underline underline-offset-2" href="/data-retention">
+            Data Retention Policy
+          </Link>
+          .
+        </p>
+      </LegalSection>
+    </LegalPage>
+  );
+}

--- a/src/app/actions/accessCodes.ts
+++ b/src/app/actions/accessCodes.ts
@@ -1,0 +1,115 @@
+'use server';
+
+import { timingSafeEqual } from 'node:crypto';
+import { headers } from 'next/headers';
+
+import bcrypt from 'bcryptjs';
+
+import { rateLimit } from '@/lib/security/rateLimit';
+
+/**
+ * Verification of the shared access codes for the Owners and Committee areas.
+ *
+ * These codes used to be plain string constants inside client components
+ * (`const OWNERS_ACCESS_CODE = '3579'`), which meant they were compiled into the
+ * JavaScript served to every anonymous visitor — anyone who opened the browser
+ * console could read them. Comparison now happens on the server only.
+ *
+ * Preferred configuration is a bcrypt hash in the environment:
+ *
+ *   OWNERS_ACCESS_CODE_HASH=$2a$...
+ *   COMMITTEE_ACCESS_CODE_HASH=$2a$...
+ *
+ * (generate with: node -e "console.log(require('bcryptjs').hashSync('CODE', 12))")
+ *
+ * If no hash is configured we fall back to the existing codes, held as
+ * server-side constants so the site keeps working after deploy. The fallback
+ * still removes the codes from the browser bundle, but the codes themselves
+ * should be rotated and moved into environment variables — see finding S-04 in
+ * docs/gdpr-audit-2026.md.
+ */
+
+const LEGACY_CODES = {
+  owners: '3579',
+  committee: '9753',
+} as const;
+
+const HASH_ENV_VARS = {
+  owners: 'OWNERS_ACCESS_CODE_HASH',
+  committee: 'COMMITTEE_ACCESS_CODE_HASH',
+} as const;
+
+export type AccessArea = keyof typeof LEGACY_CODES;
+
+export type VerifyAccessCodeResult = {
+  ok: boolean;
+  error?: string;
+};
+
+const constantTimeEquals = (a: string, b: string) => {
+  const aBuffer = Buffer.from(a);
+  const bBuffer = Buffer.from(b);
+  if (aBuffer.length !== bBuffer.length) return false;
+  try {
+    return timingSafeEqual(aBuffer, bBuffer);
+  } catch {
+    return false;
+  }
+};
+
+/** Rate-limit key from the request IP, so a shared code cannot be brute-forced. */
+async function throttleKey(area: AccessArea): Promise<string> {
+  const headerList = await headers();
+  const forwarded = headerList.get('x-forwarded-for') ?? '';
+  const ip = forwarded.split(',')[0]?.trim() || headerList.get('x-real-ip') || 'unknown';
+  return `access-code:${area}:${ip}`;
+}
+
+export async function verifyAccessCode(
+  area: AccessArea,
+  code: string,
+): Promise<VerifyAccessCodeResult> {
+  if (area !== 'owners' && area !== 'committee') {
+    return { ok: false, error: 'Unknown area.' };
+  }
+
+  // A four-digit code has only 10,000 possibilities, so throttling is the main
+  // thing standing between it and an exhaustive search.
+  const limit = rateLimit(await throttleKey(area), { limit: 8, windowMs: 10 * 60_000 });
+  if (!limit.allowed) {
+    return {
+      ok: false,
+      error: 'Too many attempts. Please wait a few minutes and try again.',
+    };
+  }
+
+  const input = String(code ?? '').trim();
+  if (!input) {
+    return { ok: false, error: 'Please enter the access code.' };
+  }
+
+  if (input.length > 128) {
+    return { ok: false, error: 'Incorrect access code.' };
+  }
+
+  const hash = process.env[HASH_ENV_VARS[area]];
+
+  if (hash) {
+    const isValid = await bcrypt.compare(input, hash);
+    return isValid ? { ok: true } : { ok: false, error: 'Incorrect access code.' };
+  }
+
+  const isValid = constantTimeEquals(input, LEGACY_CODES[area]);
+  if (!isValid) {
+    return { ok: false, error: 'Incorrect access code.' };
+  }
+
+  if (process.env.NODE_ENV === 'production') {
+    console.warn(
+      `[access-code] ${HASH_ENV_VARS[area]} is not set; using the built-in fallback code. ` +
+        'Set a bcrypt hash and rotate the code.',
+    );
+  }
+
+  return { ok: true };
+}

--- a/src/app/admin/AdminEmailPanel.tsx
+++ b/src/app/admin/AdminEmailPanel.tsx
@@ -5,7 +5,17 @@ import { collection, getDocs, orderBy, query } from 'firebase/firestore';
 
 import { auth, db } from '@/lib/firebase';
 import { sendAdminEmailRequest } from '@/lib/client/sendAdminEmailRequest';
-import { EMAIL_GROUPS, type EmailGroupKey } from '@/lib/emailGroups';
+
+/**
+ * Group keys are safe to name in the browser; the addresses behind them are not,
+ * and are fetched from /api/admin/email-groups once an admin is signed in.
+ */
+type EmailGroupKey = 'committee' | 'myreside';
+
+type EmailGroupData = {
+  groups: Record<string, string[]>;
+  counts: Record<string, number>;
+};
 
 const baseCardClasses =
   'rounded-2xl border border-white/20 bg-white/10 dark:border-white/10 dark:bg-white/5 backdrop-blur px-6 py-6 shadow-md space-y-5';
@@ -69,6 +79,38 @@ const AdminEmailPanel = () => {
   const [confirmOpen, setConfirmOpen] = useState(false);
   const [confirmText, setConfirmText] = useState('');
   const [confirmAcknowledged, setConfirmAcknowledged] = useState(false);
+  const [emailGroups, setEmailGroups] = useState<EmailGroupData>({ groups: {}, counts: {} });
+
+  // Group addresses are fetched with the admin's ID token rather than compiled
+  // into the bundle, so they are only ever visible to a verified administrator.
+  useEffect(() => {
+    let cancelled = false;
+
+    const loadGroups = async () => {
+      const currentUser = auth.currentUser;
+      if (!currentUser) return;
+
+      try {
+        const token = await currentUser.getIdToken();
+        const res = await fetch('/api/admin/email-groups', {
+          headers: { Authorization: `Bearer ${token}` },
+        });
+        if (!res.ok) return;
+        const data = (await res.json()) as EmailGroupData;
+        if (!cancelled) setEmailGroups(data);
+      } catch {
+        // Non-fatal: the composer still works, group counts simply read as zero.
+      }
+    };
+
+    const unsubscribe = auth.onAuthStateChanged(() => void loadGroups());
+    void loadGroups();
+
+    return () => {
+      cancelled = true;
+      unsubscribe();
+    };
+  }, []);
 
   useEffect(() => {
     const loadUsers = async () => {
@@ -161,8 +203,8 @@ const AdminEmailPanel = () => {
   }, [recipientMode, users, ownerUsers, normalizedCustomEmail, selectedIds]);
 
   const groupBccRecipients = useMemo(
-    () => Array.from(new Set(selectedGroups.flatMap((group) => EMAIL_GROUPS[group]))),
-    [selectedGroups],
+    () => Array.from(new Set(selectedGroups.flatMap((group) => emailGroups.groups[group] ?? []))),
+    [selectedGroups, emailGroups],
   );
 
   const combinedBccRecipients = useMemo(
@@ -583,13 +625,13 @@ const AdminEmailPanel = () => {
               </p>
               {selectedGroups.includes('committee') && (
                 <p className="text-sm text-slate-700 dark:text-slate-300">
-                  This email will be sent to <strong>{EMAIL_GROUPS.committee.length}</strong>{' '}
+                  This email will be sent to <strong>{emailGroups.counts.committee ?? 0}</strong>{' '}
                   committee members via BCC.
                 </p>
               )}
               {selectedGroups.includes('myreside') && (
                 <p className="text-sm text-slate-700 dark:text-slate-300">
-                  This email will be copied to Myreside via BCC ({EMAIL_GROUPS.myreside.length}{' '}
+                  This email will be copied to Myreside via BCC ({emailGroups.counts.myreside ?? 0}{' '}
                   recipients).
                 </p>
               )}

--- a/src/app/api/admin/email-groups/route.ts
+++ b/src/app/api/admin/email-groups/route.ts
@@ -1,0 +1,33 @@
+import { NextResponse, type NextRequest } from 'next/server';
+
+import { EMAIL_GROUPS, emailGroupCounts, EMAIL_GROUP_KEYS } from '@/lib/emailGroups';
+import { clientKey, rateLimit, tooManyRequests } from '@/lib/security/rateLimit';
+import { requireAdmin } from '@/lib/security/requireAuth';
+
+export const runtime = 'nodejs';
+export const dynamic = 'force-dynamic';
+
+/**
+ * Returns the addresses behind each named mailing group, for the admin email
+ * composer. Administrators only — this is the one path by which committee
+ * members' personal addresses reach a browser.
+ */
+export async function GET(req: NextRequest) {
+  const limit = rateLimit(clientKey(req, 'email-groups'), { limit: 30, windowMs: 60_000 });
+  if (!limit.allowed) return tooManyRequests(limit);
+
+  const auth = await requireAdmin(req);
+  if (!auth.ok) return auth.response;
+
+  return NextResponse.json(
+    {
+      groups: EMAIL_GROUP_KEYS.reduce<Record<string, string[]>>((acc, key) => {
+        acc[key] = [...EMAIL_GROUPS[key]];
+        return acc;
+      }, {}),
+      counts: emailGroupCounts(),
+    },
+    // Recipient lists must never be cached by a CDN or shared proxy.
+    { headers: { 'Cache-Control': 'no-store, private' } },
+  );
+}

--- a/src/app/api/admin/send-email/route.ts
+++ b/src/app/api/admin/send-email/route.ts
@@ -2,9 +2,12 @@ import { NextRequest, NextResponse } from "next/server";
 import { Resend } from "resend";
 
 import { renderAdminEmail } from "@/lib/email/renderAdminEmail";
-import { adminAuth } from "@/lib/firebaseAdmin";
+import { EMAIL_GROUPS, type EmailGroupKey, isEmailGroupKey } from "@/lib/emailGroups";
+import { clientKey, rateLimit, tooManyRequests } from "@/lib/security/rateLimit";
+import { requireAdmin } from "@/lib/security/requireAuth";
 
 export const runtime = "nodejs";
+export const dynamic = "force-dynamic";
 
 type RecipientMode = "all" | "owners" | "selected" | "custom";
 
@@ -20,9 +23,14 @@ type AdminEmailRequest = {
   recipients: RecipientSelection;
   cc?: string[];
   bcc?: string[];
+  /** Named groups (e.g. "committee") resolved to addresses server-side. */
+  groups?: string[];
 };
 
 const MAX_RECIPIENTS_PER_BATCH = 50;
+const MAX_TOTAL_RECIPIENTS = 500;
+const MAX_SUBJECT_LENGTH = 200;
+const MAX_MESSAGE_LENGTH = 50_000;
 const DEFAULT_SENDER = "no-reply@james-square.com";
 const ALLOWED_SENDERS = new Set([
   "no-reply@james-square.com",
@@ -51,13 +59,8 @@ const getResendClient = () => {
   return new Resend(apiKey);
 };
 
-const isValidEmail = (email: string) => /^[^\s@]+@[^\s@]+\.[^\s@]+$/.test(email);
-
-const parseBearerToken = (request: NextRequest) => {
-  const header = request.headers.get("authorization") ?? "";
-  const match = header.match(/^Bearer\s+(.+)$/i);
-  return match?.[1];
-};
+const isValidEmail = (email: string) =>
+  email.length <= 254 && /^[^\s@]+@[^\s@]+\.[^\s@]+$/.test(email);
 
 const resolveSender = (sender?: unknown) => {
   if (sender === undefined || sender === null) {
@@ -78,18 +81,21 @@ const resolveSender = (sender?: unknown) => {
 
 export async function POST(req: NextRequest) {
   try {
-    const token = parseBearerToken(req);
-    if (!token) {
-      return NextResponse.json({ error: "Not authenticated." }, { status: 401 });
+    // Throttle before doing any work, so an unauthenticated flood is cheap to shed.
+    const limit = rateLimit(clientKey(req, "admin-email"), {
+      limit: 10,
+      windowMs: 10 * 60_000,
+    });
+    if (!limit.allowed) {
+      return tooManyRequests(limit, "Too many email attempts. Please wait before trying again.");
     }
 
-    let decodedToken;
-    try {
-      decodedToken = await adminAuth.verifyIdToken(token);
-    } catch (error) {
-      console.error("[admin-email] Failed to verify token", error);
-      return NextResponse.json({ error: "Session invalid or expired." }, { status: 401 });
-    }
+    // Previously this route verified the caller's token but never checked that
+    // they were an admin, so any signed-in resident could send mail from a
+    // james-square.com address to any recipient list they chose.
+    const auth = await requireAdmin(req);
+    if (!auth.ok) return auth.response;
+    const decodedToken = auth.token;
 
     const body = (await req.json().catch(() => null)) as AdminEmailRequest | null;
 
@@ -100,8 +106,8 @@ export async function POST(req: NextRequest) {
       );
     }
 
-    const subject = String(body.subject).trim();
-    const message = String(body.message);
+    const subject = String(body.subject).trim().slice(0, MAX_SUBJECT_LENGTH);
+    const message = String(body.message).slice(0, MAX_MESSAGE_LENGTH);
     const recipients = body.recipients;
     const sender = resolveSender(body.sender);
 
@@ -116,9 +122,19 @@ export async function POST(req: NextRequest) {
       );
     }
 
+    // Named groups are expanded here rather than in the browser, so committee
+    // members' personal addresses are never shipped in the client bundle.
+    const groupKeys: EmailGroupKey[] = (Array.isArray(body.groups) ? body.groups : []).filter(
+      isEmailGroupKey,
+    );
+    const groupEmails = groupKeys.flatMap((key) => [...EMAIL_GROUPS[key]]);
+
     const primaryEmails = Array.from(
       new Set(
-        (Array.isArray(recipients.emails) ? recipients.emails : [])
+        [
+          ...(Array.isArray(recipients.emails) ? recipients.emails : []),
+          ...groupEmails,
+        ]
           .map((email) => (typeof email === "string" ? email.trim() : ""))
           .filter((email) => email.length > 0),
       ),
@@ -168,6 +184,15 @@ export async function POST(req: NextRequest) {
     if (emails.some((email) => !isValidEmail(email))) {
       return NextResponse.json(
         { error: "One or more recipient email addresses are invalid." },
+        { status: 400 },
+      );
+    }
+
+    // Upper bound on blast radius: a mistake or a compromised admin session
+    // cannot turn this endpoint into a bulk mailer.
+    if (emails.length > MAX_TOTAL_RECIPIENTS) {
+      return NextResponse.json(
+        { error: `A single send is limited to ${MAX_TOTAL_RECIPIENTS} recipients.` },
         { status: 400 },
       );
     }

--- a/src/app/api/auth/resolve-identifier/route.ts
+++ b/src/app/api/auth/resolve-identifier/route.ts
@@ -1,0 +1,73 @@
+import { NextResponse, type NextRequest } from 'next/server';
+
+import { adminDb } from '@/lib/firebaseAdmin';
+import { clientKey, rateLimit, tooManyRequests } from '@/lib/security/rateLimit';
+
+export const runtime = 'nodejs';
+export const dynamic = 'force-dynamic';
+
+/**
+ * Resolves a username to the email address used for sign-in.
+ *
+ * This exists so that login-by-username and password reset keep working while
+ * the /users collection is closed to client reads — previously every visitor
+ * could query the collection and walk out with every resident's name, email
+ * address and flat number.
+ *
+ * Two anti-abuse measures matter here:
+ *
+ *  1. Rate limiting, because this endpoint is an oracle: it necessarily reveals
+ *     whether a username exists.
+ *  2. It returns *only* the email address, never the profile. Nothing about the
+ *     resident's name, flat or role leaves the server.
+ */
+export async function POST(req: NextRequest) {
+  const limit = rateLimit(clientKey(req, 'resolve-identifier'), {
+    limit: 12,
+    windowMs: 10 * 60_000,
+  });
+  if (!limit.allowed) {
+    return tooManyRequests(limit, 'Too many lookups. Please wait a moment and try again.');
+  }
+
+  let body: unknown;
+  try {
+    body = await req.json();
+  } catch {
+    return NextResponse.json({ error: 'Invalid request.' }, { status: 400 });
+  }
+
+  const { username } = (body ?? {}) as { username?: unknown };
+
+  if (typeof username !== 'string') {
+    return NextResponse.json({ error: 'A username is required.' }, { status: 400 });
+  }
+
+  const normalised = username.trim().toLowerCase();
+
+  // Reject anything that is not plausibly a username before touching the database.
+  if (!normalised || normalised.length > 64 || normalised.includes('@')) {
+    return NextResponse.json({ error: 'A username is required.' }, { status: 400 });
+  }
+
+  try {
+    const snapshot = await adminDb
+      .collection('users')
+      .where('username', '==', normalised)
+      .limit(1)
+      .get();
+
+    if (snapshot.empty) {
+      return NextResponse.json({ email: null });
+    }
+
+    const email = snapshot.docs[0]?.get('email');
+    return NextResponse.json(
+      { email: typeof email === 'string' ? email : null },
+      { headers: { 'Cache-Control': 'no-store, private' } },
+    );
+  } catch (error) {
+    console.error('[resolve-identifier] Lookup failed', error);
+    return NextResponse.json({ error: 'Lookup failed. Please try again.' }, { status: 500 });
+  }
+}

--- a/src/app/api/availability/route.ts
+++ b/src/app/api/availability/route.ts
@@ -1,0 +1,110 @@
+import { NextResponse, type NextRequest } from 'next/server';
+
+import { adminAuth, adminDb } from '@/lib/firebaseAdmin';
+import { clientKey, rateLimit, tooManyRequests } from '@/lib/security/rateLimit';
+import { isAdminToken } from '@/lib/security/requireAuth';
+
+export const runtime = 'nodejs';
+export const dynamic = 'force-dynamic';
+
+/** Placeholder returned instead of another resident's email address. */
+const BOOKED_SENTINEL = '__booked__';
+
+const DATE_PATTERN = /^\d{4}-\d{2}-\d{2}$/;
+
+type AvailabilityEntry = {
+  facility: string;
+  date: string;
+  time: string;
+  /**
+   * The caller's own email when the booking is theirs (so "Your booking" still
+   * works), the booker's email when the caller is an admin, and an opaque
+   * sentinel for everyone else.
+   */
+  user: string;
+};
+
+/**
+ * Public facility availability.
+ *
+ * The bookings collection stores the booker's email address. It used to be
+ * world-readable so that the schedule could be shown to visitors who were not
+ * signed in — which meant every resident's email address, plus a timestamped
+ * record of when they use the pool, could be downloaded by anyone.
+ *
+ * This endpoint keeps the schedule public while resolving identities server-side:
+ * an anonymous caller learns only that a slot is taken.
+ */
+export async function GET(req: NextRequest) {
+  const limit = rateLimit(clientKey(req, 'availability'), { limit: 120, windowMs: 60_000 });
+  if (!limit.allowed) return tooManyRequests(limit);
+
+  const date = req.nextUrl.searchParams.get('date');
+
+  if (!date || !DATE_PATTERN.test(date)) {
+    return NextResponse.json(
+      { error: 'A date in YYYY-MM-DD format is required.' },
+      { status: 400 },
+    );
+  }
+
+  // Identify the caller if they supplied a token, but do not require one.
+  let callerEmail: string | null = null;
+  let callerIsAdmin = false;
+
+  const authHeader = req.headers.get('authorization') ?? '';
+  const tokenMatch = authHeader.match(/^Bearer\s+(.+)$/i);
+
+  if (tokenMatch?.[1]) {
+    try {
+      const decoded = await adminAuth.verifyIdToken(tokenMatch[1], true);
+      callerEmail = decoded.email ?? null;
+      callerIsAdmin = await isAdminToken(decoded);
+    } catch {
+      // An invalid token is treated as anonymous rather than as an error: the
+      // schedule is public, so there is nothing to fail closed on.
+    }
+  }
+
+  try {
+    const snapshot = await adminDb.collection('bookings').where('date', '==', date).get();
+
+    const bookings: AvailabilityEntry[] = snapshot.docs.flatMap((doc) => {
+      const data = doc.data() as {
+        facility?: unknown;
+        date?: unknown;
+        time?: unknown;
+        user?: unknown;
+      };
+
+      if (
+        typeof data.facility !== 'string' ||
+        typeof data.date !== 'string' ||
+        typeof data.time !== 'string'
+      ) {
+        return [];
+      }
+
+      const bookedBy = typeof data.user === 'string' ? data.user : '';
+      const isOwn = Boolean(callerEmail) && bookedBy === callerEmail;
+
+      return [
+        {
+          facility: data.facility,
+          date: data.date,
+          time: data.time,
+          user: isOwn || callerIsAdmin ? bookedBy : BOOKED_SENTINEL,
+        },
+      ];
+    });
+
+    return NextResponse.json(
+      { date, bookings },
+      // Per-caller output, so it must never be cached in a shared layer.
+      { headers: { 'Cache-Control': 'no-store, private' } },
+    );
+  } catch (error) {
+    console.error('[availability] Failed to load bookings', error);
+    return NextResponse.json({ error: 'Failed to load availability.' }, { status: 500 });
+  }
+}

--- a/src/app/api/committee/send-email/route.ts
+++ b/src/app/api/committee/send-email/route.ts
@@ -3,10 +3,13 @@ import { Resend } from "resend";
 import { Timestamp } from "firebase-admin/firestore";
 
 import { committeeEmailTemplate } from "@/lib/email/templates/committeeEmailTemplate";
-import { adminAuth, adminDb } from "@/lib/firebaseAdmin";
+import { adminDb } from "@/lib/firebaseAdmin";
 import { sanitizeHtml } from "@/lib/sanitizeHtml";
+import { clientKey, rateLimit, tooManyRequests } from "@/lib/security/rateLimit";
+import { requireCommittee } from "@/lib/security/requireAuth";
 
 export const runtime = "nodejs";
+export const dynamic = "force-dynamic";
 
 type CommitteeEmailRequest = {
   subject: string;
@@ -18,13 +21,11 @@ const FROM_EMAIL = "JSPA Committee <committee@james-square.com>";
 const DAILY_RECIPIENT_LIMIT = 100;
 const MAX_RECIPIENTS_PER_BATCH = 50;
 
-const parseBearerToken = (request: NextRequest) => {
-  const header = request.headers.get("authorization") ?? "";
-  const match = header.match(/^Bearer\s+(.+)$/i);
-  return match?.[1];
-};
+const MAX_SUBJECT_LENGTH = 200;
+const MAX_MESSAGE_LENGTH = 50_000;
 
-const isValidEmail = (email: string) => /^[^\s@]+@[^\s@]+\.[^\s@]+$/.test(email);
+const isValidEmail = (email: string) =>
+  email.length <= 254 && /^[^\s@]+@[^\s@]+\.[^\s@]+$/.test(email);
 
 const escapeHtml = (value: string) =>
   value
@@ -97,18 +98,22 @@ const getDailyRecipientCount = async () => {
 
 export async function POST(req: NextRequest) {
   try {
-    const token = parseBearerToken(req);
-    let senderEmail: string | null = null;
-
-    if (token) {
-      try {
-        const decoded = await adminAuth.verifyIdToken(token);
-        senderEmail = decoded.email ?? null;
-      } catch (error) {
-        console.error("[committee-email] Failed to verify token", error);
-        return NextResponse.json({ error: "Session invalid or expired." }, { status: 401 });
-      }
+    const limit = rateLimit(clientKey(req, "committee-email"), {
+      limit: 10,
+      windowMs: 10 * 60_000,
+    });
+    if (!limit.allowed) {
+      return tooManyRequests(limit, "Too many email attempts. Please wait before trying again.");
     }
+
+    // Authentication was previously optional: a request with no Authorization
+    // header skipped the check entirely and went on to send mail from
+    // committee@james-square.com to any address supplied in the body.
+    const auth = await requireCommittee(req);
+    if (!auth.ok) return auth.response;
+
+    const senderEmail: string | null = auth.token.email ?? null;
+    const senderUid = auth.token.uid;
 
     const body = (await req.json().catch(() => null)) as CommitteeEmailRequest | null;
 
@@ -119,8 +124,8 @@ export async function POST(req: NextRequest) {
       );
     }
 
-    const subject = String(body.subject).trim();
-    const message = String(body.message).trim();
+    const subject = String(body.subject).trim().slice(0, MAX_SUBJECT_LENGTH);
+    const message = String(body.message).trim().slice(0, MAX_MESSAGE_LENGTH);
 
     const recipients = Array.from(
       new Set(
@@ -194,6 +199,7 @@ export async function POST(req: NextRequest) {
       renderedHtml: html,
       sentAt: Timestamp.now(),
       senderEmail,
+      senderUid,
       recipientCount: recipients.length,
       manualRecipientMode: true,
     });

--- a/src/app/api/message-board/route.ts
+++ b/src/app/api/message-board/route.ts
@@ -2,6 +2,9 @@
 import { NextRequest, NextResponse } from 'next/server';
 import admin from 'firebase-admin';
 
+import { clientKey, rateLimit, tooManyRequests } from '@/lib/security/rateLimit';
+import { requireUser } from '@/lib/security/requireAuth';
+
 // Ensure this route runs on Node (firebase-admin is not Edge-compatible)
 export const runtime = 'nodejs';
 // Avoid static optimization so env is read at request time, not at build time
@@ -43,19 +46,37 @@ function getDb(): FirebaseFirestore.Firestore {
   return db!;
 }
 
+const MAX_LIMIT = 50;
+
+/**
+ * Message board summaries.
+ *
+ * Reads with the Admin SDK, which bypasses Firestore rules, so authentication has
+ * to be enforced here: the board carries residents' names and is not public.
+ * Also clamps `limit`, which was previously attacker-controlled and unbounded.
+ */
 export async function GET(req: NextRequest) {
   try {
+    const limit = rateLimit(clientKey(req, 'message-board'), { limit: 60, windowMs: 60_000 });
+    if (!limit.allowed) return tooManyRequests(limit);
+
+    const auth = await requireUser(req);
+    if (!auth.ok) return auth.response;
+
     const database = getDb();
-    const limitParam = parseInt(req.nextUrl.searchParams.get('limit') || '10', 10);
+    const requested = Number.parseInt(req.nextUrl.searchParams.get('limit') || '10', 10);
+    const pageSize = Number.isFinite(requested)
+      ? Math.min(Math.max(requested, 1), MAX_LIMIT)
+      : 10;
 
     const snapshot = await database
       .collection('posts')
       .orderBy('createdAt', 'desc')
-      .limit(Number.isFinite(limitParam) ? limitParam : 10)
+      .limit(pageSize)
       .get();
 
     const posts = snapshot.docs.map((doc) => ({ id: doc.id, ...doc.data() }));
-    return NextResponse.json({ posts });
+    return NextResponse.json({ posts }, { headers: { 'Cache-Control': 'no-store, private' } });
   } catch (err: unknown) {
     const message =
       process.env.NODE_ENV !== 'production' && err instanceof Error

--- a/src/app/book/schedule/SchedulePageClientInner.tsx
+++ b/src/app/book/schedule/SchedulePageClientInner.tsx
@@ -175,23 +175,35 @@ export default function SchedulePageClientInner() {
 
   useEffect(() => {
     async function fetchData(date: string) {
-      const q = query(collection(db, 'bookings'), where('date', '==', date));
-      const snap = await getDocs(q);
       const updated = generateInitialBookings();
-  
-      snap.forEach((docSnap) => {
-        const data = docSnap.data() as {
-          facility: string;
-          date: string;
-          time: string;
-          user: string;
-        };
-        if (!updated[data.facility][data.date]) {
-          updated[data.facility][data.date] = {};
+
+      // Availability comes from a server route rather than a direct Firestore
+      // read: it returns an opaque marker in place of other residents' email
+      // addresses, so the schedule stays public without exposing who booked what.
+      try {
+        const token = await auth.currentUser?.getIdToken();
+        const res = await fetch(`/api/availability?date=${encodeURIComponent(date)}`, {
+          headers: token ? { Authorization: `Bearer ${token}` } : undefined,
+          cache: 'no-store',
+        });
+
+        if (res.ok) {
+          const payload = (await res.json()) as {
+            bookings?: Array<{ facility: string; date: string; time: string; user: string }>;
+          };
+
+          for (const booking of payload.bookings ?? []) {
+            if (!updated[booking.facility]) continue;
+            if (!updated[booking.facility][booking.date]) {
+              updated[booking.facility][booking.date] = {};
+            }
+            updated[booking.facility][booking.date][booking.time] = booking.user;
+          }
         }
-        updated[data.facility][data.date][data.time] = data.user;
-      });
-  
+      } catch (error) {
+        console.error('Failed to load availability', error);
+      }
+
       setBookings(updated);
   
       const winSnap = await getDocs(query(
@@ -274,21 +286,17 @@ export default function SchedulePageClientInner() {
     let consecutiveCount = 0;
     for (let i = 1; i <= 3; i++) {
       const prevDate = currentDate.minus({ days: i }).toISODate();
+      // Constrained to the caller's own bookings: both cheaper and a query the
+      // tightened security rules will accept.
       const q = query(
         collection(db, 'bookings'),
+        where('user', '==', user.email),
         where('facility', '==', facility),
         where('date', '==', prevDate),
         where('time', '==', time)
       );
       const snap = await getDocs(q);
-      let found = false;
-      snap.forEach((docSnap) => {
-        const data = docSnap.data();
-        if (data.user === user.email) {
-          found = true;
-        }
-      });
-      if (found) consecutiveCount++;
+      if (!snap.empty) consecutiveCount++;
       else break;
     }
     return consecutiveCount === 3;

--- a/src/app/committee/CommitteeGate.tsx
+++ b/src/app/committee/CommitteeGate.tsx
@@ -2,10 +2,11 @@
 
 import { useEffect, useState, type FormEvent } from 'react';
 
+import { verifyAccessCode } from '@/app/actions/accessCodes';
+
 import CommitteeContent from './CommitteeContent';
 
 const ACCESS_KEY = 'js_committee_access';
-const PASSCODE = '9753';
 
 const glassCard =
   'jqs-glass rounded-2xl border border-white/20 bg-white/50 dark:bg-white/10 backdrop-blur-xl shadow-[0_8px_30px_rgba(0,0,0,0.08)]';
@@ -14,6 +15,7 @@ export default function CommitteeGate() {
   const [passcode, setPasscode] = useState('');
   const [hasAccess, setHasAccess] = useState(false);
   const [error, setError] = useState('');
+  const [submitting, setSubmitting] = useState(false);
 
   useEffect(() => {
     const stored = sessionStorage.getItem(ACCESS_KEY);
@@ -30,15 +32,26 @@ export default function CommitteeGate() {
     }
   };
 
-  const handleSubmit = (event: FormEvent<HTMLFormElement>) => {
+  const handleSubmit = async (event: FormEvent<HTMLFormElement>) => {
     event.preventDefault();
-    if (passcode === PASSCODE) {
-      sessionStorage.setItem(ACCESS_KEY, 'granted');
-      setHasAccess(true);
-      setError('');
-      return;
+    if (submitting) return;
+
+    setSubmitting(true);
+    try {
+      // Verified on the server: the code is no longer present in this bundle.
+      const result = await verifyAccessCode('committee', passcode);
+      if (result.ok) {
+        sessionStorage.setItem(ACCESS_KEY, 'granted');
+        setHasAccess(true);
+        setError('');
+        return;
+      }
+      setError(result.error ?? 'Incorrect passcode. Please try again.');
+    } catch {
+      setError('We could not check that passcode. Please try again.');
+    } finally {
+      setSubmitting(false);
     }
-    setError('Incorrect passcode. Please try again.');
   };
 
   if (hasAccess) {
@@ -69,12 +82,17 @@ export default function CommitteeGate() {
               value={passcode}
             />
           </div>
-          {error ? <p className="text-sm text-red-600 dark:text-red-400">{error}</p> : null}
+          {error ? (
+            <p className="text-sm text-red-600 dark:text-red-400" role="alert">
+              {error}
+            </p>
+          ) : null}
           <button
-            className="w-full rounded-full px-4 py-2 text-sm font-semibold jqs-glass hover:brightness-[1.05] transition"
+            className="w-full rounded-full px-4 py-2 text-sm font-semibold jqs-glass hover:brightness-[1.05] transition disabled:opacity-60"
+            disabled={submitting}
             type="submit"
           >
-            Continue
+            {submitting ? 'Checking…' : 'Continue'}
           </button>
         </form>
       </div>

--- a/src/app/cookies/page.tsx
+++ b/src/app/cookies/page.tsx
@@ -1,0 +1,205 @@
+import type { Metadata } from 'next';
+import Link from 'next/link';
+
+import { CookieSettingsLink } from '@/components/consent';
+import {
+  LEGAL_CONTACT_EMAIL,
+  LegalList,
+  LegalPage,
+  LegalSection,
+  LegalTable,
+} from '@/components/legal/LegalPage';
+import { CONSENT_CATEGORY_INFO } from '@/lib/consent/categories';
+import { CONSENT_MAX_AGE_DAYS } from '@/lib/consent/types';
+
+export const metadata: Metadata = {
+  title: 'Cookie Policy | James Square',
+  description:
+    'How James Square uses cookies and similar storage, what each category does, and how to change your choices at any time.',
+};
+
+const lastUpdated = '26 July 2026';
+
+export default function CookiePolicyPage() {
+  return (
+    <LegalPage
+      currentPath="/cookies"
+      lastUpdated={lastUpdated}
+      summary="James Square sets a small number of essential cookies so you can sign in and so we remember your cookie choices. Everything else is optional, switched off until you allow it, and can be withdrawn at any time from the Cookie Settings link in the footer. We run no advertising and no cross-site tracking."
+      title="Cookie Policy"
+    >
+      <LegalSection title="What cookies are">
+        <p>
+          A cookie is a small file a website asks your browser to keep. Similar technologies —
+          local storage and session storage — do much the same job. This policy covers all of
+          them, and uses &ldquo;cookies&rdquo; throughout for readability.
+        </p>
+        <p>
+          Under the Privacy and Electronic Communications Regulations (PECR) we may only place
+          cookies on your device without asking when they are strictly necessary to provide the
+          service you asked for. Everything else requires your consent first, which is why nothing
+          optional runs on this site until you allow it.
+        </p>
+      </LegalSection>
+
+      <LegalSection title="What we currently use">
+        <p>
+          James Square runs <strong>no analytics, advertising or tracking scripts at all</strong>.
+          At the time of writing, the only cookies and storage in use are the strictly necessary
+          ones listed below. The optional categories exist so that if useful measurement is added
+          later, your choice is already recorded and respected from the first page load.
+        </p>
+
+        <LegalTable
+          caption="Cookies and storage currently set by James Square"
+          headers={['Name', 'Type', 'Purpose', 'Expires']}
+          rows={[
+            [
+              <code key="a">js-consent</code>,
+              'Essential',
+              'Records your cookie choices so you are not asked again. Stored both in local storage and as a first-party cookie.',
+              `${CONSENT_MAX_AGE_DAYS} days`,
+            ],
+            [
+              <code key="b">firebase:authUser:*</code>,
+              'Essential',
+              'Keeps you signed in to your resident account. Set by Firebase Authentication, our sign-in provider.',
+              'Until you sign out',
+            ],
+            [
+              <code key="c">owners_secure_access</code>,
+              'Essential',
+              'Records that you entered the Owners area access code, for the length of your browsing session.',
+              'End of session',
+            ],
+            [
+              <code key="d">js_committee_access</code>,
+              'Essential',
+              'Records that you entered the Committee area access code, for the length of your browsing session.',
+              'End of session',
+            ],
+            [
+              <code key="e">useful-info-tab</code>,
+              'Functional',
+              'Remembers which information tab you last had open.',
+              '12 months',
+            ],
+            [
+              <code key="f">ovh_username, ovh_flat</code>,
+              'Functional',
+              'Pre-fills your name and flat on the voting form so you do not retype them.',
+              'End of session',
+            ],
+          ]}
+        />
+
+        <p className="text-sm">
+          Service workers used for offline access to the site are also strictly necessary, and
+          store only page assets — never personal information.
+        </p>
+      </LegalSection>
+
+      <LegalSection title="The categories explained">
+        <p>
+          These are the same categories, in the same words, that you see in the Cookie Preferences
+          panel.
+        </p>
+
+        <div className="space-y-5">
+          {CONSENT_CATEGORY_INFO.map((category) => (
+            <div key={category.id} className="space-y-2">
+              <h3 className="text-base font-semibold text-[color:var(--text-primary)]">
+                {category.label}{' '}
+                <span className="text-sm font-normal text-[color:var(--text-secondary)]">
+                  ({category.required ? 'always on' : 'optional'})
+                </span>
+              </h3>
+              <p>{category.summary}</p>
+              <LegalList items={category.examples} />
+              <p className="text-sm">
+                <strong className="font-medium text-[color:var(--text-primary)]">
+                  Personal information:
+                </strong>{' '}
+                {category.personalData}
+              </p>
+              <p className="text-sm">
+                <strong className="font-medium text-[color:var(--text-primary)]">
+                  How long it lasts:
+                </strong>{' '}
+                {category.storageDuration}
+              </p>
+            </div>
+          ))}
+        </div>
+      </LegalSection>
+
+      <LegalSection title="Changing or withdrawing your choices">
+        <p>
+          Use the <strong>Cookie Settings</strong> link in the footer of any page — or the button
+          below — to reopen the preferences panel. You can turn individual categories on or off,
+          reject everything optional, or withdraw consent entirely so that you are asked afresh.
+        </p>
+        <p>
+          <CookieSettingsLink
+            className="consent-btn consent-btn--secondary"
+            showIcon={false}
+          />
+        </p>
+        <p>
+          Withdrawing consent is as easy as giving it, takes effect immediately, and never costs
+          you access to any part of the site. Any storage belonging to a category you switch off is
+          cleared at the same time.
+        </p>
+        <p>
+          We ask again after {CONSENT_MAX_AGE_DAYS} days so that a decision you made long ago is
+          not treated as consent forever.
+        </p>
+      </LegalSection>
+
+      <LegalSection title="Browser controls">
+        <p>
+          You can also block or delete cookies in your browser settings. Blocking strictly
+          necessary cookies will stop you being able to sign in, and may break bookings and the
+          message board. Guidance for each major browser is published by the{' '}
+          <a
+            className="underline underline-offset-2"
+            href="https://ico.org.uk/for-the-public/online/cookies/"
+            rel="noopener noreferrer"
+            target="_blank"
+          >
+            Information Commissioner&rsquo;s Office
+          </a>
+          .
+        </p>
+      </LegalSection>
+
+      <LegalSection title="Third parties">
+        <p>
+          Some pages embed content from other organisations — Vimeo for video, Google Maps for
+          location, Microsoft Forms for questionnaires. These are loaded only when you allow
+          functional cookies, so no request reaches them until then. Where an embed is switched
+          off you will see a placeholder offering to enable it.
+        </p>
+        <p>
+          Our hosting provider (Vercel) and sign-in and database provider (Google Firebase) process
+          data on our behalf as part of delivering the site. They are covered in the{' '}
+          <Link className="underline underline-offset-2" href="/privacy">
+            Privacy Policy
+          </Link>
+          .
+        </p>
+      </LegalSection>
+
+      <LegalSection title="Questions">
+        <p>
+          If anything here is unclear, or you think a cookie is being set that this policy does not
+          describe, please contact us at{' '}
+          <a className="underline underline-offset-2" href={`mailto:${LEGAL_CONTACT_EMAIL}`}>
+            {LEGAL_CONTACT_EMAIL}
+          </a>
+          .
+        </p>
+      </LegalSection>
+    </LegalPage>
+  );
+}

--- a/src/app/data-retention/page.tsx
+++ b/src/app/data-retention/page.tsx
@@ -1,0 +1,181 @@
+import type { Metadata } from 'next';
+import Link from 'next/link';
+
+import {
+  LEGAL_CONTACT_EMAIL,
+  LegalList,
+  LegalPage,
+  LegalSection,
+  LegalTable,
+} from '@/components/legal/LegalPage';
+
+export const metadata: Metadata = {
+  title: 'Data Retention Policy | James Square',
+  description:
+    'How long James Square keeps each type of information, what happens when an account is closed, and how deletion is carried out.',
+};
+
+const lastUpdated = '26 July 2026';
+
+export default function DataRetentionPage() {
+  return (
+    <LegalPage
+      currentPath="/data-retention"
+      lastUpdated={lastUpdated}
+      summary="We keep account details while your account is active, bookings for two years, audit logs for two years, and community discussion for as long as it is useful. Closing your account removes your profile and anonymises what has to stay for the record."
+      title="Data Retention Policy"
+    >
+      <LegalSection title="The principle">
+        <p>
+          UK GDPR requires that personal information is kept no longer than necessary. For a
+          community website that means being honest about two competing needs: residents should not
+          have a permanent record following them around, but the building needs a reliable account
+          of decisions, bookings and safety matters.
+        </p>
+        <p>
+          The periods below are our working answer to that. Where something is kept for longer than
+          you might expect, the reason is given.
+        </p>
+      </LegalSection>
+
+      <LegalSection title="Retention periods">
+        <LegalTable
+          caption="How long each type of information is kept"
+          headers={['Information', 'Kept for', 'Why']}
+          rows={[
+            [
+              'Account profile — name, email, username, flat, resident type',
+              'While the account is active, then deleted within 30 days of closure',
+              'Needed to give you access; no reason to keep it afterwards',
+            ],
+            [
+              'Sign-in credentials',
+              'Deleted with the account',
+              'Held by Firebase Authentication, not by us',
+            ],
+            [
+              'Last sign-in timestamp',
+              '12 months',
+              'Helps spot dormant and compromised accounts',
+            ],
+            [
+              'Facility bookings',
+              '24 months from the booking date',
+              'Fair-use checks look back several days; longer history supports facility planning and disputes',
+            ],
+            [
+              'Message board posts, comments and replies',
+              'Indefinitely while relevant; author name removed if the account is closed',
+              'Community discussion loses its meaning if threads are gutted; the personal link is severed instead',
+            ],
+            [
+              'Reactions on posts',
+              'Deleted with the account',
+              'No value once the person has left',
+            ],
+            [
+              'Moderation reports',
+              '24 months',
+              'Needed to see patterns of behaviour; then no longer relevant',
+            ],
+            [
+              'Community and owners’ votes, including voter name and flat',
+              'Until 12 months after the vote closes, then reduced to anonymous totals',
+              'Results must be verifiable at the time; the totals are what matters afterwards',
+            ],
+            [
+              'Feedback submitted through the site',
+              '12 months',
+              'Long enough to act on and follow up',
+            ],
+            [
+              'Emails sent through the site, and the committee archive',
+              '6 years',
+              'Communications with owners about building matters may be needed for Association records and any dispute',
+            ],
+            [
+              'Administrative audit log',
+              '24 months',
+              'Accountability for changes to accounts and roles',
+            ],
+            [
+              'Cookie consent record',
+              '6 months, then you are asked again',
+              'Evidence that consent was given, without treating an old decision as permanent',
+            ],
+            [
+              'Web server and security logs',
+              'Held by our hosting provider on short operational cycles (typically 30 days)',
+              'Diagnosing faults and investigating abuse',
+            ],
+            [
+              'Rate-limiting counters',
+              'Minutes',
+              'Held in memory only, to slow down automated guessing; never written to the database',
+            ],
+          ]}
+        />
+      </LegalSection>
+
+      <LegalSection title="Closing your account">
+        <p>
+          Email{' '}
+          <a className="underline underline-offset-2" href={`mailto:${LEGAL_CONTACT_EMAIL}`}>
+            {LEGAL_CONTACT_EMAIL}
+          </a>{' '}
+          from the address on the account. Within 30 days we will:
+        </p>
+        <LegalList
+          items={[
+            'Delete your sign-in credentials and your profile — name, email address, username, flat and resident type.',
+            'Delete your future bookings and cancel any slots you were holding.',
+            'Remove your name from message board posts, comments and replies, leaving the content in place attributed to a former resident.',
+            'Reduce any votes you cast to anonymous totals, so results remain correct without naming you.',
+            'Delete your reactions and any feedback you submitted.',
+          ]}
+        />
+        <p>
+          A small amount of information may be kept beyond this where we are required to, or where
+          erasing it would undermine something the community relies on:
+        </p>
+        <LegalList
+          items={[
+            'Records relating to a safety incident, insurance claim or legal matter, for as long as that matter is live.',
+            'Emails already sent to residents — these have left our systems and cannot be recalled.',
+            'Entries in the administrative audit log showing actions taken on the account, so the log stays complete.',
+          ]}
+        />
+        <p>
+          We will tell you if any of these apply to you, and explain what is being kept and why.
+        </p>
+      </LegalSection>
+
+      <LegalSection title="How deletion is carried out">
+        <p>
+          Deletion is performed by a site administrator against the live database, so the record is
+          genuinely removed rather than hidden from the interface. Backups held by our providers roll
+          forward on their own cycles, so a deleted record may persist in a backup for a short period
+          before ageing out. Backups are not used to restore individual records.
+        </p>
+        <p>
+          Retention periods are reviewed alongside this policy at least once a year, and pruning of
+          expired bookings, votes and logs is currently carried out manually as part of that review.
+        </p>
+      </LegalSection>
+
+      <LegalSection title="Related documents">
+        <p>
+          See the{' '}
+          <Link className="underline underline-offset-2" href="/privacy">
+            Privacy Policy
+          </Link>{' '}
+          for what we collect and why, and the{' '}
+          <Link className="underline underline-offset-2" href="/cookies">
+            Cookie Policy
+          </Link>{' '}
+          for storage kept on your own device.
+        </p>
+      </LegalSection>
+    </LegalPage>
+  );
+}

--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -512,3 +512,221 @@ body::before {
     padding: 0 !important;
   }
 }
+
+/* ──────────────────────────────────────────────────────────────────────────
+   Cookie consent — Liquid Glass surfaces
+   Built from the same tokens as .jqs-glass so the consent UI reads as part of
+   the site rather than a bolted-on compliance widget.
+   ────────────────────────────────────────────────────────────────────────── */
+
+.consent-surface {
+  position: relative;
+  border-radius: 1.75rem;
+  border: 1px solid hsl(var(--glass-border));
+  background:
+    linear-gradient(180deg, color-mix(in srgb, var(--glass-highlight) 70%, transparent) 0%, transparent 32%),
+    color-mix(in srgb, var(--glass-bg-light) 96%, transparent);
+  box-shadow: var(--glass-shadow-lift);
+  backdrop-filter: blur(26px) saturate(160%);
+  -webkit-backdrop-filter: blur(26px) saturate(160%);
+}
+
+/* The thin specular line along the top edge that the site's cards all share. */
+.consent-surface::before {
+  content: '';
+  position: absolute;
+  inset: 0 0 auto 0;
+  height: 1px;
+  border-radius: inherit;
+  background: linear-gradient(
+    90deg,
+    transparent,
+    color-mix(in srgb, var(--glass-highlight) 90%, transparent),
+    transparent
+  );
+  pointer-events: none;
+}
+
+.consent-scrim {
+  background: color-mix(in srgb, rgb(15 23 42 / 0.28) 100%, transparent);
+  backdrop-filter: blur(10px) saturate(120%);
+  -webkit-backdrop-filter: blur(10px) saturate(120%);
+}
+
+@media (prefers-color-scheme: dark) {
+  .consent-scrim {
+    background: rgb(2 6 12 / 0.52);
+  }
+}
+
+/* Buttons: a clear visual hierarchy achieved with depth, not colour shouting. */
+.consent-btn {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  gap: 0.5rem;
+  border-radius: 999px;
+  padding: 0.625rem 1.25rem;
+  font-size: 0.875rem;
+  font-weight: 600;
+  line-height: 1.2;
+  border: 1px solid transparent;
+  /* Labels are short and meaningful; wrapping them mid-phrase reads as cramped. */
+  white-space: nowrap;
+  transition: transform 220ms cubic-bezier(0.16, 1, 0.3, 1), box-shadow 220ms ease,
+    background-color 220ms ease, filter 220ms ease;
+}
+
+.consent-btn:focus-visible {
+  outline: 2px solid var(--btn-ring);
+  outline-offset: 2px;
+}
+
+.consent-btn:active {
+  transform: scale(0.975);
+}
+
+.consent-btn--primary {
+  background: var(--btn-primary-bg);
+  color: var(--btn-primary-text);
+  box-shadow: 0 10px 26px rgb(37 99 235 / 0.28), inset 0 1px 0 rgb(255 255 255 / 0.28);
+}
+
+.consent-btn--primary:hover {
+  filter: brightness(1.06);
+  box-shadow: 0 14px 32px rgb(37 99 235 / 0.34), inset 0 1px 0 rgb(255 255 255 / 0.3);
+}
+
+.consent-btn--secondary {
+  background: color-mix(in srgb, var(--glass-bg-light) 92%, transparent);
+  border-color: hsl(var(--glass-border));
+  color: var(--text-primary);
+  box-shadow: inset 0 1px 0 color-mix(in srgb, var(--glass-highlight) 80%, transparent);
+}
+
+.consent-btn--secondary:hover {
+  background: color-mix(in srgb, var(--glass-bg-light) 100%, transparent);
+}
+
+.consent-btn--ghost {
+  background: transparent;
+  color: var(--text-secondary);
+  padding-inline: 0.75rem;
+}
+
+.consent-btn--ghost:hover {
+  color: var(--text-primary);
+  background: color-mix(in srgb, var(--glass-bg-light) 60%, transparent);
+}
+
+/* Toggle switch — Apple-style, driven entirely by the checkbox state so it
+   stays keyboard operable and announceable. */
+.consent-toggle {
+  position: relative;
+  display: inline-flex;
+  flex-shrink: 0;
+  height: 1.625rem;
+  width: 2.875rem;
+  align-items: center;
+  border-radius: 999px;
+  border: 1px solid hsl(var(--glass-border));
+  background: color-mix(in srgb, var(--muted) 22%, transparent);
+  transition: background-color 240ms cubic-bezier(0.16, 1, 0.3, 1);
+  cursor: pointer;
+}
+
+.consent-toggle__knob {
+  position: absolute;
+  left: 3px;
+  height: 1.25rem;
+  width: 1.25rem;
+  border-radius: 999px;
+  background: #ffffff;
+  box-shadow: 0 2px 6px rgb(15 23 42 / 0.28);
+  transition: transform 240ms cubic-bezier(0.16, 1, 0.3, 1);
+}
+
+.consent-toggle-input:checked + .consent-toggle {
+  background: linear-gradient(135deg, #2563eb, #1d4ed8);
+  border-color: transparent;
+}
+
+.consent-toggle-input:checked + .consent-toggle .consent-toggle__knob {
+  transform: translateX(1.1875rem);
+}
+
+.consent-toggle-input:disabled + .consent-toggle {
+  opacity: 0.55;
+  cursor: not-allowed;
+}
+
+.consent-toggle-input:focus-visible + .consent-toggle {
+  outline: 2px solid var(--btn-ring);
+  outline-offset: 2px;
+}
+
+/* The small cookie mark. A slow, single-pass shimmer — noticed, not animated at. */
+@keyframes consent-crumb-drift {
+  0%, 100% { transform: translateY(0) rotate(0deg); }
+  50% { transform: translateY(-1px) rotate(6deg); }
+}
+
+.consent-icon {
+  animation: consent-crumb-drift 6s ease-in-out infinite;
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .consent-icon {
+    animation: none;
+  }
+  .consent-btn,
+  .consent-toggle,
+  .consent-toggle__knob {
+    transition-duration: 1ms;
+  }
+}
+
+/* Keeps the banner clear of the iOS home indicator and any PWA safe area. */
+.consent-dock {
+  padding-bottom: max(1rem, env(safe-area-inset-bottom));
+}
+
+@media print {
+  .consent-dock,
+  .consent-modal-root {
+    display: none !important;
+  }
+}
+
+/* Skip link — visible only when focused, styled as a small glass pill so it
+   matches the site when a keyboard user lands on it. */
+.skip-to-content {
+  position: fixed;
+  top: 0.75rem;
+  left: 50%;
+  z-index: 100;
+  transform: translate(-50%, -150%);
+  border-radius: 999px;
+  border: 1px solid hsl(var(--glass-border));
+  background: color-mix(in srgb, var(--glass-bg-light) 98%, transparent);
+  box-shadow: var(--glass-shadow-soft);
+  backdrop-filter: blur(18px);
+  -webkit-backdrop-filter: blur(18px);
+  padding: 0.5rem 1.125rem;
+  font-size: 0.875rem;
+  font-weight: 600;
+  color: var(--text-primary);
+  transition: transform 220ms cubic-bezier(0.16, 1, 0.3, 1);
+}
+
+.skip-to-content:focus-visible {
+  transform: translate(-50%, 0);
+  outline: 2px solid var(--btn-ring);
+  outline-offset: 2px;
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .skip-to-content {
+    transition-duration: 1ms;
+  }
+}

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -7,6 +7,7 @@ import Footer from "@/components/Footer";
 import { AuthProvider } from "@/context/AuthContext";
 import AppLaunchShell from "@/components/AppLaunchShell";
 import AppModeGate from "@/components/layout/AppModeGate";
+import { ConsentProvider, ConsentSurface } from "@/components/consent";
 
 const geistSans = Geist({ subsets: ["latin"], variable: "--font-geist-sans" });
 const geistMono = Geist_Mono({ subsets: ["latin"], variable: "--font-geist-mono" });
@@ -64,9 +65,24 @@ export default function RootLayout({ children }: { children: React.ReactNode }) 
         <AppModeGate />
         <AppLaunchShell>
           <AuthProvider>
-            <Header />
-            <main className="site-content max-w-6xl mx-auto px-4 sm:px-6 py-8">{children}</main>
-            <Footer />
+            <ConsentProvider>
+              <a className="skip-to-content" href="#main-content">
+                Skip to main content
+              </a>
+              {/* Placed before the header in the DOM so a keyboard user reaches
+                  the consent choice immediately. The banner is position: fixed,
+                  so it still appears at the bottom of the viewport, and the
+                  preferences dialog is portalled to <body> regardless. */}
+              <ConsentSurface />
+              <Header />
+              <main
+                className="site-content max-w-6xl mx-auto px-4 sm:px-6 py-8"
+                id="main-content"
+              >
+                {children}
+              </main>
+              <Footer />
+            </ConsentProvider>
           </AuthProvider>
         </AppLaunchShell>
       </body>

--- a/src/app/login/LoginClient.tsx
+++ b/src/app/login/LoginClient.tsx
@@ -10,7 +10,8 @@ import {
   signInWithEmailAndPassword,
   onAuthStateChanged,
 } from 'firebase/auth';
-import { collection, doc, getDoc, getDocs, query, serverTimestamp, where, setDoc } from 'firebase/firestore';
+import { doc, getDoc, serverTimestamp, setDoc } from 'firebase/firestore';
+import { resolveLoginEmail } from '@/lib/client/resolveIdentifier';
 
 type ResidentType = 'owner' | 'renter' | 'stl_guest';
 
@@ -128,17 +129,12 @@ export default function LoginClient() {
           window.location.href = '/dashboard';
         }, 2000);
       } else {
-        // Login: Treat identifier as email if it contains "@" otherwise as username.
-        let loginEmail = identifier;
-        if (!loginEmail.includes('@')) {
-          const q = query(collection(db, 'users'), where('username', '==', loginEmail));
-          const querySnapshot = await getDocs(q);
-          if (!querySnapshot.empty) {
-            loginEmail = querySnapshot.docs[0].data().email;
-          } else {
-            setMessage('No account found for that username.');
-            return;
-          }
+        // Login: an email is used directly; a username is resolved server-side,
+        // since resident profiles are no longer readable from the browser.
+        const loginEmail = await resolveLoginEmail(identifier);
+        if (!loginEmail) {
+          setMessage('No account found for that username.');
+          return;
         }
         const userCredential = await signInWithEmailAndPassword(auth, loginEmail, password);
         await userCredential.user.getIdToken(true);

--- a/src/app/message-board/page.tsx
+++ b/src/app/message-board/page.tsx
@@ -8,7 +8,6 @@ import {
   collection,
   doc,
   addDoc,
-  getDocs,
   getDoc,
   onSnapshot,
   orderBy,
@@ -79,15 +78,23 @@ type ReportPayload = {
    Helpers
 ============================ */
 
-/** Look up user's display name from /users by email */
-async function getDisplayNameFromProfile(email?: string | null): Promise<string | undefined> {
-  if (!email) return undefined;
-  const snap = await getDocs(query(collection(db, 'users'), where('email', '==', email)));
-  if (!snap.empty) {
-    const data = snap.docs[0].data() as UserDoc;
-    if (data?.fullName) return data.fullName;
+/**
+ * Look up the signed-in user's own display name from /users.
+ *
+ * Reads the profile by uid rather than querying the collection by email: a
+ * resident can read their own profile, but nobody can enumerate everyone else's.
+ * All callers use this for the current user's own name, which is the only case
+ * that ever needed a profile read.
+ */
+async function getDisplayNameFromProfile(uid?: string | null): Promise<string | undefined> {
+  if (!uid) return undefined;
+  try {
+    const snap = await getDoc(doc(db, 'users', uid));
+    const data = snap.data() as UserDoc | undefined;
+    return data?.fullName || undefined;
+  } catch {
+    return undefined;
   }
-  return undefined;
 }
 
 /** Create a report in /reports with a consistent shape */
@@ -288,7 +295,7 @@ export default function MessageBoardPage() {
     setBusy(true);
     try {
       const name =
-        (await getDisplayNameFromProfile(user.email)) ||
+        (await getDisplayNameFromProfile(user.uid)) ||
         user.displayName ||
         user.email ||
         'Unknown';
@@ -774,7 +781,7 @@ function Comments({ postId, currentUser }: { postId: string; currentUser: User |
     if (!body.trim()) return;
 
     const name =
-      (await getDisplayNameFromProfile(currentUser.email)) ||
+      (await getDisplayNameFromProfile(currentUser.uid)) ||
       currentUser.displayName ||
       currentUser.email ||
       'Unknown';
@@ -963,7 +970,7 @@ function Replies({
     if (!body.trim()) return;
 
     const name =
-      (await getDisplayNameFromProfile(currentUser.email)) ||
+      (await getDisplayNameFromProfile(currentUser.uid)) ||
       currentUser.displayName ||
       currentUser.email ||
       'Unknown';

--- a/src/app/owners/page.tsx
+++ b/src/app/owners/page.tsx
@@ -6,10 +6,10 @@ import { useRouter } from 'next/navigation';
 import { AnimatePresence, motion, useReducedMotion } from 'framer-motion';
 import { FormEvent, useState } from 'react';
 
+import { verifyAccessCode } from '@/app/actions/accessCodes';
 import { GlassCard } from '@/components/GlassCard';
 import GradientBG from '@/components/GradientBG';
 
-const OWNERS_ACCESS_CODE = '3579';
 const OWNERS_ACCESS_KEY = 'owners_secure_access';
 const COMMITTEE_EMAIL = 'committee@james-square.com';
 const EMAIL_SUBJECT = 'Request for owners access code – James Square';
@@ -24,22 +24,39 @@ const OwnersPage = () => {
   const prefersReducedMotion = useReducedMotion();
   const [accessCode, setAccessCode] = useState('');
   const [showError, setShowError] = useState(false);
+  const [errorMessage, setErrorMessage] = useState('');
   const [isSubmitting, setIsSubmitting] = useState(false);
 
-  const handleOwnersAccessSubmit = (event: FormEvent<HTMLFormElement>) => {
+  const handleOwnersAccessSubmit = async (event: FormEvent<HTMLFormElement>) => {
     event.preventDefault();
+    if (isSubmitting) return;
 
-    if (accessCode === OWNERS_ACCESS_CODE) {
-      sessionStorage.setItem(OWNERS_ACCESS_KEY, 'true');
-      setIsSubmitting(true);
-      const delay = prefersReducedMotion ? 0 : 250;
-      window.setTimeout(() => {
-        router.replace('/owners/secure');
-      }, delay);
-      return;
+    setIsSubmitting(true);
+    setShowError(false);
+
+    try {
+      // Checked on the server. The code used to be a constant in this file and
+      // was therefore readable by anyone who viewed the page source.
+      const result = await verifyAccessCode('owners', accessCode);
+
+      if (result.ok) {
+        sessionStorage.setItem(OWNERS_ACCESS_KEY, 'true');
+        setErrorMessage('');
+        const delay = prefersReducedMotion ? 0 : 250;
+        window.setTimeout(() => {
+          router.replace('/owners/secure');
+        }, delay);
+        return;
+      }
+
+      setErrorMessage(result.error ?? '');
+      setShowError(true);
+    } catch {
+      setErrorMessage('We could not check that code. Please try again.');
+      setShowError(true);
+    } finally {
+      setIsSubmitting(false);
     }
-
-    setShowError(true);
   };
 
   return (
@@ -116,8 +133,9 @@ const OwnersPage = () => {
                   exit={{ opacity: 0, y: prefersReducedMotion ? 0 : 4 }}
                   transition={{ duration: prefersReducedMotion ? 0 : 0.2, ease: 'easeOut' }}
                   className="text-sm text-rose-600 dark:text-rose-300"
+                  role="alert"
                 >
-                  Incorrect access code.
+                  {errorMessage || 'Incorrect access code.'}
                   <br />
                   If you’re an owner and don’t have the code, please contact the factor or ask another owner.
                 </motion.p>

--- a/src/app/privacy/page.tsx
+++ b/src/app/privacy/page.tsx
@@ -1,110 +1,277 @@
 import type { Metadata } from 'next';
+import Link from 'next/link';
+
+import {
+  LEGAL_CONTACT_EMAIL,
+  LegalList,
+  LegalPage,
+  LegalSection,
+  LegalTable,
+} from '@/components/legal/LegalPage';
 
 export const metadata: Metadata = {
   title: 'Privacy Policy | James Square',
   description:
-    'Privacy Policy for the James Square community website, outlining how personal information is handled.',
+    'How the James Square community website collects, uses, stores and protects residents’ personal information, and the rights you have under UK GDPR.',
 };
 
-const lastUpdated = '20 January 2026';
+const lastUpdated = '26 July 2026';
 
 export default function PrivacyPolicyPage() {
   return (
-    <article className="mx-auto w-full max-w-3xl space-y-8 text-base leading-relaxed text-slate-700 dark:text-slate-200">
-      <header className="space-y-2">
-        <h1 className="text-3xl font-semibold text-slate-900 dark:text-slate-100">Privacy Policy</h1>
-        <p className="text-sm text-slate-500 dark:text-slate-400">Last updated: {lastUpdated}</p>
-      </header>
-
-      <section className="space-y-3">
-        <h2 className="text-xl font-semibold text-slate-900 dark:text-slate-100">About this policy</h2>
+    <LegalPage
+      currentPath="/privacy"
+      lastUpdated={lastUpdated}
+      summary="We collect the minimum needed to run a residents' portal: your name, email address, flat and whether you are an owner, renter or short-stay guest. It is used to give you access, take facility bookings, run community votes and send building updates. It is never sold, never used for advertising, and never shared outside the building except where the law requires it."
+      title="Privacy Policy"
+    >
+      <LegalSection title="Who we are and who is responsible">
         <p>
-          This Privacy Policy explains how personal information is handled on the James Square community website. The
-          site is community-run by a resident volunteer and is provided on a non-commercial basis for residents and
-          owners.
+          James-Square.com is a community website for residents and owners of James Square,
+          Caledonian Crescent, Edinburgh. It is run on a voluntary, non-commercial basis by a
+          resident on behalf of the James Square Proprietors&rsquo; Association, and is not a
+          property management company or factor.
         </p>
-      </section>
-
-      <section className="space-y-3">
-        <h2 className="text-xl font-semibold text-slate-900 dark:text-slate-100">Who runs the site</h2>
         <p>
-          The website is managed by a resident volunteer who acts as the data controller for information collected
-          through the site. This is not a commercial service and does not represent a professional management company
-          or factor.
+          For the purposes of UK GDPR the data controller is the James Square Proprietors&rsquo;
+          Association, contactable at{' '}
+          <a className="underline underline-offset-2" href={`mailto:${LEGAL_CONTACT_EMAIL}`}>
+            {LEGAL_CONTACT_EMAIL}
+          </a>
+          . We are not required to appoint a Data Protection Officer, and have not done so; privacy
+          enquiries are handled by the site administrator with the committee.
         </p>
-      </section>
+      </LegalSection>
 
-      <section className="space-y-3">
-        <h2 className="text-xl font-semibold text-slate-900 dark:text-slate-100">Information we collect</h2>
-        <p>
-          When you create an account we collect your name, email address, username, property information, resident type,
-          and login credentials. We also collect information you submit through bookings, voting, message board posts, or
-          direct communications. We may record basic technical information such as device, browser, IP address, and time
-          of access for security and audit purposes.
-        </p>
-      </section>
+      <LegalSection title="What we collect, and why">
+        <LegalTable
+          caption="Personal information collected by James Square, with the purpose and lawful basis for each"
+          headers={['What we collect', 'Why we need it', 'Lawful basis']}
+          rows={[
+            [
+              'Your name, email address, chosen username and flat number, and whether you are an owner, renter or short-stay guest',
+              'To create your account, confirm you are connected to the building, and show your name on bookings, posts and votes',
+              'Contract — we cannot give you an account without it',
+            ],
+            [
+              'Your password',
+              'To sign you in. Stored and checked by Firebase Authentication; we never see it and cannot recover it',
+              'Contract',
+            ],
+            [
+              'Facility bookings: which facility, date, time and the account that booked',
+              'To operate the pool, gym and sauna booking system and apply fair-use limits',
+              'Contract',
+            ],
+            [
+              'Message board posts, comments, replies and reactions',
+              'To run the residents’ message board',
+              'Legitimate interests — running a community noticeboard',
+            ],
+            [
+              'Votes in community and owners’ polls, including your name and flat',
+              'So each household votes once and the result can be verified',
+              'Legitimate interests — fair and auditable community decisions',
+            ],
+            [
+              'Feedback and moderation reports you submit',
+              'To respond to problems and moderate the message board',
+              'Legitimate interests',
+            ],
+            [
+              'Emails you send to the committee, and records of emails the committee sends through the site',
+              'To answer you and keep a record of what was communicated to residents',
+              'Legitimate interests',
+            ],
+            [
+              'Sign-in timestamps, and an audit log of administrative actions',
+              'To keep accounts secure and to show who changed what',
+              'Legal obligation (UK GDPR security duty) and legitimate interests',
+            ],
+            [
+              'Your cookie choices',
+              'So we honour your preferences and stop asking',
+              'Legal obligation (PECR)',
+            ],
+          ]}
+        />
 
-      <section className="space-y-3">
-        <h2 className="text-xl font-semibold text-slate-900 dark:text-slate-100">How we use your information</h2>
         <p>
-          We use personal information to manage accounts, verify resident access, operate bookings and voting, maintain
-          community communications, and keep the website secure. We do not use personal information for advertising or
-          marketing.
+          We do not ask for, and do not want, information such as your date of birth, telephone
+          number, financial details, or any special category data (health, ethnicity, beliefs and
+          so on). Please do not include such information in message board posts or emails.
         </p>
-      </section>
+        <p>
+          Where a form asks for something, the reason is stated next to the field. If you think we
+          are collecting more than we need, tell us — data minimisation is something we actively
+          check.
+        </p>
+      </LegalSection>
 
-      <section className="space-y-3">
-        <h2 className="text-xl font-semibold text-slate-900 dark:text-slate-100">Lawful bases for processing</h2>
+      <LegalSection title="Technical information">
         <p>
-          We process personal information based on legitimate interests in running a community service, and on consent
-          where you choose to provide optional information or communications. Some processing is necessary to provide
-          access to the site features you request.
+          Like any website, ours receives technical information as a by-product of serving pages:
+          your IP address, browser and device type, and the pages requested. This is used only to
+          deliver the site and to protect it against abuse — for example, temporarily counting
+          requests from an address to stop repeated guessing of an access code.
         </p>
-      </section>
+        <p>
+          We do not store IP addresses in our own database, and do not use them to build any profile
+          of you. Our hosting provider keeps short-term operational logs on our behalf.
+        </p>
+      </LegalSection>
 
-      <section className="space-y-3">
-        <h2 className="text-xl font-semibold text-slate-900 dark:text-slate-100">Sharing and disclosures</h2>
+      <LegalSection title="Who can see your information">
+        <LegalList
+          items={[
+            'Only you can see your own account profile. Other residents cannot look up your email address, flat or account details.',
+            'Your name is shown alongside anything you choose to post publicly on the message board, and alongside your vote in owners’ polls, so results can be verified.',
+            'Bookings show as “booked” to other residents. Your email address is not revealed to them.',
+            'Site administrators can see resident accounts, bookings and audit logs in order to run the site. Administrative actions are logged.',
+            'The committee can see emails sent to committee addresses, and the archive of emails sent through the site.',
+          ]}
+        />
         <p>
-          Personal information is not sold or shared with third parties for marketing. It may be shared with service
-          providers that host or secure the website, and with authorities if required by law or to protect the safety of
-          residents.
+          We do not sell personal information, and we do not share it for marketing. It is not
+          passed to the factor, to Myreside Management, or to any other organisation except where
+          you have asked us to, or where we are legally required to.
         </p>
-      </section>
+      </LegalSection>
 
-      <section className="space-y-3">
-        <h2 className="text-xl font-semibold text-slate-900 dark:text-slate-100">Storage and retention</h2>
+      <LegalSection title="Service providers">
         <p>
-          Information is stored using secure systems and is retained only as long as needed for the community purposes
-          described or while your account remains active. You can request deletion of your account, subject to any legal
-          or safety obligations.
+          A small number of companies process data on our behalf, under contract, and only on our
+          instructions:
         </p>
-      </section>
+        <LegalTable
+          caption="Processors used by James Square"
+          headers={['Provider', 'What they do', 'Where data is processed']}
+          rows={[
+            [
+              'Google (Firebase Authentication, Cloud Firestore, Cloud Functions)',
+              'Sign-in, database and server-side functions',
+              'European Union and United States, under Google’s standard contractual clauses',
+            ],
+            [
+              'Vercel',
+              'Website hosting and delivery',
+              'European Union and United States, under standard contractual clauses',
+            ],
+            [
+              'Resend',
+              'Sending emails from the site (building updates, committee mail)',
+              'European Union and United States, under standard contractual clauses',
+            ],
+          ]}
+        />
+        <p>
+          Where data reaches the United States it is protected by the safeguards named above. If you
+          would like more detail on any transfer, please ask.
+        </p>
+      </LegalSection>
 
-      <section className="space-y-3">
-        <h2 className="text-xl font-semibold text-slate-900 dark:text-slate-100">Your rights</h2>
+      <LegalSection title="How long we keep it">
         <p>
-          You have rights under UK GDPR, including access, correction, deletion, restriction, objection, and data
-          portability. You can exercise these rights by contacting the site administrator through the website. You also
-          have the right to complain to the Information Commissioner&apos;s Office (ICO).
+          Retention periods for each type of information are set out in full in our{' '}
+          <Link className="underline underline-offset-2" href="/data-retention">
+            Data Retention Policy
+          </Link>
+          . In summary: account details are kept while your account is active, bookings for two
+          years, audit logs for two years, and communications for as long as they are relevant to
+          the running of the building.
         </p>
-      </section>
+      </LegalSection>
 
-      <section className="space-y-3">
-        <h2 className="text-xl font-semibold text-slate-900 dark:text-slate-100">Cookies and similar technologies</h2>
+      <LegalSection title="How we protect it">
+        <LegalList
+          items={[
+            'All traffic is encrypted in transit (HTTPS), and the site is served only over HTTPS.',
+            'Passwords are handled by Firebase Authentication and are never visible to us.',
+            'Database rules restrict every collection so residents can read their own information and administrators can read what they need to run the site — not everything by default.',
+            'Administrative functions verify the caller’s identity and role on the server. Being able to reach a page is never treated as permission to use it.',
+            'Emails sent through the site use blind copy so recipients cannot see each other’s addresses.',
+            'Sensitive settings and keys are held as server-side environment variables and are never sent to your browser.',
+          ]}
+        />
         <p>
-          The site uses cookies or similar storage that are necessary to keep you signed in and to protect the security of
-          the service. You can control cookies through your browser settings, but some features may not function without
-          them.
+          No system is perfect. If you believe you have found a security or privacy problem, please
+          report it to{' '}
+          <a className="underline underline-offset-2" href={`mailto:${LEGAL_CONTACT_EMAIL}`}>
+            {LEGAL_CONTACT_EMAIL}
+          </a>{' '}
+          and give us a reasonable opportunity to fix it before disclosing it more widely. We will
+          not pursue anyone who reports a genuine issue in good faith.
         </p>
-      </section>
+      </LegalSection>
 
-      <section className="space-y-3">
-        <h2 className="text-xl font-semibold text-slate-900 dark:text-slate-100">Changes to this policy</h2>
+      <LegalSection title="Your rights">
+        <p>Under UK GDPR you have the right to:</p>
+        <LegalList
+          items={[
+            'Be told what we hold about you, and get a copy of it (access).',
+            'Have inaccurate information corrected (rectification).',
+            'Have your information deleted, including closing your account (erasure).',
+            'Ask us to stop or limit how we use it (restriction and objection).',
+            'Receive your information in a portable format (portability).',
+            'Withdraw consent where we rely on it — for example, your cookie choices.',
+          ]}
+        />
         <p>
-          We may update this policy to reflect changes to the site or legal requirements. Updates will be posted on this
-          page with a new &quot;Last updated&quot; date.
+          To exercise any of these, email{' '}
+          <a className="underline underline-offset-2" href={`mailto:${LEGAL_CONTACT_EMAIL}`}>
+            {LEGAL_CONTACT_EMAIL}
+          </a>
+          . We will respond within one month. There is no charge. We may ask you to confirm your
+          identity — usually by replying from the email address on the account — so that we do not
+          disclose your information to someone else.
         </p>
-      </section>
-    </article>
+        <p>
+          Some things cannot simply be erased on request. Where a vote has been counted or a
+          decision minuted, removing your record would undermine the integrity of a community
+          decision, so we may keep the minimum needed and explain why. Content that relates to a
+          safety or legal matter may also be retained.
+        </p>
+        <p>
+          If you are unhappy with how we have handled your information you can complain to the{' '}
+          <a
+            className="underline underline-offset-2"
+            href="https://ico.org.uk/make-a-complaint/"
+            rel="noopener noreferrer"
+            target="_blank"
+          >
+            Information Commissioner&rsquo;s Office
+          </a>
+          , the UK data protection regulator. We would appreciate the chance to put things right
+          first.
+        </p>
+      </LegalSection>
+
+      <LegalSection title="Children">
+        <p>
+          Accounts are intended for adult residents and owners. We do not knowingly collect
+          information from children. Where a facility booking is made for a family, it is made by
+          and recorded against the adult account holder.
+        </p>
+      </LegalSection>
+
+      <LegalSection title="Cookies">
+        <p>
+          Cookies and similar storage are covered separately in our{' '}
+          <Link className="underline underline-offset-2" href="/cookies">
+            Cookie Policy
+          </Link>
+          , which lists every cookie we set and lets you change your choices at any time.
+        </p>
+      </LegalSection>
+
+      <LegalSection title="Changes to this policy">
+        <p>
+          We will update this policy when the site changes or the law requires it. The
+          &ldquo;last updated&rdquo; date at the top always reflects the current version. If a
+          change materially affects how your information is used, we will say so on the site rather
+          than change it quietly.
+        </p>
+      </LegalSection>
+    </LegalPage>
   );
 }

--- a/src/app/reset-password/page.tsx
+++ b/src/app/reset-password/page.tsx
@@ -4,8 +4,8 @@ import { useState } from 'react';
 import { useRouter } from 'next/navigation';
 import { sendPasswordResetEmail } from 'firebase/auth';
 import { FirebaseError } from 'firebase/app';
-import { auth, db } from '@/lib/firebase';
-import { collection, query, where, getDocs } from 'firebase/firestore';
+import { auth } from '@/lib/firebase';
+import { resolveLoginEmail } from '@/lib/client/resolveIdentifier';
 
 export default function ResetPasswordPage() {
   const router = useRouter();
@@ -16,7 +16,8 @@ export default function ResetPasswordPage() {
   const [error, setError] = useState('');
 
   const resolveEmail = async (id: string): Promise<string | null> => {
-    // If it looks like an email, validate its format
+    // Validate an email locally; resolve a username through the server route,
+    // since resident profiles are no longer readable from the browser.
     if (id.includes('@')) {
       const emailPattern = /^[^\s@]+@[^\s@]+\.[^\s@]+$/;
       if (!emailPattern.test(id)) {
@@ -24,13 +25,8 @@ export default function ResetPasswordPage() {
       }
       return id;
     }
-    // Otherwise treat as username and look up
-    const q = query(
-      collection(db, 'users'),
-      where('username', '==', id.toLowerCase())
-    );
-    const snap = await getDocs(q);
-    return snap.empty ? null : (snap.docs[0].data().email as string);
+
+    return resolveLoginEmail(id);
   };
 
   const handleSubmit = async (e: React.FormEvent) => {

--- a/src/app/robots.ts
+++ b/src/app/robots.ts
@@ -1,0 +1,37 @@
+import type { MetadataRoute } from 'next';
+
+const BASE_URL = 'https://james-square.com';
+
+/**
+ * Keeps resident-facing and private areas out of search indexes.
+ *
+ * This is discouragement rather than access control — a crawler that ignores
+ * robots.txt is unaffected, which is why the underlying areas are also protected
+ * by Firestore rules, server-side checks and X-Robots-Tag headers.
+ */
+export default function robots(): MetadataRoute.Robots {
+  return {
+    rules: [
+      {
+        userAgent: '*',
+        allow: '/',
+        disallow: [
+          '/admin',
+          '/api/',
+          '/committee',
+          '/owners',
+          '/dashboard',
+          '/account',
+          '/message-board',
+          '/book/my-bookings',
+          '/login',
+          '/reset-password',
+          // Building surveys, AGM minutes and factor reports.
+          '/docs/',
+        ],
+      },
+    ],
+    sitemap: `${BASE_URL}/sitemap.xml`,
+    host: BASE_URL,
+  };
+}

--- a/src/app/terms/page.tsx
+++ b/src/app/terms/page.tsx
@@ -1,111 +1,162 @@
 import type { Metadata } from 'next';
+import Link from 'next/link';
+
+import {
+  LEGAL_CONTACT_EMAIL,
+  LegalList,
+  LegalPage,
+  LegalSection,
+} from '@/components/legal/LegalPage';
 
 export const metadata: Metadata = {
   title: 'Terms of Use | James Square',
-  description: 'Terms of Use for the James Square community website.',
+  description:
+    'The terms on which residents and owners may use the James Square community website.',
 };
 
-const lastUpdated = '20 January 2026';
+const lastUpdated = '26 July 2026';
 
 export default function TermsOfUsePage() {
   return (
-    <article className="mx-auto w-full max-w-3xl space-y-8 text-base leading-relaxed text-slate-700 dark:text-slate-200">
-      <header className="space-y-2">
-        <h1 className="text-3xl font-semibold text-slate-900 dark:text-slate-100">Terms of Use</h1>
-        <p className="text-sm text-slate-500 dark:text-slate-400">Last updated: {lastUpdated}</p>
-      </header>
-
-      <section className="space-y-3">
-        <h2 className="text-xl font-semibold text-slate-900 dark:text-slate-100">About these terms</h2>
+    <LegalPage
+      currentPath="/terms"
+      lastUpdated={lastUpdated}
+      summary="This is a volunteer-run community website for James Square residents and owners. Use it respectfully, keep your login to yourself, and remember that it supports the running of the building rather than replacing the factor or any official process."
+      title="Terms of Use"
+    >
+      <LegalSection title="About these terms">
         <p>
-          These Terms of Use govern the James Square community website. The site is community-run by a resident volunteer
-          for residents and owners. It is non-commercial and does not provide professional property management services.
+          These Terms of Use govern your use of James-Square.com. The site is run on a voluntary,
+          non-commercial basis by a resident on behalf of the James Square Proprietors&rsquo;
+          Association. It does not provide professional property management services.
         </p>
-      </section>
-
-      <section className="space-y-3">
-        <h2 className="text-xl font-semibold text-slate-900 dark:text-slate-100">Eligibility and accounts</h2>
         <p>
-          Accounts are intended for residents, owners, or short-term let guests associated with James Square. You must
-          provide accurate information and keep it up to date. You are responsible for keeping your login details secure
-          and for activity under your account.
+          By creating an account or using the site you accept these terms, our{' '}
+          <Link className="underline underline-offset-2" href="/acceptable-use">
+            Acceptable Use Policy
+          </Link>{' '}
+          and our{' '}
+          <Link className="underline underline-offset-2" href="/privacy">
+            Privacy Policy
+          </Link>
+          .
         </p>
-      </section>
+      </LegalSection>
 
-      <section className="space-y-3">
-        <h2 className="text-xl font-semibold text-slate-900 dark:text-slate-100">Community conduct</h2>
+      <LegalSection title="Eligibility and accounts">
         <p>
-          Use the website respectfully and lawfully. Harassment, abusive language, or misuse of voting, booking, or
-          messaging features is not permitted. The site administrator may remove content or restrict access to protect the
-          community.
+          Accounts are for residents, owners and short-term let guests connected with James Square.
+          When you register you must give accurate information and keep it up to date, so that
+          bookings and votes can be attributed properly.
         </p>
-      </section>
+        <LegalList
+          items={[
+            'Keep your password to yourself. Do not share your account, and do not use anyone else’s.',
+            'You are responsible for activity carried out under your account.',
+            'Shared access codes for the Owners and Committee areas are for members of those groups only. Do not pass them on.',
+            'Tell us promptly if you think your account has been accessed by someone else.',
+          ]}
+        />
+        <p>
+          You can close your account at any time by emailing{' '}
+          <a className="underline underline-offset-2" href={`mailto:${LEGAL_CONTACT_EMAIL}`}>
+            {LEGAL_CONTACT_EMAIL}
+          </a>
+          .
+        </p>
+      </LegalSection>
 
-      <section className="space-y-3">
-        <h2 className="text-xl font-semibold text-slate-900 dark:text-slate-100">Content and communications</h2>
+      <LegalSection title="Community conduct">
         <p>
-          Any content you post is your responsibility. Content that is abusive, misleading, or unlawful may be removed.
-          Messages or records related to safety or legal issues may be retained and, where appropriate, shared with
-          relevant authorities.
+          Use the website respectfully and lawfully. Harassment, abusive language, or misuse of the
+          voting, booking or messaging features is not permitted. What counts as acceptable is set
+          out in detail in the{' '}
+          <Link className="underline underline-offset-2" href="/acceptable-use">
+            Acceptable Use Policy
+          </Link>
+          . Administrators may remove content or restrict access to protect the community.
         </p>
-      </section>
+      </LegalSection>
 
-      <section className="space-y-3">
-        <h2 className="text-xl font-semibold text-slate-900 dark:text-slate-100">Availability and changes</h2>
+      <LegalSection title="Content you post">
         <p>
-          The site is provided on an &quot;as is&quot; basis and may be changed, paused, or withdrawn at any time. We aim to keep
-          information accurate but do not guarantee completeness or availability.
+          Anything you post remains your responsibility. You keep ownership of it, and by posting
+          you allow us to display it on the site to other residents for as long as it remains
+          relevant. Content that is abusive, misleading or unlawful may be removed.
         </p>
-      </section>
+        <p>
+          Posts, comments and votes carry your name so that community discussion and decisions are
+          accountable. Please treat other residents&rsquo; names and flat numbers as private — do
+          not copy them elsewhere.
+        </p>
+        <p>
+          Material relating to safety or legal matters may be retained and, where appropriate,
+          shared with the factor, insurers or the authorities.
+        </p>
+      </LegalSection>
 
-      <section className="space-y-3">
-        <h2 className="text-xl font-semibold text-slate-900 dark:text-slate-100">Bookings and community features</h2>
+      <LegalSection title="Bookings and community features">
         <p>
-          Bookings, voting, and information tools are provided to support community coordination. They do not replace
-          official building rules, factor communications, or legal obligations.
+          Bookings, voting and information tools support community coordination. They do not replace
+          official building rules, factor communications, title deeds or any legal obligation. Fair
+          use limits apply to facility bookings so that everyone gets a turn; repeatedly working
+          around them may result in bookings being cancelled.
         </p>
-      </section>
+        <p>
+          Information about the building — surveys, minutes, financial summaries — is published for
+          residents&rsquo; convenience. It is not a substitute for the official records held by the
+          factor or the Association.
+        </p>
+      </LegalSection>
 
-      <section className="space-y-3">
-        <h2 className="text-xl font-semibold text-slate-900 dark:text-slate-100">Liability</h2>
+      <LegalSection title="Availability and changes">
         <p>
-          To the fullest extent permitted by law, the site administrator is not liable for any loss, damage, or
-          inconvenience arising from use of the website, reliance on its content, or temporary unavailability. Nothing in
-          these terms limits liability for death or personal injury caused by negligence or for fraud.
+          The site is provided on an &ldquo;as is&rdquo; basis and may be changed, paused or
+          withdrawn at any time. We aim to keep information accurate but cannot guarantee
+          completeness or continuous availability. It is run by volunteers in their own time.
         </p>
-      </section>
+      </LegalSection>
 
-      <section className="space-y-3">
-        <h2 className="text-xl font-semibold text-slate-900 dark:text-slate-100">Links to other sites</h2>
+      <LegalSection title="Liability">
         <p>
-          The website may contain links to external sites for convenience. We are not responsible for their content or
-          policies.
+          To the fullest extent permitted by law, the Association and the site administrator are not
+          liable for any loss, damage or inconvenience arising from use of the website, reliance on
+          its content, or temporary unavailability. Nothing in these terms limits liability for
+          death or personal injury caused by negligence, for fraud, or for anything else that cannot
+          lawfully be excluded.
         </p>
-      </section>
+      </LegalSection>
 
-      <section className="space-y-3">
-        <h2 className="text-xl font-semibold text-slate-900 dark:text-slate-100">Termination</h2>
+      <LegalSection title="Links to other sites">
         <p>
-          Access may be suspended or removed if these terms are breached or if continued access could harm the
-          community.
+          The website links to and embeds content from other organisations for convenience. We are
+          not responsible for their content or their privacy practices. Embedded content loads only
+          if you have allowed functional cookies.
         </p>
-      </section>
+      </LegalSection>
 
-      <section className="space-y-3">
-        <h2 className="text-xl font-semibold text-slate-900 dark:text-slate-100">Governing law</h2>
+      <LegalSection title="Termination">
         <p>
-          These terms are governed by the law of Scotland, and any disputes will be subject to the exclusive
-          jurisdiction of the Scottish courts.
+          Access may be suspended or removed if these terms or the Acceptable Use Policy are
+          breached, or if continued access could harm the community. Where practical we will explain
+          why, and you may ask for the decision to be reviewed by the committee.
         </p>
-      </section>
+      </LegalSection>
 
-      <section className="space-y-3">
-        <h2 className="text-xl font-semibold text-slate-900 dark:text-slate-100">Changes to these terms</h2>
+      <LegalSection title="Governing law">
         <p>
-          We may update these terms from time to time. Updates will be posted on this page with a new &quot;Last updated&quot;
-          date.
+          These terms are governed by the law of Scotland, and any disputes are subject to the
+          exclusive jurisdiction of the Scottish courts.
         </p>
-      </section>
-    </article>
+      </LegalSection>
+
+      <LegalSection title="Changes to these terms">
+        <p>
+          We may update these terms from time to time. Updates are posted on this page with a new
+          &ldquo;last updated&rdquo; date. Continuing to use the site after a change means you
+          accept the revised terms.
+        </p>
+      </LegalSection>
+    </LegalPage>
   );
 }

--- a/src/components/Footer.tsx
+++ b/src/components/Footer.tsx
@@ -1,6 +1,8 @@
 import Image from "next/image";
 import Link from "next/link";
 
+import { CookieSettingsLink } from "@/components/consent";
+
 const contactEmails = [
   "contact@james-square.com",
   "support@james-square.com",
@@ -8,11 +10,17 @@ const contactEmails = [
 ];
 
 const quickLinks = [
-  { href: "/privacy", label: "Privacy Policy", icon: ShieldIcon },
-  { href: "/terms", label: "Terms of Use", icon: FileIcon },
   { href: "/local", label: "More Information", icon: InfoIcon },
   { href: "/message-board", label: "Message Board", icon: MessageIcon },
   { href: "/book", label: "Book Facilities", icon: CalendarIcon },
+];
+
+const legalLinks = [
+  { href: "/privacy", label: "Privacy Policy" },
+  { href: "/cookies", label: "Cookie Policy" },
+  { href: "/terms", label: "Terms of Use" },
+  { href: "/acceptable-use", label: "Acceptable Use" },
+  { href: "/data-retention", label: "Data Retention" },
 ];
 
 export default function Footer() {
@@ -20,7 +28,7 @@ export default function Footer() {
     <footer className="mt-12">
       <div className="jqs-glass rounded-t-3xl rounded-b-none border border-slate-200/60 dark:border-slate-800/60">
         <div className="max-w-6xl mx-auto px-3 sm:px-6 py-4 md:py-8">
-          <div className="grid grid-cols-[minmax(0,1fr)_minmax(0,1fr)_minmax(0,1fr)] gap-3 sm:gap-4 md:gap-10 text-[10px] sm:text-[11px] md:text-sm text-slate-600 dark:text-slate-300">
+          <div className="grid grid-cols-2 md:grid-cols-4 gap-3 sm:gap-4 md:gap-10 text-[10px] sm:text-[11px] md:text-sm text-slate-600 dark:text-slate-300">
             <section className="min-w-0 flex flex-col gap-2 md:gap-3">
               <div className="hidden md:flex items-center gap-3">
                 <LogoMark />
@@ -77,10 +85,44 @@ export default function Footer() {
                 ))}
               </ul>
             </section>
+
+            <section className="min-w-0 flex flex-col gap-2 md:gap-3">
+              <h2 className="text-[10px] font-semibold uppercase tracking-wide text-slate-500 dark:text-slate-400">
+                Privacy &amp; Legal
+              </h2>
+              <ul className="space-y-2 md:space-y-3">
+                {legalLinks.map(({ href, label }) => (
+                  <li key={href}>
+                    <Link
+                      href={href}
+                      className="flex items-center gap-1.5 rounded-lg text-slate-600 transition-colors hover:text-slate-900 dark:text-slate-300 dark:hover:text-slate-100 md:gap-2"
+                    >
+                      <ShieldIcon className="h-3.5 w-3.5 shrink-0 md:h-4 md:w-4" />
+                      <span className="break-words text-[10px] sm:text-[11px] md:text-sm leading-tight">
+                        {label}
+                      </span>
+                    </Link>
+                  </li>
+                ))}
+                <li>
+                  {/* Permanent, always-available way to review or withdraw consent. */}
+                  <CookieSettingsLink className="flex w-full items-center gap-1.5 rounded-lg text-left text-slate-600 transition-colors hover:text-slate-900 dark:text-slate-300 dark:hover:text-slate-100 md:gap-2" />
+                </li>
+              </ul>
+            </section>
           </div>
 
-          <div className="mt-4 border-t border-slate-200/70 dark:border-slate-700/60 pt-2 text-[10px] text-slate-500 dark:text-slate-400">
-            © {new Date().getFullYear()} James Square. All rights reserved.
+          <div className="mt-4 flex flex-col gap-1 border-t border-slate-200/70 dark:border-slate-700/60 pt-2 text-[10px] text-slate-500 dark:text-slate-400 sm:flex-row sm:items-center sm:justify-between">
+            <span>© {new Date().getFullYear()} James Square. All rights reserved.</span>
+            <span>
+              Privacy enquiries:{" "}
+              <a
+                className="underline underline-offset-2 transition-colors hover:text-slate-700 dark:hover:text-slate-200"
+                href="mailto:privacy@james-square.com"
+              >
+                privacy@james-square.com
+              </a>
+            </span>
           </div>
         </div>
       </div>
@@ -148,23 +190,6 @@ function ShieldIcon({ className }: { className?: string }) {
   );
 }
 
-function FileIcon({ className }: { className?: string }) {
-  return (
-    <svg
-      className={className}
-      viewBox="0 0 24 24"
-      fill="none"
-      stroke="currentColor"
-      strokeWidth={1.5}
-      strokeLinecap="round"
-      strokeLinejoin="round"
-      aria-hidden="true"
-    >
-      <path d="M14 3H6a2 2 0 0 0-2 2v14a2 2 0 0 0 2 2h12a2 2 0 0 0 2-2V9l-6-6Z" />
-      <path d="M14 3v6h6" />
-    </svg>
-  );
-}
 
 function InfoIcon({ className }: { className?: string }) {
   return (

--- a/src/components/Header.tsx
+++ b/src/components/Header.tsx
@@ -6,7 +6,7 @@ import { usePathname } from "next/navigation";
 import { useEffect, useRef, useState } from "react";
 import { onAuthStateChanged, signOut, User } from "firebase/auth";
 import { auth, db } from "@/lib/firebase";
-import { collection, doc, getDocs, onSnapshot, query, where, DocumentData, type Timestamp } from "firebase/firestore";
+import { doc, getDoc, onSnapshot, DocumentData, type Timestamp } from "firebase/firestore";
 import { motion } from "framer-motion";
 import { getUnreadMessageBoardCount } from "@/lib/messageBoardNotifications";
 import { lightHaptic } from "@/lib/haptics";
@@ -60,9 +60,11 @@ export default function Header() {
         return;
       }
       try {
-        const qUsers = query(collection(db, "users"), where("email", "==", u.email));
-        const snap = await getDocs(qUsers);
-        const docData = snap.docs[0]?.data() as UserDoc | undefined;
+        // Read the profile directly by uid. The previous email query needed the
+        // whole /users collection to be listable, which is what made every
+        // resident's details readable by anyone.
+        const snap = await getDoc(doc(db, "users", u.uid));
+        const docData = snap.data() as UserDoc | undefined;
 
         setUserName(docData?.fullName || u.displayName || "");
         setIsAdmin(Boolean(docData?.isAdmin));

--- a/src/components/MessageBoard/MessageBoardHighlights.tsx
+++ b/src/components/MessageBoard/MessageBoardHighlights.tsx
@@ -2,6 +2,7 @@
 
 import { useEffect, useState } from 'react';
 import Link from 'next/link';
+import { auth } from '@/lib/firebase';
 import { Post } from './types';
 
 export default function MessageBoardHighlights({ limit = 3 }: { limit?: number }) {
@@ -10,7 +11,16 @@ export default function MessageBoardHighlights({ limit = 3 }: { limit?: number }
   useEffect(() => {
     const load = async () => {
       try {
-        const res = await fetch(`/api/message-board?limit=${limit}`);
+        // The board is residents-only, so the request must be authenticated.
+        const token = await auth.currentUser?.getIdToken();
+        if (!token) {
+          setPosts([]);
+          return;
+        }
+
+        const res = await fetch(`/api/message-board?limit=${limit}`, {
+          headers: { Authorization: `Bearer ${token}` },
+        });
         if (res.ok) {
           const data: { posts: Post[] } = await res.json();
           setPosts(data.posts || []);

--- a/src/components/committee/PreviouslySentEmails.tsx
+++ b/src/components/committee/PreviouslySentEmails.tsx
@@ -2,6 +2,8 @@
 
 import { useState } from 'react';
 
+import { sanitizeHtml } from '@/lib/sanitizeHtml';
+
 export type SentEmail = {
   id: string;
   subject: string;
@@ -68,9 +70,12 @@ export default function PreviouslySentEmails({ emails }: PreviouslySentEmailsPro
               {isOpen ? (
                 <div className="rounded-2xl border border-white/10 bg-slate-100/80 p-4 shadow-inner dark:bg-slate-900/60">
                   <div className="max-h-96 overflow-auto">
+                    {/* Sanitised again at render time. The stored copy was
+                        sanitised when it was sent, but archives outlive the code
+                        that wrote them, so this must not trust its own history. */}
                     <div
                       className="mx-auto w-full max-w-3xl"
-                      dangerouslySetInnerHTML={{ __html: email.html }}
+                      dangerouslySetInnerHTML={{ __html: sanitizeHtml(email.html) }}
                     />
                   </div>
                 </div>

--- a/src/components/consent/ConsentGate.tsx
+++ b/src/components/consent/ConsentGate.tsx
@@ -1,0 +1,58 @@
+'use client';
+
+import type { ReactNode } from 'react';
+
+import type { ConsentCategory } from '@/lib/consent/types';
+
+import { useConsent } from './ConsentProvider';
+import { getCategoryInfo } from '@/lib/consent/categories';
+
+/**
+ * Wraps anything that must not load before consent — a Google Map, a Vimeo or
+ * social embed, a future AI assistant. Until consent exists the children are
+ * never rendered, so no third-party request is made at all.
+ *
+ *   <ConsentGate category="functional" label="Google Maps">
+ *     <iframe src="https://www.google.com/maps/embed?..." />
+ *   </ConsentGate>
+ */
+export default function ConsentGate({
+  category,
+  children,
+  label,
+  fallback,
+  className,
+}: {
+  category: ConsentCategory;
+  children: ReactNode;
+  /** Name of the embedded service, shown in the placeholder. */
+  label: string;
+  /** Custom placeholder. Defaults to a glass panel offering to enable it. */
+  fallback?: ReactNode;
+  className?: string;
+}) {
+  const { hasConsent, openPreferences } = useConsent();
+
+  if (hasConsent(category)) {
+    return <>{children}</>;
+  }
+
+  if (fallback !== undefined) return <>{fallback}</>;
+
+  const info = getCategoryInfo(category);
+
+  return (
+    <div
+      className={`consent-surface flex flex-col items-center justify-center gap-3 p-6 text-center ${className ?? ''}`}
+    >
+      <p className="text-sm font-medium text-[color:var(--text-primary)]">{label} is switched off</p>
+      <p className="max-w-sm text-xs leading-relaxed text-[color:var(--text-secondary)]">
+        This content is provided by {label} and is only loaded once you allow{' '}
+        {info.label.toLowerCase()} cookies. Nothing is requested from them until you do.
+      </p>
+      <button className="consent-btn consent-btn--secondary" onClick={openPreferences} type="button">
+        Cookie Preferences
+      </button>
+    </div>
+  );
+}

--- a/src/components/consent/ConsentProvider.tsx
+++ b/src/components/consent/ConsentProvider.tsx
@@ -1,0 +1,117 @@
+'use client';
+
+import {
+  createContext,
+  useCallback,
+  useContext,
+  useEffect,
+  useMemo,
+  useState,
+  type ReactNode,
+} from 'react';
+
+import { reconcileConsentServices } from '@/lib/consent/registry';
+import {
+  acceptAll as storeAcceptAll,
+  acceptEssentialOnly as storeAcceptEssentialOnly,
+  getConsentState,
+  hydrateConsent,
+  savePreferences as storeSavePreferences,
+  subscribeToConsent,
+  withdrawConsent as storeWithdrawConsent,
+  type ConsentState,
+} from '@/lib/consent/store';
+import type { ConsentCategory, ConsentDecisions } from '@/lib/consent/types';
+
+type ConsentContextValue = ConsentState & {
+  /** True when the banner should be shown: hydrated, with no valid decision. */
+  needsDecision: boolean;
+  isPreferencesOpen: boolean;
+  openPreferences: () => void;
+  closePreferences: () => void;
+  acceptAll: () => void;
+  acceptEssentialOnly: () => void;
+  savePreferences: (decisions: Partial<Record<ConsentCategory, boolean>>) => void;
+  withdrawConsent: () => void;
+  hasConsent: (category: ConsentCategory) => boolean;
+};
+
+const ConsentContext = createContext<ConsentContextValue | null>(null);
+
+/** Custom event so a plain anchor anywhere can open the panel without prop drilling. */
+export const OPEN_PREFERENCES_EVENT = 'js:open-cookie-preferences';
+
+export function ConsentProvider({ children }: { children: ReactNode }) {
+  const [state, setState] = useState<ConsentState>(() => getConsentState());
+  const [isPreferencesOpen, setPreferencesOpen] = useState(false);
+
+  useEffect(() => {
+    // Subscribe before hydrating so we never miss the first transition.
+    const unsubscribe = subscribeToConsent(setState);
+    setState(hydrateConsent());
+    reconcileConsentServices();
+    return unsubscribe;
+  }, []);
+
+  const openPreferences = useCallback(() => setPreferencesOpen(true), []);
+  const closePreferences = useCallback(() => setPreferencesOpen(false), []);
+
+  useEffect(() => {
+    const handler = () => openPreferences();
+    window.addEventListener(OPEN_PREFERENCES_EVENT, handler);
+    return () => window.removeEventListener(OPEN_PREFERENCES_EVENT, handler);
+  }, [openPreferences]);
+
+  const value = useMemo<ConsentContextValue>(() => {
+    const decisions: ConsentDecisions = state.decisions;
+
+    return {
+      ...state,
+      needsDecision: state.hydrated && state.record === null,
+      isPreferencesOpen,
+      openPreferences,
+      closePreferences,
+      acceptAll: () => {
+        storeAcceptAll();
+        setPreferencesOpen(false);
+      },
+      acceptEssentialOnly: () => {
+        storeAcceptEssentialOnly();
+        setPreferencesOpen(false);
+      },
+      savePreferences: (next) => {
+        storeSavePreferences(next);
+        setPreferencesOpen(false);
+      },
+      withdrawConsent: () => {
+        storeWithdrawConsent();
+        setPreferencesOpen(false);
+      },
+      hasConsent: (category) => category === 'essential' || decisions[category] === true,
+    };
+  }, [state, isPreferencesOpen, openPreferences, closePreferences]);
+
+  return <ConsentContext.Provider value={value}>{children}</ConsentContext.Provider>;
+}
+
+export function useConsent(): ConsentContextValue {
+  const context = useContext(ConsentContext);
+  if (!context) {
+    throw new Error('useConsent must be used inside <ConsentProvider>');
+  }
+  return context;
+}
+
+/**
+ * Convenience hook for gating a single feature:
+ *   const canEmbed = useConsentFor('functional');
+ */
+export function useConsentFor(category: ConsentCategory): boolean {
+  return useConsent().hasConsent(category);
+}
+
+/** Opens the preferences panel from anywhere, including non-React code. */
+export function openCookiePreferences() {
+  if (typeof window === 'undefined') return;
+  window.dispatchEvent(new Event(OPEN_PREFERENCES_EVENT));
+}

--- a/src/components/consent/ConsentSurface.tsx
+++ b/src/components/consent/ConsentSurface.tsx
@@ -1,0 +1,24 @@
+'use client';
+
+import { useEffect } from 'react';
+
+import { registerSiteConsentServices } from '@/lib/consent/services';
+
+import CookieConsentBanner from './CookieConsentBanner';
+import CookiePreferencesPanel from './CookiePreferencesPanel';
+
+/**
+ * Single mount point for the consent experience. Registering the site's
+ * services here — rather than at import time — keeps the registry a
+ * client-only, post-hydration concern.
+ */
+export default function ConsentSurface() {
+  useEffect(() => registerSiteConsentServices(), []);
+
+  return (
+    <>
+      <CookieConsentBanner />
+      <CookiePreferencesPanel />
+    </>
+  );
+}

--- a/src/components/consent/CookieConsentBanner.tsx
+++ b/src/components/consent/CookieConsentBanner.tsx
@@ -1,0 +1,131 @@
+'use client';
+
+import Link from 'next/link';
+import { AnimatePresence, motion, useReducedMotion } from 'framer-motion';
+import { useEffect, useRef } from 'react';
+
+import { useConsent } from './ConsentProvider';
+import CookieIcon from './CookieIcon';
+
+const EASE_OUT = [0.16, 1, 0.3, 1] as const;
+
+/**
+ * The floating consent panel.
+ *
+ * Rendered only when there is genuinely no decision on file, so returning
+ * visitors never see it. It is a polite `region`, not an alert dialog: it does
+ * not trap focus or block the page, because forcing a choice before the site
+ * can be read is exactly the pattern the ICO objects to.
+ */
+export default function CookieConsentBanner() {
+  const { needsDecision, acceptAll, acceptEssentialOnly, openPreferences, isPreferencesOpen } =
+    useConsent();
+  const prefersReducedMotion = useReducedMotion();
+  const acceptRef = useRef<HTMLButtonElement>(null);
+
+  // Let keyboard users jump straight to the choice without hunting for it,
+  // while leaving pointer users' focus exactly where it was.
+  useEffect(() => {
+    if (!needsDecision) return;
+
+    const onKeyDown = (event: KeyboardEvent) => {
+      if (event.key === 'Escape') {
+        // Escape is not consent, and it is not refusal. Open the full panel so
+        // the visitor still has an explicit way to decide.
+        openPreferences();
+      }
+    };
+
+    window.addEventListener('keydown', onKeyDown);
+    return () => window.removeEventListener('keydown', onKeyDown);
+  }, [needsDecision, openPreferences]);
+
+  const show = needsDecision && !isPreferencesOpen;
+
+  return (
+    <AnimatePresence>
+      {show && (
+        <motion.div
+          className="consent-dock pointer-events-none fixed inset-x-0 bottom-0 z-[60] flex justify-center px-3 sm:px-6"
+          initial={prefersReducedMotion ? { opacity: 0 } : { opacity: 0, y: 28, scale: 0.97 }}
+          animate={prefersReducedMotion ? { opacity: 1 } : { opacity: 1, y: 0, scale: 1 }}
+          exit={prefersReducedMotion ? { opacity: 0 } : { opacity: 0, y: 20, scale: 0.98 }}
+          transition={{ duration: prefersReducedMotion ? 0.01 : 0.5, ease: EASE_OUT }}
+        >
+          <section
+            aria-labelledby="consent-banner-title"
+            aria-describedby="consent-banner-description"
+            className="consent-surface pointer-events-auto w-full max-w-2xl p-5 sm:p-6"
+            role="region"
+          >
+            <div className="flex items-start gap-3.5 sm:gap-4">
+              <span
+                className="mt-0.5 flex h-10 w-10 shrink-0 items-center justify-center rounded-2xl border text-[color:var(--text-secondary)]"
+                style={{
+                  borderColor: 'hsl(var(--glass-border))',
+                  background: 'color-mix(in srgb, var(--glass-bg-light) 70%, transparent)',
+                }}
+              >
+                <CookieIcon className="h-5 w-5" />
+              </span>
+
+              <div className="min-w-0 space-y-2">
+                <h2
+                  className="text-base font-semibold text-[color:var(--text-primary)]"
+                  id="consent-banner-title"
+                >
+                  A note about cookies
+                </h2>
+                <p
+                  className="text-sm leading-relaxed text-[color:var(--text-secondary)]"
+                  id="consent-banner-description"
+                >
+                  James Square uses a small number of essential cookies to keep you signed in and
+                  the site secure. With your permission we would also like to measure which pages
+                  residents find useful, so we can improve them. We run no advertising and never
+                  sell your information.{' '}
+                  <Link
+                    className="underline decoration-[color:var(--glass-border)] underline-offset-2 transition-colors hover:text-[color:var(--text-primary)]"
+                    href="/cookies"
+                  >
+                    Read our Cookie Policy
+                  </Link>
+                  .
+                </p>
+              </div>
+            </div>
+
+            <div className="mt-5 flex flex-col gap-2.5 sm:flex-row sm:items-center sm:justify-between">
+              <button
+                className="consent-btn consent-btn--ghost order-3 sm:order-1"
+                onClick={openPreferences}
+                type="button"
+              >
+                Cookie Preferences
+              </button>
+
+              {/* See the preferences panel: Accept All leads the stack on phones. */}
+              <div className="flex flex-col-reverse gap-2.5 sm:order-2 sm:flex-row sm:items-center">
+                <button
+                  className="consent-btn consent-btn--secondary"
+                  onClick={acceptEssentialOnly}
+                  type="button"
+                >
+                  Essential Only
+                </button>
+                <button
+                  className="consent-btn consent-btn--primary"
+                  onClick={acceptAll}
+                  ref={acceptRef}
+                  type="button"
+                >
+                  Accept All
+                </button>
+              </div>
+            </div>
+          </section>
+        </motion.div>
+      )}
+    </AnimatePresence>
+  );
+}

--- a/src/components/consent/CookieIcon.tsx
+++ b/src/components/consent/CookieIcon.tsx
@@ -1,0 +1,32 @@
+'use client';
+
+/**
+ * A small cookie mark drawn to sit alongside the site's other line icons —
+ * 1.5 stroke, rounded caps, no fill. The crumbs drift very slightly (see
+ * .consent-icon) which stops the panel feeling static without demanding
+ * attention.
+ */
+export default function CookieIcon({ className }: { className?: string }) {
+  return (
+    <svg
+      className={className}
+      viewBox="0 0 24 24"
+      fill="none"
+      stroke="currentColor"
+      strokeWidth={1.5}
+      strokeLinecap="round"
+      strokeLinejoin="round"
+      aria-hidden="true"
+      focusable="false"
+    >
+      <path d="M21 12a9 9 0 1 1-9-9 3.6 3.6 0 0 0 3.6 3.6A2.4 2.4 0 0 0 18 9a3 3 0 0 0 3 3Z" />
+      <g className="consent-icon">
+        <path d="M8.5 9.5h.01" />
+        <path d="M12 14h.01" />
+        <path d="M7.5 14.5h.01" />
+        <path d="M15.5 15.5h.01" />
+        <path d="M11 10.5h.01" />
+      </g>
+    </svg>
+  );
+}

--- a/src/components/consent/CookiePreferencesPanel.tsx
+++ b/src/components/consent/CookiePreferencesPanel.tsx
@@ -1,0 +1,419 @@
+'use client';
+
+import Link from 'next/link';
+import { AnimatePresence, motion, useReducedMotion } from 'framer-motion';
+import { useCallback, useEffect, useId, useMemo, useRef, useState } from 'react';
+import { createPortal } from 'react-dom';
+
+import { CONSENT_CATEGORY_INFO } from '@/lib/consent/categories';
+import type { ConsentCategory } from '@/lib/consent/types';
+
+import { useConsent } from './ConsentProvider';
+import CookieIcon from './CookieIcon';
+
+const EASE_OUT = [0.16, 1, 0.3, 1] as const;
+
+const FOCUSABLE =
+  'a[href], button:not([disabled]), input:not([disabled]), select:not([disabled]), textarea:not([disabled]), [tabindex]:not([tabindex="-1"])';
+
+export default function CookiePreferencesPanel() {
+  const {
+    isPreferencesOpen,
+    closePreferences,
+    decisions,
+    record,
+    acceptAll,
+    savePreferences,
+    withdrawConsent,
+  } = useConsent();
+  const prefersReducedMotion = useReducedMotion();
+  const [mounted, setMounted] = useState(false);
+
+  useEffect(() => setMounted(true), []);
+
+  if (!mounted) return null;
+
+  return createPortal(
+    <AnimatePresence>
+      {isPreferencesOpen && (
+        <PreferencesDialog
+          decisions={decisions}
+          key="cookie-preferences"
+          onAcceptAll={acceptAll}
+          onClose={closePreferences}
+          onSave={savePreferences}
+          onWithdraw={withdrawConsent}
+          prefersReducedMotion={Boolean(prefersReducedMotion)}
+          lastDecidedAt={record?.decidedAt ?? null}
+        />
+      )}
+    </AnimatePresence>,
+    document.body,
+  );
+}
+
+type DialogProps = {
+  decisions: Record<ConsentCategory, boolean>;
+  lastDecidedAt: string | null;
+  prefersReducedMotion: boolean;
+  onClose: () => void;
+  onSave: (next: Partial<Record<ConsentCategory, boolean>>) => void;
+  onAcceptAll: () => void;
+  onWithdraw: () => void;
+};
+
+function PreferencesDialog({
+  decisions,
+  lastDecidedAt,
+  prefersReducedMotion,
+  onClose,
+  onSave,
+  onAcceptAll,
+  onWithdraw,
+}: DialogProps) {
+  const titleId = useId();
+  const descriptionId = useId();
+  const dialogRef = useRef<HTMLDivElement>(null);
+  const previouslyFocused = useRef<HTMLElement | null>(null);
+
+  // Working copy, so nothing is written until the visitor commits.
+  const [draft, setDraft] = useState<Record<ConsentCategory, boolean>>(() => ({ ...decisions }));
+
+  const toggle = useCallback((category: ConsentCategory) => {
+    setDraft((current) => ({ ...current, [category]: !current[category] }));
+  }, []);
+
+  const setAll = useCallback((value: boolean) => {
+    setDraft(() =>
+      CONSENT_CATEGORY_INFO.reduce(
+        (acc, category) => {
+          acc[category.id] = category.required ? true : value;
+          return acc;
+        },
+        {} as Record<ConsentCategory, boolean>,
+      ),
+    );
+  }, []);
+
+  // Focus management: remember what had focus, move into the dialog, restore on close.
+  useEffect(() => {
+    previouslyFocused.current = document.activeElement as HTMLElement | null;
+    const first = dialogRef.current?.querySelector<HTMLElement>(FOCUSABLE);
+    first?.focus();
+
+    return () => previouslyFocused.current?.focus?.();
+  }, []);
+
+  // Escape closes; Tab is contained within the dialog.
+  useEffect(() => {
+    const onKeyDown = (event: KeyboardEvent) => {
+      if (event.key === 'Escape') {
+        event.stopPropagation();
+        onClose();
+        return;
+      }
+
+      if (event.key !== 'Tab') return;
+
+      const focusable = Array.from(
+        dialogRef.current?.querySelectorAll<HTMLElement>(FOCUSABLE) ?? [],
+      ).filter((element) => element.offsetParent !== null || element === document.activeElement);
+
+      if (focusable.length === 0) return;
+
+      const first = focusable[0];
+      const last = focusable[focusable.length - 1];
+
+      if (event.shiftKey && document.activeElement === first) {
+        event.preventDefault();
+        last.focus();
+      } else if (!event.shiftKey && document.activeElement === last) {
+        event.preventDefault();
+        first.focus();
+      }
+    };
+
+    document.addEventListener('keydown', onKeyDown, true);
+    return () => document.removeEventListener('keydown', onKeyDown, true);
+  }, [onClose]);
+
+  // Prevent the page behind from scrolling, without the layout shift that
+  // setting `overflow: hidden` alone would cause on desktop scrollbars.
+  useEffect(() => {
+    const { body } = document;
+    const previousOverflow = body.style.overflow;
+    const previousPadding = body.style.paddingRight;
+    const scrollbar = window.innerWidth - document.documentElement.clientWidth;
+
+    body.style.overflow = 'hidden';
+    if (scrollbar > 0) body.style.paddingRight = `${scrollbar}px`;
+
+    return () => {
+      body.style.overflow = previousOverflow;
+      body.style.paddingRight = previousPadding;
+    };
+  }, []);
+
+  const lastReviewed = useMemo(() => {
+    if (!lastDecidedAt) return null;
+    try {
+      return new Intl.DateTimeFormat('en-GB', {
+        day: 'numeric',
+        month: 'long',
+        year: 'numeric',
+      }).format(new Date(lastDecidedAt));
+    } catch {
+      return null;
+    }
+  }, [lastDecidedAt]);
+
+  return (
+    <div className="consent-modal-root fixed inset-0 z-[70] flex items-end justify-center sm:items-center">
+      <motion.div
+        animate={{ opacity: 1 }}
+        aria-hidden="true"
+        className="consent-scrim absolute inset-0"
+        exit={{ opacity: 0 }}
+        initial={{ opacity: 0 }}
+        onClick={onClose}
+        transition={{ duration: prefersReducedMotion ? 0.01 : 0.3, ease: 'easeOut' }}
+      />
+
+      <motion.div
+        animate={prefersReducedMotion ? { opacity: 1 } : { opacity: 1, y: 0, scale: 1 }}
+        aria-describedby={descriptionId}
+        aria-labelledby={titleId}
+        aria-modal="true"
+        // Presented as a bottom sheet on phones and a centred card from `sm` up.
+        // The sheet keeps square bottom corners so it reads as anchored to the
+        // edge of the screen rather than floating just off it.
+        className="consent-surface relative m-0 flex max-h-[92dvh] w-full max-w-2xl flex-col overflow-hidden rounded-b-none pb-[env(safe-area-inset-bottom)] sm:m-6 sm:rounded-[1.75rem] sm:pb-0"
+        exit={prefersReducedMotion ? { opacity: 0 } : { opacity: 0, y: 24, scale: 0.98 }}
+        initial={prefersReducedMotion ? { opacity: 0 } : { opacity: 0, y: 32, scale: 0.97 }}
+        ref={dialogRef}
+        role="dialog"
+        transition={{ duration: prefersReducedMotion ? 0.01 : 0.45, ease: EASE_OUT }}
+      >
+        <header className="flex items-start gap-3.5 px-5 pb-4 pt-5 sm:px-7 sm:pt-6">
+          <span
+            className="mt-0.5 flex h-10 w-10 shrink-0 items-center justify-center rounded-2xl border text-[color:var(--text-secondary)]"
+            style={{
+              borderColor: 'hsl(var(--glass-border))',
+              background: 'color-mix(in srgb, var(--glass-bg-light) 70%, transparent)',
+            }}
+          >
+            <CookieIcon className="h-5 w-5" />
+          </span>
+
+          <div className="min-w-0 flex-1 space-y-1.5">
+            <h2
+              className="text-lg font-semibold text-[color:var(--text-primary)]"
+              id={titleId}
+            >
+              Cookie Preferences
+            </h2>
+            <p
+              className="text-sm leading-relaxed text-[color:var(--text-secondary)]"
+              id={descriptionId}
+            >
+              Choose what James Square is allowed to store on your device. Nothing optional runs
+              until you turn it on, and you can change your mind at any time.
+            </p>
+          </div>
+
+          <button
+            aria-label="Close cookie preferences"
+            className="consent-btn consent-btn--ghost -mr-2 -mt-1 !px-2 !py-2"
+            onClick={onClose}
+            type="button"
+          >
+            <svg
+              aria-hidden="true"
+              className="h-4 w-4"
+              fill="none"
+              stroke="currentColor"
+              strokeLinecap="round"
+              strokeLinejoin="round"
+              strokeWidth={1.75}
+              viewBox="0 0 24 24"
+            >
+              <path d="M18 6 6 18" />
+              <path d="m6 6 12 12" />
+            </svg>
+          </button>
+        </header>
+
+        <div
+          className="min-h-0 flex-1 overflow-y-auto overscroll-contain border-t px-5 py-4 sm:px-7"
+          style={{ borderColor: 'hsl(var(--glass-border))' }}
+        >
+          <ul className="space-y-3">
+            {CONSENT_CATEGORY_INFO.map((category) => (
+              <CategoryRow
+                checked={category.required ? true : draft[category.id] === true}
+                info={category}
+                key={category.id}
+                onToggle={() => toggle(category.id)}
+              />
+            ))}
+          </ul>
+
+          <p className="mt-5 text-xs leading-relaxed text-[color:var(--text-secondary)]">
+            Full detail of every cookie, how long it lasts and who provides it is set out in our{' '}
+            <Link className="underline underline-offset-2" href="/cookies">
+              Cookie Policy
+            </Link>
+            . How we handle personal information is covered in the{' '}
+            <Link className="underline underline-offset-2" href="/privacy">
+              Privacy Policy
+            </Link>
+            .
+            {lastReviewed ? (
+              <>
+                {' '}
+                Your current choices were saved on {lastReviewed}.
+              </>
+            ) : null}
+          </p>
+        </div>
+
+        <footer
+          className="border-t px-5 py-4 sm:px-7"
+          style={{ borderColor: 'hsl(var(--glass-border))' }}
+        >
+          <div className="flex flex-col gap-2.5 sm:flex-row sm:items-center sm:justify-between">
+            <button
+              className="consent-btn consent-btn--ghost order-3 !px-3 sm:order-1"
+              onClick={() => {
+                setAll(false);
+                onSave({});
+              }}
+              type="button"
+            >
+              Reject Optional Cookies
+            </button>
+
+            {/* column-reverse on phones puts Accept All at the top of the stack,
+                nearest the thumb; from `sm` it becomes secondary-then-primary. */}
+            <div className="flex flex-col-reverse gap-2.5 sm:order-2 sm:flex-row sm:items-center">
+              <button
+                className="consent-btn consent-btn--secondary"
+                onClick={() => onSave(draft)}
+                type="button"
+              >
+                Save Preferences
+              </button>
+              <button
+                className="consent-btn consent-btn--primary"
+                onClick={() => {
+                  setAll(true);
+                  onAcceptAll();
+                }}
+                type="button"
+              >
+                Accept All
+              </button>
+            </div>
+          </div>
+
+          {lastReviewed ? (
+            <button
+              className="mt-3 text-xs text-[color:var(--text-secondary)] underline underline-offset-2 transition-colors hover:text-[color:var(--text-primary)]"
+              onClick={onWithdraw}
+              type="button"
+            >
+              Withdraw consent and forget my choices
+            </button>
+          ) : null}
+        </footer>
+      </motion.div>
+    </div>
+  );
+}
+
+function CategoryRow({
+  info,
+  checked,
+  onToggle,
+}: {
+  info: (typeof CONSENT_CATEGORY_INFO)[number];
+  checked: boolean;
+  onToggle: () => void;
+}) {
+  const inputId = useId();
+  const detailsId = useId();
+
+  return (
+    <li
+      className="rounded-2xl border p-4"
+      style={{
+        borderColor: 'hsl(var(--glass-border))',
+        background: 'color-mix(in srgb, var(--glass-bg-light) 55%, transparent)',
+      }}
+    >
+      <div className="flex items-start justify-between gap-4">
+        <div className="min-w-0 space-y-1">
+          <div className="flex flex-wrap items-center gap-2">
+            <span className="text-sm font-semibold text-[color:var(--text-primary)]">
+              {info.label}
+            </span>
+            <span
+              className="rounded-full border px-2 py-0.5 text-[10px] font-medium uppercase tracking-wide text-[color:var(--text-secondary)]"
+              style={{ borderColor: 'hsl(var(--glass-border))' }}
+            >
+              {info.required ? 'Always on' : 'Optional'}
+            </span>
+          </div>
+          <p className="text-xs leading-relaxed text-[color:var(--text-secondary)]">
+            {info.summary}
+          </p>
+        </div>
+
+        {/* The input is the control; the span is only its skin. Screen readers
+            and keyboards therefore get a plain checkbox. */}
+        <span className="shrink-0 pt-0.5">
+          <input
+            aria-describedby={detailsId}
+            checked={checked}
+            className="consent-toggle-input sr-only"
+            disabled={info.required}
+            id={inputId}
+            onChange={onToggle}
+            type="checkbox"
+          />
+          <label className="consent-toggle" htmlFor={inputId}>
+            <span className="consent-toggle__knob" />
+            <span className="sr-only">
+              {info.required
+                ? `${info.label} cookies are required and cannot be switched off`
+                : `Allow ${info.label.toLowerCase()} cookies`}
+            </span>
+          </label>
+        </span>
+      </div>
+
+      <dl className="mt-3 space-y-2 text-xs leading-relaxed" id={detailsId}>
+        <div>
+          <dt className="font-medium text-[color:var(--text-primary)]">What these do</dt>
+          <dd className="mt-1">
+            <ul className="list-disc space-y-0.5 pl-4 text-[color:var(--text-secondary)]">
+              {info.examples.map((example) => (
+                <li key={example}>{example}</li>
+              ))}
+            </ul>
+          </dd>
+        </div>
+        <div>
+          <dt className="font-medium text-[color:var(--text-primary)]">
+            Does this store personal information?
+          </dt>
+          <dd className="mt-1 text-[color:var(--text-secondary)]">{info.personalData}</dd>
+        </div>
+        <div>
+          <dt className="font-medium text-[color:var(--text-primary)]">How long it lasts</dt>
+          <dd className="mt-1 text-[color:var(--text-secondary)]">{info.storageDuration}</dd>
+        </div>
+      </dl>
+    </li>
+  );
+}

--- a/src/components/consent/CookieSettingsLink.tsx
+++ b/src/components/consent/CookieSettingsLink.tsx
@@ -1,0 +1,26 @@
+'use client';
+
+import CookieIcon from './CookieIcon';
+import { openCookiePreferences } from './ConsentProvider';
+
+/**
+ * The permanent footer entry point. Deliberately not using `useConsent`, so it
+ * can sit anywhere in the tree — it dispatches the same event the provider
+ * listens for, rather than requiring context.
+ */
+export default function CookieSettingsLink({
+  className,
+  showIcon = true,
+}: {
+  className?: string;
+  showIcon?: boolean;
+}) {
+  return (
+    <button className={className} onClick={openCookiePreferences} type="button">
+      {showIcon ? <CookieIcon className="h-3.5 w-3.5 shrink-0 md:h-4 md:w-4" /> : null}
+      <span className="break-words text-[10px] sm:text-[11px] md:text-sm leading-tight">
+        Cookie Settings
+      </span>
+    </button>
+  );
+}

--- a/src/components/consent/index.ts
+++ b/src/components/consent/index.ts
@@ -1,0 +1,11 @@
+export {
+  ConsentProvider,
+  useConsent,
+  useConsentFor,
+  openCookiePreferences,
+} from './ConsentProvider';
+export { default as CookieConsentBanner } from './CookieConsentBanner';
+export { default as CookiePreferencesPanel } from './CookiePreferencesPanel';
+export { default as CookieSettingsLink } from './CookieSettingsLink';
+export { default as ConsentGate } from './ConsentGate';
+export { default as ConsentSurface } from './ConsentSurface';

--- a/src/components/legal/LegalPage.tsx
+++ b/src/components/legal/LegalPage.tsx
@@ -1,0 +1,173 @@
+import Link from 'next/link';
+import type { ReactNode } from 'react';
+
+/**
+ * Shared shell for the privacy and legal documents, so all five read as one set
+ * and inherit the site's glass surfaces rather than looking like pasted text.
+ */
+
+export const LEGAL_CONTACT_EMAIL = 'privacy@james-square.com';
+
+const OTHER_DOCUMENTS = [
+  { href: '/privacy', label: 'Privacy Policy' },
+  { href: '/cookies', label: 'Cookie Policy' },
+  { href: '/terms', label: 'Terms of Use' },
+  { href: '/acceptable-use', label: 'Acceptable Use' },
+  { href: '/data-retention', label: 'Data Retention' },
+];
+
+export function LegalPage({
+  title,
+  summary,
+  lastUpdated,
+  currentPath,
+  children,
+}: {
+  title: string;
+  /** One-paragraph plain-English précis, shown above the document proper. */
+  summary: string;
+  lastUpdated: string;
+  currentPath: string;
+  children: ReactNode;
+}) {
+  return (
+    <article className="mx-auto w-full max-w-3xl space-y-8">
+      <header className="space-y-4">
+        <h1 className="text-3xl font-semibold text-[color:var(--text-primary)] sm:text-4xl">
+          {title}
+        </h1>
+        <p className="text-sm text-[color:var(--text-secondary)]">Last updated: {lastUpdated}</p>
+        <div
+          className="rounded-2xl border p-4 text-sm leading-relaxed text-[color:var(--text-secondary)]"
+          style={{
+            borderColor: 'hsl(var(--glass-border))',
+            background: 'color-mix(in srgb, var(--glass-bg-light) 60%, transparent)',
+          }}
+        >
+          <p className="font-medium text-[color:var(--text-primary)]">In short</p>
+          <p className="mt-1">{summary}</p>
+        </div>
+      </header>
+
+      <div className="space-y-8 text-base leading-relaxed text-[color:var(--text-secondary)]">
+        {children}
+      </div>
+
+      <nav
+        aria-label="Other privacy and legal documents"
+        className="space-y-3 border-t pt-6"
+        style={{ borderColor: 'hsl(var(--glass-border))' }}
+      >
+        <h2 className="text-xs font-semibold uppercase tracking-wide text-[color:var(--text-secondary)]">
+          Related documents
+        </h2>
+        <ul className="flex flex-wrap gap-2">
+          {OTHER_DOCUMENTS.filter((document) => document.href !== currentPath).map((document) => (
+            <li key={document.href}>
+              <Link
+                className="inline-flex items-center rounded-full border px-3 py-1.5 text-sm text-[color:var(--text-secondary)] transition-colors hover:text-[color:var(--text-primary)]"
+                href={document.href}
+                style={{
+                  borderColor: 'hsl(var(--glass-border))',
+                  background: 'color-mix(in srgb, var(--glass-bg-light) 50%, transparent)',
+                }}
+              >
+                {document.label}
+              </Link>
+            </li>
+          ))}
+        </ul>
+      </nav>
+    </article>
+  );
+}
+
+/** A titled section. Headings carry ids so they can be linked to directly. */
+export function LegalSection({
+  title,
+  id,
+  children,
+}: {
+  title: string;
+  id?: string;
+  children: ReactNode;
+}) {
+  const slug = id ?? title.toLowerCase().replace(/[^a-z0-9]+/g, '-').replace(/^-|-$/g, '');
+
+  return (
+    <section aria-labelledby={slug} className="space-y-3">
+      <h2
+        className="text-xl font-semibold text-[color:var(--text-primary)] scroll-mt-24"
+        id={slug}
+      >
+        {title}
+      </h2>
+      {children}
+    </section>
+  );
+}
+
+/** Bulleted list with the spacing used across the site's prose. */
+export function LegalList({ items }: { items: ReactNode[] }) {
+  return (
+    <ul className="list-disc space-y-1.5 pl-5">
+      {items.map((item, index) => (
+        <li key={index}>{item}</li>
+      ))}
+    </ul>
+  );
+}
+
+/**
+ * Data table used by the Cookie and Retention policies. Scrolls inside its own
+ * container so a narrow phone never scrolls the whole page sideways.
+ */
+export function LegalTable({
+  caption,
+  headers,
+  rows,
+}: {
+  caption: string;
+  headers: string[];
+  rows: ReactNode[][];
+}) {
+  return (
+    <div
+      className="overflow-x-auto rounded-2xl border"
+      style={{ borderColor: 'hsl(var(--glass-border))' }}
+    >
+      <table className="w-full min-w-[34rem] border-collapse text-left text-sm">
+        <caption className="sr-only">{caption}</caption>
+        <thead>
+          <tr style={{ background: 'color-mix(in srgb, var(--glass-bg-light) 70%, transparent)' }}>
+            {headers.map((header) => (
+              <th
+                className="border-b px-4 py-3 font-semibold text-[color:var(--text-primary)]"
+                key={header}
+                scope="col"
+                style={{ borderColor: 'hsl(var(--glass-border))' }}
+              >
+                {header}
+              </th>
+            ))}
+          </tr>
+        </thead>
+        <tbody>
+          {rows.map((row, rowIndex) => (
+            <tr key={rowIndex}>
+              {row.map((cell, cellIndex) => (
+                <td
+                  className="border-b px-4 py-3 align-top text-[color:var(--text-secondary)]"
+                  key={cellIndex}
+                  style={{ borderColor: 'hsl(var(--glass-border))' }}
+                >
+                  {cell}
+                </td>
+              ))}
+            </tr>
+          ))}
+        </tbody>
+      </table>
+    </div>
+  );
+}

--- a/src/lib/client/resolveIdentifier.ts
+++ b/src/lib/client/resolveIdentifier.ts
@@ -1,0 +1,28 @@
+/**
+ * Turns whatever the visitor typed into the email address Firebase Auth expects.
+ *
+ * Usernames are resolved by a server route, because the /users collection is no
+ * longer readable from the browser. Returns null when no account matches.
+ */
+export async function resolveLoginEmail(identifier: string): Promise<string | null> {
+  const trimmed = identifier.trim();
+  if (!trimmed) return null;
+  if (trimmed.includes('@')) return trimmed.toLowerCase();
+
+  const res = await fetch('/api/auth/resolve-identifier', {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify({ username: trimmed }),
+  });
+
+  if (res.status === 429) {
+    throw new Error('Too many attempts. Please wait a few minutes and try again.');
+  }
+
+  if (!res.ok) {
+    throw new Error('We could not look up that username. Please try your email address.');
+  }
+
+  const data = (await res.json()) as { email?: string | null };
+  return data.email ?? null;
+}

--- a/src/lib/consent/categories.ts
+++ b/src/lib/consent/categories.ts
@@ -1,0 +1,99 @@
+import type { ConsentCategory } from './types';
+
+/**
+ * Plain-English descriptions of each category, written to be read by a resident
+ * rather than a lawyer. These strings are the single source of truth for the
+ * preferences panel and the Cookie Policy page, so the two can never drift.
+ */
+export type ConsentCategoryInfo = {
+  id: ConsentCategory;
+  label: string;
+  /** One-line summary shown as the row subtitle. */
+  summary: string;
+  /** Concrete examples of what the category actually does on this site. */
+  examples: string[];
+  /** Honest answer to "does this identify me?". */
+  personalData: string;
+  required: boolean;
+  /** Retention shown in the panel so visitors can see how long things last. */
+  storageDuration: string;
+};
+
+export const CONSENT_CATEGORY_INFO: readonly ConsentCategoryInfo[] = [
+  {
+    id: 'essential',
+    label: 'Essential',
+    summary: 'Needed for the site to work at all. These are always on.',
+    examples: [
+      'Keeping you signed in as you move between pages',
+      'Remembering your cookie choices so we stop asking',
+      'Protecting forms and logins against abuse',
+    ],
+    personalData:
+      'Your account session is linked to you while you are signed in. Nothing here is used to profile you or shared for advertising.',
+    required: true,
+    storageDuration: 'Session, or up to 6 months for your cookie choices',
+  },
+  {
+    id: 'functional',
+    label: 'Functional',
+    summary: 'Remembers small preferences so the site behaves the way you left it.',
+    examples: [
+      'The facility or information tab you last had open',
+      'Remembering that you dismissed a notice',
+      'Your preferred booking view',
+    ],
+    personalData:
+      'No. These are stored on your device only and hold preferences, not identity.',
+    required: false,
+    storageDuration: 'Up to 12 months on your device',
+  },
+  {
+    id: 'analytics',
+    label: 'Analytics',
+    summary: 'Anonymous counts of which pages residents find useful.',
+    examples: [
+      'How many people viewed the pool safety page',
+      'Which building updates are actually being read',
+      'Whether a new page is helping or being ignored',
+    ],
+    personalData:
+      'Measurement is aggregated and IP addresses are truncated where the provider supports it. We do not build profiles or track you across other websites.',
+    required: false,
+    storageDuration: 'Up to 14 months',
+  },
+  {
+    id: 'performance',
+    label: 'Performance',
+    summary: 'Helps us find slow pages and errors so they can be fixed.',
+    examples: [
+      'Page load timings and Core Web Vitals',
+      'Reports when something on the site breaks',
+      'Spotting a facility page that is slow on mobile',
+    ],
+    personalData:
+      'Technical only — device type, browser and timings. An error report can include the page you were on, so we keep these for a short time.',
+    required: false,
+    storageDuration: 'Up to 90 days',
+  },
+  {
+    id: 'marketing',
+    label: 'Marketing',
+    summary: 'Not used. James Square runs no advertising or tracking.',
+    examples: [
+      'No advertising cookies are set',
+      'No data is sold or shared with advertisers',
+      'Kept here only so this control exists if it were ever needed',
+    ],
+    personalData:
+      'Nothing is collected. This category is switched off and empty by design.',
+    required: false,
+    storageDuration: 'Not applicable',
+  },
+];
+
+export function getCategoryInfo(id: ConsentCategory): ConsentCategoryInfo {
+  const found = CONSENT_CATEGORY_INFO.find((category) => category.id === id);
+  if (!found) throw new Error(`Unknown consent category: ${id}`);
+  return found;
+}

--- a/src/lib/consent/registry.ts
+++ b/src/lib/consent/registry.ts
@@ -1,0 +1,209 @@
+'use client';
+
+import { hasConsent, subscribeToConsent } from './store';
+import type { ConsentCategory } from './types';
+
+/**
+ * The registry is how anything optional gets onto the page.
+ *
+ * A service declares which category it belongs to and how to switch itself on
+ * and off. The registry then guarantees:
+ *
+ *   - `activate` never runs before consent for its category exists;
+ *   - it runs exactly once, even if consent is re-confirmed;
+ *   - `deactivate` runs the moment consent is withdrawn.
+ *
+ * Adding Google Analytics, Clarity, a map embed or an AI assistant later is
+ * therefore a single `registerConsentService` call — no changes to the banner,
+ * the panel, or this file.
+ */
+export type ConsentService = {
+  /** Stable id, also used to de-duplicate registrations across renders. */
+  id: string;
+  /** Human-readable name, surfaced in the Cookie Policy service table. */
+  name: string;
+  category: ConsentCategory;
+  /**
+   * Turn the service on. Called on the client only, after consent.
+   * May return a cleanup function, which is used if consent is later withdrawn.
+   */
+  activate: () => void | (() => void) | Promise<void | (() => void)>;
+  /**
+   * Optional explicit teardown. Runs alongside any cleanup returned by
+   * `activate`. Use it to remove cookies the service set.
+   */
+  deactivate?: () => void;
+  /** Cookies/storage keys to clear on withdrawal, as a convenience. */
+  clearsStorage?: string[];
+};
+
+type RegisteredService = ConsentService & {
+  active: boolean;
+  cleanup?: () => void;
+};
+
+const services = new Map<string, RegisteredService>();
+let subscribed = false;
+
+function clearStorageKeys(keys: readonly string[] | undefined) {
+  if (!keys?.length || typeof document === 'undefined') return;
+
+  const host = window.location.hostname;
+  const secure = window.location.protocol === 'https:' ? '; Secure' : '';
+
+  for (const key of keys) {
+    try {
+      window.localStorage.removeItem(key);
+      window.sessionStorage.removeItem(key);
+    } catch {
+      // Storage may be unavailable; cookie removal below still applies.
+    }
+
+    // Expire on the exact host and on the registrable domain, since analytics
+    // vendors commonly set cookies on a leading-dot domain.
+    document.cookie = `${key}=; Path=/; Max-Age=0; SameSite=Lax${secure}`;
+    document.cookie = `${key}=; Path=/; Domain=${host}; Max-Age=0; SameSite=Lax${secure}`;
+    const parts = host.split('.');
+    if (parts.length > 2) {
+      const registrable = parts.slice(-2).join('.');
+      document.cookie = `${key}=; Path=/; Domain=.${registrable}; Max-Age=0; SameSite=Lax${secure}`;
+    }
+  }
+}
+
+async function activate(service: RegisteredService) {
+  if (service.active) return;
+  service.active = true;
+
+  try {
+    const cleanup = await service.activate();
+    if (typeof cleanup === 'function') {
+      service.cleanup = cleanup;
+    }
+  } catch (error) {
+    service.active = false;
+    // A failing optional service must never break the page.
+    if (process.env.NODE_ENV !== 'production') {
+      console.warn(`[consent] Failed to activate "${service.id}"`, error);
+    }
+  }
+}
+
+function deactivate(service: RegisteredService) {
+  if (!service.active) return;
+  service.active = false;
+
+  try {
+    service.cleanup?.();
+    service.deactivate?.();
+  } catch (error) {
+    if (process.env.NODE_ENV !== 'production') {
+      console.warn(`[consent] Failed to deactivate "${service.id}"`, error);
+    }
+  } finally {
+    service.cleanup = undefined;
+    clearStorageKeys(service.clearsStorage);
+  }
+}
+
+/** Brings every registered service in line with the current decisions. */
+export function reconcileConsentServices() {
+  for (const service of services.values()) {
+    if (hasConsent(service.category)) {
+      void activate(service);
+    } else {
+      deactivate(service);
+    }
+  }
+}
+
+function ensureSubscription() {
+  if (subscribed || typeof window === 'undefined') return;
+  subscribed = true;
+  subscribeToConsent(() => reconcileConsentServices());
+}
+
+/**
+ * Registers a service and immediately activates it if consent already exists.
+ * Returns an unregister function for component-scoped services.
+ */
+export function registerConsentService(service: ConsentService): () => void {
+  if (typeof window === 'undefined') return () => {};
+
+  const existing = services.get(service.id);
+  if (existing) {
+    // Re-registration (e.g. a remount) should not double-load the script.
+    return () => unregisterConsentService(service.id);
+  }
+
+  const registered: RegisteredService = { ...service, active: false };
+  services.set(service.id, registered);
+
+  ensureSubscription();
+
+  if (hasConsent(registered.category)) {
+    void activate(registered);
+  }
+
+  return () => unregisterConsentService(service.id);
+}
+
+export function unregisterConsentService(id: string) {
+  const service = services.get(id);
+  if (!service) return;
+  deactivate(service);
+  services.delete(id);
+}
+
+export function getRegisteredServices(): ReadonlyArray<Pick<ConsentService, 'id' | 'name' | 'category'>> {
+  return Array.from(services.values(), ({ id, name, category }) => ({ id, name, category }));
+}
+
+/**
+ * Helper for the most common case: injecting a third-party `<script>` only
+ * after consent, and removing it again on withdrawal.
+ *
+ *   registerConsentService(
+ *     scriptService({
+ *       id: 'google-analytics',
+ *       name: 'Google Analytics 4',
+ *       category: 'analytics',
+ *       src: 'https://www.googletagmanager.com/gtag/js?id=G-XXXX',
+ *       clearsStorage: ['_ga', '_ga_XXXX', '_gid'],
+ *     }),
+ *   );
+ */
+export function scriptService(options: {
+  id: string;
+  name: string;
+  category: ConsentCategory;
+  src: string;
+  /** Runs after the script has loaded, for any bootstrap the vendor needs. */
+  onLoad?: () => void;
+  attributes?: Record<string, string>;
+  clearsStorage?: string[];
+}): ConsentService {
+  return {
+    id: options.id,
+    name: options.name,
+    category: options.category,
+    clearsStorage: options.clearsStorage,
+    activate: () => {
+      const script = document.createElement('script');
+      script.src = options.src;
+      script.async = true;
+      script.dataset.consentService = options.id;
+      for (const [key, value] of Object.entries(options.attributes ?? {})) {
+        script.setAttribute(key, value);
+      }
+      if (options.onLoad) {
+        script.addEventListener('load', options.onLoad, { once: true });
+      }
+      document.head.appendChild(script);
+
+      return () => {
+        script.remove();
+      };
+    },
+  };
+}

--- a/src/lib/consent/services.ts
+++ b/src/lib/consent/services.ts
@@ -1,0 +1,65 @@
+'use client';
+
+import { registerConsentService, scriptService } from './registry';
+
+/**
+ * The site's consent-gated services, in one place.
+ *
+ * James Square currently runs **no** analytics, tagging or advertising scripts,
+ * so this list is intentionally empty. It exists so that adding one later is a
+ * self-contained change: append a registration below and the banner, the
+ * preferences panel and the withdrawal path all pick it up with no other edits.
+ *
+ * Worked examples for the services most likely to be added are kept as comments
+ * rather than dead code, so nothing ships that nobody has consented to.
+ *
+ * ── Google Analytics 4 ───────────────────────────────────────────────────────
+ *   const GA_ID = process.env.NEXT_PUBLIC_GA_ID;
+ *   if (GA_ID) {
+ *     unregister.push(
+ *       registerConsentService(
+ *         scriptService({
+ *           id: 'google-analytics',
+ *           name: 'Google Analytics 4',
+ *           category: 'analytics',
+ *           src: `https://www.googletagmanager.com/gtag/js?id=${GA_ID}`,
+ *           clearsStorage: ['_ga', `_ga_${GA_ID.replace('G-', '')}`, '_gid'],
+ *           onLoad: () => {
+ *             window.dataLayer = window.dataLayer || [];
+ *             const gtag = (...args: unknown[]) => window.dataLayer.push(args);
+ *             gtag('js', new Date());
+ *             // Keep IPs truncated and drop ad signals: analytics, not tracking.
+ *             gtag('config', GA_ID, {
+ *               anonymize_ip: true,
+ *               allow_google_signals: false,
+ *               allow_ad_personalization_signals: false,
+ *             });
+ *           },
+ *         }),
+ *       ),
+ *     );
+ *   }
+ *
+ * ── Microsoft Clarity ────────────────────────────────────────────────────────
+ *   Clarity records session replays, which can capture form contents. If it is
+ *   ever added it belongs in 'performance', must have masking set to "strict",
+ *   and the Cookie Policy and Privacy Policy both need updating first.
+ *
+ * ── Embedded maps / social / Vimeo ───────────────────────────────────────────
+ *   Do not register these here. Wrap the embed in <ConsentGate category="functional">
+ *   so the iframe is never inserted — and therefore never contacted — until the
+ *   visitor allows it.
+ */
+export function registerSiteConsentServices(): () => void {
+  const unregister: Array<() => void> = [];
+
+  // Nothing registered yet — see the worked examples above.
+  // Referencing the helpers keeps them in the module graph and type-checked,
+  // so the first real registration is a one-line change.
+  void registerConsentService;
+  void scriptService;
+
+  return () => {
+    for (const cleanup of unregister) cleanup();
+  };
+}

--- a/src/lib/consent/store.ts
+++ b/src/lib/consent/store.ts
@@ -1,0 +1,182 @@
+'use client';
+
+import {
+  ACCEPT_ALL_DECISIONS,
+  CONSENT_VERSION,
+  DEFAULT_DECISIONS,
+  ESSENTIAL_ONLY_DECISIONS,
+  OPTIONAL_CONSENT_CATEGORIES,
+  normaliseConsentRecord,
+  type ConsentCategory,
+  type ConsentDecisions,
+  type ConsentRecord,
+} from './types';
+
+/**
+ * Where the decision lives.
+ *
+ * localStorage is deliberate: the record never needs to reach the server, so
+ * sending it on every request as a cookie would be gratuitous. A first-party
+ * cookie mirror is written too, so that server-rendered pages and any future
+ * edge logic can read the decision without JavaScript.
+ */
+const STORAGE_KEY = 'js-consent';
+export const CONSENT_COOKIE_NAME = 'js-consent';
+
+const COOKIE_MAX_AGE_SECONDS = 60 * 60 * 24 * 182;
+
+type Listener = (state: ConsentState) => void;
+
+export type ConsentState = {
+  /** null until the visitor has made a choice (or their old choice expired). */
+  record: ConsentRecord | null;
+  decisions: ConsentDecisions;
+  /** True once we have actually looked at storage — prevents a flash of the banner. */
+  hydrated: boolean;
+};
+
+let state: ConsentState = {
+  record: null,
+  decisions: DEFAULT_DECISIONS,
+  hydrated: false,
+};
+
+const listeners = new Set<Listener>();
+
+function emit() {
+  for (const listener of listeners) listener(state);
+}
+
+function setState(next: ConsentState) {
+  state = next;
+  emit();
+}
+
+function readStoredRecord(): ConsentRecord | null {
+  if (typeof window === 'undefined') return null;
+
+  try {
+    const raw = window.localStorage.getItem(STORAGE_KEY);
+    if (raw) {
+      const parsed = normaliseConsentRecord(JSON.parse(raw));
+      if (parsed) return parsed;
+      // Expired or from an older version — clear it rather than leave litter.
+      window.localStorage.removeItem(STORAGE_KEY);
+    }
+  } catch {
+    // Private browsing or storage disabled. Treat as "no decision yet".
+  }
+
+  return readCookieRecord();
+}
+
+function readCookieRecord(): ConsentRecord | null {
+  if (typeof document === 'undefined') return null;
+
+  try {
+    const match = document.cookie
+      .split('; ')
+      .find((entry) => entry.startsWith(`${CONSENT_COOKIE_NAME}=`));
+    if (!match) return null;
+    const value = decodeURIComponent(match.slice(CONSENT_COOKIE_NAME.length + 1));
+    return normaliseConsentRecord(JSON.parse(value));
+  } catch {
+    return null;
+  }
+}
+
+function persist(record: ConsentRecord | null) {
+  if (typeof window === 'undefined') return;
+
+  try {
+    if (record) {
+      window.localStorage.setItem(STORAGE_KEY, JSON.stringify(record));
+    } else {
+      window.localStorage.removeItem(STORAGE_KEY);
+    }
+  } catch {
+    // Storage unavailable — the cookie mirror below is the fallback.
+  }
+
+  if (typeof document === 'undefined') return;
+
+  const secure = window.location.protocol === 'https:' ? '; Secure' : '';
+
+  if (record) {
+    const value = encodeURIComponent(JSON.stringify(record));
+    document.cookie = `${CONSENT_COOKIE_NAME}=${value}; Path=/; Max-Age=${COOKIE_MAX_AGE_SECONDS}; SameSite=Lax${secure}`;
+  } else {
+    document.cookie = `${CONSENT_COOKIE_NAME}=; Path=/; Max-Age=0; SameSite=Lax${secure}`;
+  }
+}
+
+/** Reads storage once and flips `hydrated`. Safe to call repeatedly. */
+export function hydrateConsent(): ConsentState {
+  if (state.hydrated) return state;
+
+  const record = readStoredRecord();
+  setState({
+    record,
+    decisions: record ? record.decisions : DEFAULT_DECISIONS,
+    hydrated: true,
+  });
+
+  return state;
+}
+
+export function getConsentState(): ConsentState {
+  return state;
+}
+
+export function hasConsent(category: ConsentCategory): boolean {
+  if (category === 'essential') return true;
+  return state.decisions[category] === true;
+}
+
+export function subscribeToConsent(listener: Listener): () => void {
+  listeners.add(listener);
+  return () => {
+    listeners.delete(listener);
+  };
+}
+
+function commit(decisions: ConsentDecisions, method: ConsentRecord['method']) {
+  const record: ConsentRecord = {
+    version: CONSENT_VERSION,
+    decidedAt: new Date().toISOString(),
+    method,
+    decisions: { ...decisions, essential: true },
+  };
+
+  persist(record);
+  setState({ record, decisions: record.decisions, hydrated: true });
+}
+
+export function acceptAll() {
+  commit(ACCEPT_ALL_DECISIONS, 'accept-all');
+}
+
+export function acceptEssentialOnly() {
+  commit(ESSENTIAL_ONLY_DECISIONS, 'essential-only');
+}
+
+export function savePreferences(partial: Partial<Record<ConsentCategory, boolean>>) {
+  const decisions = OPTIONAL_CONSENT_CATEGORIES.reduce(
+    (acc, category) => {
+      acc[category] = partial[category] === true;
+      return acc;
+    },
+    { essential: true } as ConsentDecisions,
+  );
+
+  commit(decisions, 'preferences');
+}
+
+/**
+ * Full withdrawal: forgets the decision entirely so the visitor is asked again.
+ * Also clears any storage written by optional services that are now switched off.
+ */
+export function withdrawConsent() {
+  persist(null);
+  setState({ record: null, decisions: DEFAULT_DECISIONS, hydrated: true });
+}

--- a/src/lib/consent/types.ts
+++ b/src/lib/consent/types.ts
@@ -1,0 +1,103 @@
+/**
+ * Consent model for James Square.
+ *
+ * The shape stored on the visitor's device is intentionally small and boring:
+ * a version, a timestamp and one boolean per category. Anything richer would be
+ * personal data we have no reason to keep.
+ */
+
+export const CONSENT_CATEGORIES = [
+  'essential',
+  'functional',
+  'analytics',
+  'performance',
+  'marketing',
+] as const;
+
+export type ConsentCategory = (typeof CONSENT_CATEGORIES)[number];
+
+/** Categories a visitor can actually change. Essential is never optional. */
+export type OptionalConsentCategory = Exclude<ConsentCategory, 'essential'>;
+
+export const OPTIONAL_CONSENT_CATEGORIES: readonly OptionalConsentCategory[] = [
+  'functional',
+  'analytics',
+  'performance',
+  'marketing',
+];
+
+export type ConsentDecisions = Record<ConsentCategory, boolean>;
+
+/**
+ * Bumping this invalidates stored consent and re-prompts everyone. Increment it
+ * only when the categories or the services inside them materially change —
+ * re-asking without cause is its own kind of dark pattern.
+ */
+export const CONSENT_VERSION = 1;
+
+export type ConsentRecord = {
+  version: number;
+  /** ISO-8601 timestamp of the decision, used to show "last reviewed" and to expire consent. */
+  decidedAt: string;
+  /** How the decision was made, so we can evidence that it was a real choice. */
+  method: 'accept-all' | 'essential-only' | 'preferences';
+  decisions: ConsentDecisions;
+};
+
+/** UK ICO guidance: re-ask periodically rather than treating consent as forever. */
+export const CONSENT_MAX_AGE_DAYS = 182;
+
+export const ESSENTIAL_ONLY_DECISIONS: ConsentDecisions = {
+  essential: true,
+  functional: false,
+  analytics: false,
+  performance: false,
+  marketing: false,
+};
+
+export const ACCEPT_ALL_DECISIONS: ConsentDecisions = {
+  essential: true,
+  functional: true,
+  analytics: true,
+  performance: true,
+  marketing: true,
+};
+
+/**
+ * What we assume before a visitor has decided anything: nothing optional runs.
+ * This is the default the whole app reads from during server rendering too, so
+ * there is no window in which an optional script could slip through.
+ */
+export const DEFAULT_DECISIONS: ConsentDecisions = ESSENTIAL_ONLY_DECISIONS;
+
+export function isConsentCategory(value: unknown): value is ConsentCategory {
+  return typeof value === 'string' && (CONSENT_CATEGORIES as readonly string[]).includes(value);
+}
+
+/** Normalises anything we read back from storage into a trustworthy record. */
+export function normaliseConsentRecord(input: unknown): ConsentRecord | null {
+  if (!input || typeof input !== 'object') return null;
+
+  const candidate = input as Partial<ConsentRecord> & { decisions?: unknown };
+  if (candidate.version !== CONSENT_VERSION) return null;
+  if (typeof candidate.decidedAt !== 'string') return null;
+
+  const decidedAt = new Date(candidate.decidedAt);
+  if (Number.isNaN(decidedAt.getTime())) return null;
+
+  const ageDays = (Date.now() - decidedAt.getTime()) / 86_400_000;
+  if (ageDays > CONSENT_MAX_AGE_DAYS || ageDays < -1) return null;
+
+  const rawDecisions = (candidate.decisions ?? {}) as Record<string, unknown>;
+  const decisions = CONSENT_CATEGORIES.reduce((acc, category) => {
+    acc[category] = category === 'essential' ? true : rawDecisions[category] === true;
+    return acc;
+  }, {} as ConsentDecisions);
+
+  const method: ConsentRecord['method'] =
+    candidate.method === 'accept-all' || candidate.method === 'essential-only'
+      ? candidate.method
+      : 'preferences';
+
+  return { version: CONSENT_VERSION, decidedAt: decidedAt.toISOString(), method, decisions };
+}

--- a/src/lib/emailGroups.ts
+++ b/src/lib/emailGroups.ts
@@ -1,3 +1,17 @@
+import 'server-only';
+
+/**
+ * Named mailing groups.
+ *
+ * `server-only` is load-bearing here: these are committee members' and the
+ * factor's personal email addresses, and this module was previously imported by
+ * a client component, which published every address in the JavaScript bundle
+ * served to anonymous visitors. The import now fails the build if that happens
+ * again.
+ *
+ * Group membership reaches the browser only through /api/admin/email-groups,
+ * which requires a verified administrator.
+ */
 export const EMAIL_GROUPS = {
   committee: [
     'derekp19@gmail.com',
@@ -14,3 +28,20 @@ export const EMAIL_GROUPS = {
 } as const;
 
 export type EmailGroupKey = keyof typeof EMAIL_GROUPS;
+
+export const EMAIL_GROUP_KEYS = Object.keys(EMAIL_GROUPS) as EmailGroupKey[];
+
+export function isEmailGroupKey(value: unknown): value is EmailGroupKey {
+  return typeof value === 'string' && (EMAIL_GROUP_KEYS as string[]).includes(value);
+}
+
+/** Sizes only — safe to expose without revealing addresses. */
+export function emailGroupCounts(): Record<EmailGroupKey, number> {
+  return EMAIL_GROUP_KEYS.reduce(
+    (acc, key) => {
+      acc[key] = EMAIL_GROUPS[key].length;
+      return acc;
+    },
+    {} as Record<EmailGroupKey, number>,
+  );
+}

--- a/src/lib/sanitizeHtml.ts
+++ b/src/lib/sanitizeHtml.ts
@@ -1,13 +1,137 @@
-export function sanitizeHtml(input: string): string {
-  let out = input.replace(/<script[\s\S]*?>[\s\S]*?<\/script>/gi, '');
-  out = out
-    .replace(/\son\w+="[^"]*"/gi, '')
-    .replace(/\son\w+='[^']*'/gi, '');
+/**
+ * Minimal HTML sanitiser for author-supplied email bodies.
+ *
+ * The previous implementation had three exploitable gaps:
+ *
+ *   1. The allow-list regex was unanchored, so any tag whose name merely
+ *      *contained* an allowed name passed — `<iframe>` matched on the `i` of the
+ *      italic tag, and `<img onerror=...>` matched on `i` too.
+ *   2. Event handlers were stripped only when their value was quoted, so
+ *      `<div onerror=alert(1)>` survived untouched.
+ *   3. `href`/`src` values were not checked, so `javascript:` and `data:` URLs
+ *      passed straight through.
+ *
+ * This version inverts the approach: attributes are dropped unless explicitly
+ * permitted, tag names are matched exactly, and URL schemes are checked against
+ * a small allow-list. Anything not recognised is escaped rather than removed, so
+ * the author can see what happened to their content.
+ *
+ * Note on scope: this protects the rendered *email*, and the stored copy that the
+ * committee archive displays. It is not a substitute for a full parser — if rich
+ * user-generated HTML is ever rendered to other residents, use a maintained
+ * library (DOMPurify server-side via jsdom, or `sanitize-html`).
+ */
 
-  const allowed = /(p|br|strong|em|b|i|u|ul|ol|li|h[1-6]|a|div|span)/i;
-  out = out.replace(/<(?=\/?)([^>\s/]+)([^>]*)>/g, (match, tag) => {
-    return allowed.test(tag) ? match : match.replace(/</g, '&lt;').replace(/>/g, '&gt;');
-  });
+const ALLOWED_TAGS = new Set([
+  'p',
+  'br',
+  'strong',
+  'b',
+  'em',
+  'i',
+  'u',
+  'ul',
+  'ol',
+  'li',
+  'h1',
+  'h2',
+  'h3',
+  'h4',
+  'h5',
+  'h6',
+  'a',
+  'div',
+  'span',
+  'blockquote',
+]);
+
+/** Attributes permitted per tag. Everything else is dropped. */
+const ALLOWED_ATTRIBUTES: Record<string, Set<string>> = {
+  a: new Set(['href', 'title', 'target', 'rel']),
+};
+
+const SAFE_URL_SCHEME = /^(https?:|mailto:|tel:|\/|#)/i;
+
+const escapeTag = (value: string) => value.replace(/</g, '&lt;').replace(/>/g, '&gt;');
+
+/** Parses an attribute list, keeping only what is allowed and safe. */
+function filterAttributes(tagName: string, rawAttributes: string): string {
+  const allowed = ALLOWED_ATTRIBUTES[tagName];
+  if (!allowed || !rawAttributes.trim()) return '';
+
+  const kept: string[] = [];
+
+  // Matches name="value", name='value' and bare name=value, plus valueless names.
+  const pattern = /([a-zA-Z_:][-\w:.]*)\s*(?:=\s*(?:"([^"]*)"|'([^']*)'|([^\s"'>=`]+)))?/g;
+
+  let match: RegExpExecArray | null;
+  while ((match = pattern.exec(rawAttributes)) !== null) {
+    const name = match[1].toLowerCase();
+    const value = match[2] ?? match[3] ?? match[4] ?? '';
+
+    if (!allowed.has(name)) continue;
+
+    // Reject any scheme we do not recognise, which covers javascript:, data:
+    // and vbscript: however they are cased or padded with control characters.
+    if (name === 'href' || name === 'src') {
+      // Strip control characters and whitespace first, so "java\tscript:" and
+      // "\0javascript:" cannot slip past the scheme check.
+      const normalised = value.replace(/[\u0000-\u0020]/g, '');
+      if (!SAFE_URL_SCHEME.test(normalised)) continue;
+      kept.push(`${name}="${escapeAttributeValue(normalised)}"`);
+      continue;
+    }
+
+    kept.push(`${name}="${escapeAttributeValue(value)}"`);
+  }
+
+  // Any link that opens a new tab gets noopener, so the target cannot reach back
+  // through window.opener.
+  if (tagName === 'a' && kept.some((attribute) => attribute.startsWith('target='))) {
+    if (!kept.some((attribute) => attribute.startsWith('rel='))) {
+      kept.push('rel="noopener noreferrer"');
+    }
+  }
+
+  return kept.length ? ` ${kept.join(' ')}` : '';
+}
+
+const escapeAttributeValue = (value: string) =>
+  value.replace(/&/g, '&amp;').replace(/"/g, '&quot;').replace(/</g, '&lt;').replace(/>/g, '&gt;');
+
+export function sanitizeHtml(input: string): string {
+  if (!input) return '';
+
+  let out = input;
+
+  // Remove whole elements whose *content* is dangerous, not just their tags.
+  out = out.replace(/<script\b[\s\S]*?(?:<\/script\s*>|$)/gi, '');
+  out = out.replace(/<style\b[\s\S]*?(?:<\/style\s*>|$)/gi, '');
+  out = out.replace(/<!--[\s\S]*?(?:-->|$)/g, '');
+
+  // Rebuild every remaining tag from a strict allow-list.
+  out = out.replace(
+    /<\s*(\/?)\s*([a-zA-Z][a-zA-Z0-9]*)((?:[^>"']|"[^"]*"|'[^']*')*)>/g,
+    (match, closing: string, rawName: string, rawAttributes: string) => {
+      const tagName = rawName.toLowerCase();
+
+      if (!ALLOWED_TAGS.has(tagName)) {
+        return escapeTag(match);
+      }
+
+      if (closing) {
+        return `</${tagName}>`;
+      }
+
+      const attributes = filterAttributes(tagName, rawAttributes);
+      const selfClosing = tagName === 'br' ? ' /' : '';
+      return `<${tagName}${attributes}${selfClosing}>`;
+    },
+  );
+
+  // Anything left that looks like a tag was not recognised above — escape it so
+  // it renders as text instead of being interpreted by a lenient parser.
+  out = out.replace(/<(?!\/?(?:[a-z][a-z0-9]*)[\s/>])/gi, '&lt;');
 
   return out;
 }

--- a/src/lib/security/rateLimit.ts
+++ b/src/lib/security/rateLimit.ts
@@ -1,0 +1,86 @@
+import 'server-only';
+
+/**
+ * Small in-process rate limiter for API routes and Server Actions.
+ *
+ * Deliberately dependency-free. On a serverless platform each instance keeps its
+ * own counters, so this is a throttle rather than a hard guarantee — it stops
+ * scripted brute-forcing of passcodes and mail endpoints, which is what it is
+ * for. Anything needing a strict global limit should use the Firestore-backed
+ * counter pattern already used for the committee mail daily cap.
+ */
+
+type Bucket = { count: number; resetAt: number };
+
+const buckets = new Map<string, Bucket>();
+let lastSweep = Date.now();
+
+/** Drop expired buckets occasionally so the map cannot grow without bound. */
+function sweep(now: number) {
+  if (now - lastSweep < 60_000) return;
+  lastSweep = now;
+  for (const [key, bucket] of buckets) {
+    if (bucket.resetAt <= now) buckets.delete(key);
+  }
+}
+
+export type RateLimitResult = {
+  allowed: boolean;
+  remaining: number;
+  /** Seconds until the window resets — suitable for a Retry-After header. */
+  retryAfter: number;
+};
+
+export function rateLimit(
+  key: string,
+  options: { limit: number; windowMs: number },
+): RateLimitResult {
+  const now = Date.now();
+  sweep(now);
+
+  const existing = buckets.get(key);
+
+  if (!existing || existing.resetAt <= now) {
+    buckets.set(key, { count: 1, resetAt: now + options.windowMs });
+    return { allowed: true, remaining: options.limit - 1, retryAfter: 0 };
+  }
+
+  existing.count += 1;
+  const retryAfter = Math.max(1, Math.ceil((existing.resetAt - now) / 1000));
+
+  if (existing.count > options.limit) {
+    return { allowed: false, remaining: 0, retryAfter };
+  }
+
+  return { allowed: true, remaining: options.limit - existing.count, retryAfter };
+}
+
+/**
+ * Best-effort client identifier. Vercel and most proxies set x-forwarded-for;
+ * we take the left-most entry, which is the closest thing to the real client.
+ *
+ * The value is used only as an in-memory throttle key and is never stored, so no
+ * IP address is retained beyond the length of the rate-limit window.
+ */
+export function clientKey(request: Request, scope: string): string {
+  const forwarded = request.headers.get('x-forwarded-for') ?? '';
+  const realIp = request.headers.get('x-real-ip') ?? '';
+  const ip = forwarded.split(',')[0]?.trim() || realIp || 'unknown';
+  return `${scope}:${ip}`;
+}
+
+/** Standard 429 response with the headers a well-behaved client expects. */
+export function tooManyRequests(result: RateLimitResult, message?: string): Response {
+  return new Response(
+    JSON.stringify({
+      error: message ?? 'Too many requests. Please wait a moment and try again.',
+    }),
+    {
+      status: 429,
+      headers: {
+        'Content-Type': 'application/json',
+        'Retry-After': String(result.retryAfter),
+      },
+    },
+  );
+}

--- a/src/lib/security/requireAuth.ts
+++ b/src/lib/security/requireAuth.ts
@@ -1,0 +1,107 @@
+import 'server-only';
+
+import type { DecodedIdToken } from 'firebase-admin/auth';
+import { NextResponse } from 'next/server';
+
+import { adminAuth, adminDb } from '@/lib/firebaseAdmin';
+
+/**
+ * Shared authentication and authorisation for API routes.
+ *
+ * Every privileged endpoint funnels through here so that "verified the token"
+ * and "checked they are actually an admin" cannot drift apart again — the two
+ * mail endpoints previously did the first without the second.
+ */
+
+export type AuthFailure = { ok: false; response: NextResponse };
+export type AuthSuccess = { ok: true; token: DecodedIdToken };
+export type AuthResult = AuthSuccess | AuthFailure;
+
+function fail(status: number, error: string): AuthFailure {
+  return { ok: false, response: NextResponse.json({ error }, { status }) };
+}
+
+function bearerToken(request: Request): string | undefined {
+  const header = request.headers.get('authorization') ?? '';
+  const match = header.match(/^Bearer\s+(.+)$/i);
+  return match?.[1]?.trim() || undefined;
+}
+
+/** Verifies the caller is signed in. Revoked tokens are rejected. */
+export async function requireUser(request: Request): Promise<AuthResult> {
+  const token = bearerToken(request);
+  if (!token) {
+    return fail(401, 'Not authenticated.');
+  }
+
+  try {
+    // checkRevoked: a disabled or signed-out account must lose access at once.
+    const decoded = await adminAuth.verifyIdToken(token, true);
+    return { ok: true, token: decoded };
+  } catch {
+    // Deliberately vague: distinguishing "expired" from "forged" helps attackers.
+    return fail(401, 'Session invalid or expired.');
+  }
+}
+
+/**
+ * True if the account is an administrator.
+ *
+ * The custom claim is authoritative, with a fallback to the `isAdmin` flag on the
+ * user's Firestore document for admins whose claims have not been synced yet.
+ * The fallback is read with the Admin SDK, so a client cannot influence it.
+ */
+export async function isAdminToken(token: DecodedIdToken): Promise<boolean> {
+  if (token.admin === true) return true;
+
+  try {
+    const snapshot = await adminDb.collection('users').doc(token.uid).get();
+    return snapshot.exists && snapshot.get('isAdmin') === true;
+  } catch (error) {
+    console.error('[auth] Failed to read admin flag', error);
+    return false;
+  }
+}
+
+/** Verifies the caller is signed in **and** an administrator. */
+export async function requireAdmin(request: Request): Promise<AuthResult> {
+  const auth = await requireUser(request);
+  if (!auth.ok) return auth;
+
+  if (!(await isAdminToken(auth.token))) {
+    console.warn('[auth] Non-admin attempted a privileged action', { uid: auth.token.uid });
+    return fail(403, 'You do not have permission to perform this action.');
+  }
+
+  return auth;
+}
+
+/**
+ * Verifies the caller may send committee mail: an administrator, or an account
+ * explicitly flagged as a committee member.
+ */
+export async function requireCommittee(request: Request): Promise<AuthResult> {
+  const auth = await requireUser(request);
+  if (!auth.ok) return auth;
+
+  if (auth.token.admin === true || auth.token.committee === true) {
+    return auth;
+  }
+
+  try {
+    const snapshot = await adminDb.collection('users').doc(auth.token.uid).get();
+    if (
+      snapshot.exists &&
+      (snapshot.get('isAdmin') === true || snapshot.get('isCommittee') === true)
+    ) {
+      return auth;
+    }
+  } catch (error) {
+    console.error('[auth] Failed to read committee flag', error);
+  }
+
+  console.warn('[auth] Non-committee account attempted to send committee mail', {
+    uid: auth.token.uid,
+  });
+  return fail(403, 'Committee members only.');
+}


### PR DESCRIPTION
Adds a consent management platform and fixes a set of security and
privacy defects found while auditing the site against UK GDPR and PECR.
Full findings, risk ratings and remaining recommendations are in
docs/gdpr-audit-2026.md.

Critical fixes
- Firestore rules allowed any resident to set isAdmin on their own
  profile, and isAdmin() trusted that flag: full privilege escalation.
  Role-bearing fields are now admin-only via field-level diff checks,
  while the self-service the dashboard relies on still works.
- /users was world-readable, exposing every resident's name, email,
  flat and resident type. Reads are now self-or-admin; username lookups
  for login and password reset move to a rate-limited server route.
- /api/admin/send-email verified the caller's token but never checked
  they were an admin, letting any signed-in resident send mail from a
  james-square.com address to arbitrary recipients.
- /api/committee/send-email wrapped its token check in `if (token)`, so
  an unauthenticated request skipped verification and sent as
  committee@james-square.com.

Also fixed
- Owners and Committee access codes were plain constants in client
  components. Verification moves to a rate-limited Server Action with
  bcrypt hashes from the environment. The codes should be rotated.
- Bookings were world-readable and store the booker's email. The public
  schedule now comes from /api/availability, which resolves identities
  server-side; the rules require auth and constrain queries to the
  caller's own bookings.
- Message board and individual ballots were world-readable.
- voting_questions allowed anonymous creation.
- emailGroups.ts held committee members' personal addresses and was
  imported by a client component, publishing them in the bundle. It is
  now server-only, with an admin-gated route for the composer.
- sanitizeHtml's allow-list regex was unanchored (iframe matched on the
  italic tag), unquoted event handlers survived, and URL schemes were
  unchecked. Rewritten as a strict allow-list; verified against 12 XSS
  payloads.
- Added security headers, robots rules, rate limiting, recipient caps,
  and explicit rules for activityLogs, feedback and the server-only
  collections, plus a default-deny catch-all.

Consent platform
- Versioned consent store with a category registry, so a future service
  registers itself and is guaranteed never to activate before consent
  and to tear down on withdrawal. No services are registered yet: the
  site runs no analytics or tracking, and loads zero third-party
  resources before consent.
- Liquid Glass banner and preferences dialog built from the existing
  glass tokens and easing, honouring prefers-reduced-motion. The banner
  is a non-blocking region rather than a modal; Essential Only is one
  click, and withdrawal is available from every page footer.
- ConsentGate for embeds, so an iframe is never inserted until allowed.

Legal documents
- Rewrote the Privacy Policy and Terms of Use; added Cookie, Acceptable
  Use and Data Retention policies, all linked from the footer with a
  permanent Cookie Settings control and a privacy contact address. The
  Cookie Policy renders from the same category definitions as the
  preferences panel so the two cannot drift.

Verification
- 29 Firestore rules tests (npm run test:rules); 15 fail against the
  previous rules and pass against these.
- 22 automated consent and accessibility checks; CLS measured at 0.
- Added a site-wide skip link; the consent choice is 5 tab stops away
  rather than 63.

Co-Authored-By: Claude Opus 5 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01CW9TLTuNb9aMsTvpRxtX8S