### PR TITLE
Fix CCTV request email delivery and add Reply-To

### DIFF
--- a/src/app/api/cctv/request/route.test.ts
+++ b/src/app/api/cctv/request/route.test.ts
@@ -51,7 +51,9 @@ describe('POST /api/cctv/request', () => {
     const body = await result.json();
     expect(body).toEqual({ success: true, requestId: expect.stringMatching(/^JS-\d{8}-\d{4}$/) });
     expect(mocks.sendWithResend).toHaveBeenCalledWith(expect.objectContaining({
+      from: 'James Square CCTV <cctv@james-square.com>',
       to: 'cctv@james-square.com',
+      replyTo: 'alex@example.com',
       html: expect.stringContaining(body.requestId),
     }));
     expect(mocks.saveDeliveredCctvRequest).toHaveBeenCalledWith(body.requestId, expect.any(Object));

--- a/src/app/api/cctv/request/route.ts
+++ b/src/app/api/cctv/request/route.ts
@@ -14,6 +14,9 @@ export const runtime = 'nodejs';
 export const dynamic = 'force-dynamic';
 const MAX_BODY_BYTES = 32 * 1024;
 const RECIPIENT = 'cctv@james-square.com';
+// Use the verified james-square.com domain directly rather than relying on the
+// optional RESEND_FROM_EMAIL setting used by generic application emails.
+const SENDER = 'James Square CCTV <cctv@james-square.com>';
 const headers = { 'Cache-Control': 'no-store', 'Content-Type': 'application/json' };
 const response = (body: object, status: number) => Response.json(body, { status, headers });
 
@@ -54,7 +57,9 @@ export async function POST(request: Request) {
   const subjectName = validated.data.requestorName.replace(/[\r\n]+/g, ' ');
   try {
     await sendWithResend({
+      from: SENDER,
       to: RECIPIENT,
+      replyTo: validated.data.email,
       subject: `CCTV review request — ${validated.data.incidentDate} — ${subjectName}`,
       html: `<p><strong>James Square reference:</strong> ${requestId}</p>${rendered.html}`,
       text: `James Square reference: ${requestId}\n\n${rendered.text}`,

--- a/src/lib/email/sendWithResend.ts
+++ b/src/lib/email/sendWithResend.ts
@@ -16,8 +16,6 @@ function getResendClient() {
   return new Resend(apiKey);
 }
 
-const FROM_EMAIL = process.env.RESEND_FROM_EMAIL;
-
 function stripHtml(html: string) {
   return html
     .replace(/<style[^>]*>[\s\S]*?<\/style>/gi, "")
@@ -28,20 +26,22 @@ function stripHtml(html: string) {
 }
 
 export async function sendWithResend(args: {
+  from?: string;
   to: string | string[];
+  replyTo?: string;
   subject: string;
   html: string;
   text?: string;
   attachments?: { filename: string; content: string }[];
 }) {
   const resend = getResendClient();
-  if (!FROM_EMAIL) {
-    throw new Error("RESEND_FROM_EMAIL is not set");
-  }
+  const from = args.from ?? process.env.RESEND_FROM_EMAIL;
+  if (!from) throw new Error("An email sender is not configured");
 
   const { error, data } = await resend.emails.send({
-    from: FROM_EMAIL,
+    from,
     to: args.to,
+    replyTo: args.replyTo,
     subject: args.subject,
     html: args.html,
     text: args.text ?? stripHtml(args.html),


### PR DESCRIPTION
### Motivation

- The CCTV request endpoint failed when the global `RESEND_FROM_EMAIL` env var was not set, preventing form submissions from being emailed. 
- CCTV submissions must always be delivered to `cctv@james-square.com` using a verified sender address. 
- Reviewers need a working `Reply-To` so they can respond directly to the resident who submitted the form.

### Description

- Updated `src/lib/email/sendWithResend.ts` to accept an optional `from` and `replyTo` in the call and to fall back to `process.env.RESEND_FROM_EMAIL` only when `from` is not provided. 
- Changed `src/app/api/cctv/request/route.ts` to use a fixed `SENDER = 'James Square CCTV <cctv@james-square.com>'` and pass `from: SENDER` and `replyTo: validated.data.email` to `sendWithResend`. 
- Ensured the CCTV endpoint still records a request reference and preserves delivery bookkeeping on success or marks delivery state on failure. 
- Updated `src/app/api/cctv/request/route.test.ts` to assert the expected `from` and `replyTo` fields are passed to the email helper.

### Testing

- Ran the endpoint unit tests with `npm test -- --run src/app/api/cctv/request/route.test.ts`, which executed 2 tests and they passed. 
- Ran TypeScript checks with `npx tsc --noEmit`, which succeeded. 
- Attempted a production build with `npm run build`; the build reached the Next.js stage but failed due to inability to download Google Fonts during compilation, which is unrelated to the email changes.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a7a625db2f08324b891abe0821ea79c)