### PR TITLE
Configure Committee Meeting social sharing metadata

### DIFF
--- a/src/app/committee-meeting/page.tsx
+++ b/src/app/committee-meeting/page.tsx
@@ -13,6 +13,13 @@ import {
 const teamsLink =
   "https://teams.live.com/meet/9392352296034?p=TlgOqGScBL4kqTLwZV";
 
+const pageTitle = "James Square Committee Meeting";
+const pageDescription =
+  "Committee meeting information, agenda and joining details for the James Square community.";
+const canonicalUrl = "https://www.james-square.com/committee-meeting";
+const socialImageUrl =
+  "https://www.james-square.com/images/logo/E7197D9E-8704-47EC-92E2-BC4D9C9506BC.png";
+
 const agendaItems = [
   "Introductions for new members",
   "Official acceptance of the constitution",
@@ -26,11 +33,36 @@ const agendaItems = [
 ];
 
 export const metadata: Metadata = {
-  title: "Committee Meeting – 10 August 2026 | James Square",
-  description:
-    "Joining details and agenda for the James Square committee meeting on 10 August 2026 at 18:00.",
+  title: pageTitle,
+  description: pageDescription,
   alternates: {
-    canonical: "/committee-meeting",
+    canonical: canonicalUrl,
+  },
+  openGraph: {
+    title: pageTitle,
+    description: pageDescription,
+    url: canonicalUrl,
+    type: "website",
+    siteName: "James Square",
+    images: [
+      {
+        url: socialImageUrl,
+        width: 1536,
+        height: 1024,
+        alt: "James Square Committee Meeting",
+      },
+    ],
+  },
+  twitter: {
+    card: "summary_large_image",
+    title: pageTitle,
+    description: pageDescription,
+    images: [
+      {
+        url: socialImageUrl,
+        alt: "James Square Committee Meeting",
+      },
+    ],
   },
   robots: {
     index: false,

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -15,7 +15,7 @@ const geistMono = Geist_Mono({ subsets: ["latin"], variable: "--font-geist-mono"
 export const metadata: Metadata = {
   title: "James Square",
   description: "Residents community website for James Square, Edinburgh",
-  metadataBase: new URL("https://james-square.com"),
+  metadataBase: new URL("https://www.james-square.com"),
   manifest: "/manifest.json",
   appleWebApp: {
     capable: true,


### PR DESCRIPTION
### Motivation
- Ensure the specific route `/committee-meeting` has correct Open Graph and Twitter/X metadata so link previews use the new Committee Meeting image and the correct canonical URL. 
- Make the canonical origin consistent with deployed URLs by aligning the global `metadataBase` to `https://www.james-square.com`.
- Apply these social metadata updates only to the Committee Meeting page without changing defaults for other pages.

### Description
- Added route-specific constants and metadata in `src/app/committee-meeting/page.tsx` including `title`, `description`, `alternates.canonical`, an `openGraph` block (with `siteName`, `type`, `images` using the 1536×1024 PNG and `alt` text) and a `twitter` block using `summary_large_image`. 
- Updated the global `metadataBase` in `src/app/layout.tsx` to `new URL("https://www.james-square.com")` so generated URLs and canonical references match the public origin. 
- Did not modify any visible page content or change the project’s default social image used by other routes. 

### Testing
- Ran `npx tsc --noEmit` which completed without errors. 
- Rendered the route via the Next.js dev server and fetched `/committee-meeting` with `curl -fsS` and validated the rendered `<head>` contains the expected `title`, `description`, `canonical`, `og:*` and `twitter:*` tags. 
- Verified the public image URL `https://www.james-square.com/images/logo/E7197D9E-8704-47EC-92E2-BC4D9C9506BC.png` responds (HTTP 200) and confirmed the PNG is 1536×1024. 
- Ran `git diff --check` to ensure no linting diffs, and committed the change; note that `npm run build` in this environment failed due to `next/font` being unable to download Google Fonts for `Geist`/`Geist Mono`, which is an environment/network issue unrelated to the metadata changes.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a79d78104448324a677e78e42ff1bae)