### PR TITLE
Add standalone accommodation invoice page at /invoice/HM3W

### DIFF
--- a/src/app/invoice/HM3W/invoice.module.css
+++ b/src/app/invoice/HM3W/invoice.module.css
@@ -1,0 +1,80 @@
+.portal {
+  min-height: 100vh;
+  padding: 48px 20px;
+  background: #f1f5f9;
+  color: #172033;
+}
+
+.invoice {
+  width: min(100%, 920px);
+  margin: 0 auto;
+  overflow: hidden;
+  border: 1px solid #dce3ec;
+  border-radius: 18px;
+  background: #fff;
+  box-shadow: 0 18px 50px rgb(15 23 42 / 8%);
+}
+
+.header, .recipient, .summary, .actions { padding: 32px 40px; }
+.header, .recipient, .sectionHeading, .actions { display: flex; justify-content: space-between; gap: 32px; }
+.header { align-items: flex-start; border-bottom: 1px solid #e6eaf0; }
+.header h1 { max-width: 560px; margin: 5px 0 0; font-size: clamp(1.65rem, 4vw, 2.35rem); line-height: 1.15; letter-spacing: -.035em; }
+.eyebrow, .label { margin: 0; color: #64748b; font-size: .73rem; font-weight: 700; letter-spacing: .12em; text-transform: uppercase; }
+.reference { min-width: 128px; padding: 14px 18px; border-radius: 10px; background: #f1f5f9; text-align: right; }
+.reference span { display: block; color: #64748b; font-size: .75rem; }
+.reference strong { display: block; margin-top: 2px; font-size: 1.2rem; }
+
+.recipient { align-items: flex-start; border-bottom: 1px solid #e6eaf0; }
+.recipient p { margin: 4px 0 0; color: #64748b; }
+.recipient .recipientName { margin-top: 8px; color: #172033; font-size: 1.15rem; font-weight: 700; }
+.meta { display: grid; width: min(100%, 460px); margin: 0; grid-template-columns: repeat(2, 1fr); gap: 18px 30px; }
+.meta div { min-width: 0; }
+.meta dt { color: #64748b; font-size: .75rem; }
+.meta dd { margin: 4px 0 0; font-size: .9rem; font-weight: 600; overflow-wrap: anywhere; }
+
+.summary { padding-top: 36px; }
+.sectionHeading { align-items: center; }
+.sectionHeading h2 { margin: 4px 0 0; font-size: 1.25rem; }
+.status { border: 1px solid #a7e4c6; border-radius: 999px; padding: 7px 12px; background: #ecfdf5; color: #087647; font-size: .75rem; font-weight: 750; letter-spacing: .04em; text-transform: uppercase; }
+.tableWrap { margin-top: 24px; overflow-x: auto; border: 1px solid #e2e8f0; border-radius: 10px; }
+.tableWrap table { width: 100%; border-collapse: collapse; font-size: .875rem; }
+.tableWrap th { padding: 12px 16px; background: #f8fafc; color: #64748b; font-size: .7rem; letter-spacing: .08em; text-align: left; text-transform: uppercase; }
+.tableWrap td { padding: 15px 16px; border-top: 1px solid #e9edf2; }
+.tableWrap td:nth-child(2) { color: #64748b; }
+.tableWrap th:last-child, .tableWrap td:last-child { text-align: right; white-space: nowrap; font-weight: 650; }
+.totals { width: min(100%, 420px); margin: 24px 0 0 auto; }
+.totals div { display: flex; justify-content: space-between; gap: 24px; padding: 10px 0; }
+.totals span { color: #64748b; }
+.totals .balance { margin-top: 5px; padding-top: 15px; border-top: 1px solid #cbd5e1; color: #172033; font-size: 1.05rem; }
+.totals .balance span { color: inherit; font-weight: 650; }
+
+.actions { align-items: center; border-top: 1px solid #e6eaf0; background: #f8fafc; }
+.actions p { margin: 4px 0 0; font-size: .85rem; }
+.download { display: inline-flex; flex: 0 0 auto; align-items: center; justify-content: center; gap: 9px; min-height: 46px; border-radius: 9px; padding: 12px 18px; background: #172033; color: #fff; font-size: .875rem; font-weight: 700; text-decoration: none; transition: background .15s ease, transform .15s ease; }
+.download:hover { background: #2c3b55; transform: translateY(-1px); }
+.download:focus-visible { outline: 3px solid #93c5fd; outline-offset: 3px; }
+.download svg { width: 18px; height: 18px; stroke: currentcolor; stroke-width: 1.8; stroke-linecap: round; stroke-linejoin: round; }
+
+@media (max-width: 680px) {
+  .portal { padding: 18px 12px; }
+  .invoice { border-radius: 13px; }
+  .header, .recipient, .summary, .actions { padding: 24px 20px; }
+  .header, .recipient, .actions { flex-direction: column; gap: 22px; }
+  .reference { width: 100%; text-align: left; }
+  .meta { width: 100%; }
+  .actions { align-items: stretch; }
+  .download { width: 100%; }
+  .tableWrap { border: 0; overflow: visible; }
+  .tableWrap table, .tableWrap tbody, .tableWrap tr, .tableWrap td { display: block; }
+  .tableWrap thead { display: none; }
+  .tableWrap tr { margin-bottom: 10px; padding: 14px; border: 1px solid #e2e8f0; border-radius: 9px; }
+  .tableWrap td { padding: 3px 0; border: 0; }
+  .tableWrap td:nth-child(2) { font-size: .8rem; }
+  .tableWrap td:last-child { margin-top: 7px; text-align: left; }
+}
+
+@media print {
+  .portal { padding: 0; background: #fff; }
+  .invoice { border: 0; border-radius: 0; box-shadow: none; }
+  .actions { display: none; }
+}

--- a/src/app/invoice/HM3W/page.tsx
+++ b/src/app/invoice/HM3W/page.tsx
@@ -1,0 +1,116 @@
+import type { Metadata } from "next";
+import styles from "./invoice.module.css";
+
+export const metadata: Metadata = {
+  title: "Invoice #HM3W | James Square Accommodation",
+  description: "Accommodation invoice for David Harant.",
+  robots: {
+    index: false,
+    follow: false,
+  },
+};
+
+const lineItems = [
+  {
+    description: "Guest bedroom accommodation",
+    details: "2-night private guest-bedroom stay",
+    amount: "£540.95",
+  },
+  {
+    description: "Edinburgh Visitor Levy (5%)",
+    details: "Included within the accommodation price",
+    amount: "£27.05",
+  },
+  {
+    description: "Short-stay cleaning fee",
+    details: "One-time cleaning charge",
+    amount: "£20.00",
+  },
+  {
+    description: "Airbnb guest service fee",
+    details: "Shown by Airbnb as £0.00",
+    amount: "£0.00",
+  },
+];
+
+export default function InvoicePage() {
+  return (
+    <div className={styles.portal}>
+      <article className={styles.invoice} aria-labelledby="invoice-title">
+        <header className={styles.header}>
+          <div>
+            <p className={styles.eyebrow}>James Square · Edinburgh</p>
+            <h1 id="invoice-title">James Square Accommodation Invoice</h1>
+          </div>
+          <div className={styles.reference}>
+            <span>Reference</span>
+            <strong>#HM3W</strong>
+          </div>
+        </header>
+
+        <section className={styles.recipient} aria-labelledby="recipient-heading">
+          <div>
+            <p id="recipient-heading" className={styles.label}>Recipient</p>
+            <p className={styles.recipientName}>David Harant</p>
+            <p>Powertica Materials a.s.</p>
+          </div>
+          <dl className={styles.meta}>
+            <div><dt>Invoice date</dt><dd>2 August 2026</dd></div>
+            <div><dt>Stay</dt><dd>2 nights</dd></div>
+            <div><dt>Booking channel</dt><dd>Airbnb</dd></div>
+            <div><dt>Confirmation</dt><dd>HM3WSQKX92</dd></div>
+          </dl>
+        </section>
+
+        <section className={styles.summary} aria-labelledby="summary-heading">
+          <div className={styles.sectionHeading}>
+            <div>
+              <p className={styles.label}>Invoice summary</p>
+              <h2 id="summary-heading">Accommodation details</h2>
+            </div>
+            <span className={styles.status}>Paid in full</span>
+          </div>
+
+          <div className={styles.tableWrap}>
+            <table>
+              <thead>
+                <tr><th>Description</th><th>Details</th><th>Amount</th></tr>
+              </thead>
+              <tbody>
+                {lineItems.map((item) => (
+                  <tr key={item.description}>
+                    <td>{item.description}</td>
+                    <td>{item.details}</td>
+                    <td>{item.amount}</td>
+                  </tr>
+                ))}
+              </tbody>
+            </table>
+          </div>
+
+          <div className={styles.totals}>
+            <div><span>Total paid through Airbnb</span><strong>£588.00 GBP</strong></div>
+            <div className={styles.balance}><span>Balance due</span><strong>£0.00</strong></div>
+          </div>
+        </section>
+
+        <footer className={styles.actions}>
+          <div>
+            <p className={styles.label}>Payment status</p>
+            <p>Payment processed through Airbnb · Paid in full</p>
+          </div>
+          <a
+            className={styles.download}
+            href="/docs/survey/accommodation_invoice_david_harant.pdf"
+            download="accommodation_invoice_david_harant.pdf"
+          >
+            <svg aria-hidden="true" viewBox="0 0 24 24" fill="none">
+              <path d="M12 3v12m0 0 4-4m-4 4-4-4M5 19h14" />
+            </svg>
+            Download PDF Invoice
+          </a>
+        </footer>
+      </article>
+    </div>
+  );
+}

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -2,12 +2,9 @@
 import type { Metadata, Viewport } from "next";
 import { Geist, Geist_Mono } from "next/font/google";
 import "./globals.css";
-import Header from "@/components/Header";
-import Footer from "@/components/Footer";
-import { AuthProvider } from "@/context/AuthContext";
 import AppLaunchShell from "@/components/AppLaunchShell";
 import AppModeGate from "@/components/layout/AppModeGate";
-import { ConsentProvider, ConsentSurface } from "@/components/consent";
+import SiteFrame from "@/components/layout/SiteFrame";
 
 const geistSans = Geist({ subsets: ["latin"], variable: "--font-geist-sans" });
 const geistMono = Geist_Mono({ subsets: ["latin"], variable: "--font-geist-mono" });
@@ -64,26 +61,7 @@ export default function RootLayout({ children }: { children: React.ReactNode }) 
       <body className={`${geistSans.variable} ${geistMono.variable} antialiased min-h-screen`}>
         <AppModeGate />
         <AppLaunchShell>
-          <AuthProvider>
-            <ConsentProvider>
-              <a className="skip-to-content" href="#main-content">
-                Skip to main content
-              </a>
-              {/* Placed before the header in the DOM so a keyboard user reaches
-                  the consent choice immediately. The banner is position: fixed,
-                  so it still appears at the bottom of the viewport, and the
-                  preferences dialog is portalled to <body> regardless. */}
-              <ConsentSurface />
-              <Header />
-              <main
-                className="site-content max-w-6xl mx-auto px-4 sm:px-6 py-8"
-                id="main-content"
-              >
-                {children}
-              </main>
-              <Footer />
-            </ConsentProvider>
-          </AuthProvider>
+          <SiteFrame>{children}</SiteFrame>
         </AppLaunchShell>
       </body>
     </html>

--- a/src/components/layout/SiteFrame.tsx
+++ b/src/components/layout/SiteFrame.tsx
@@ -1,0 +1,39 @@
+"use client";
+
+import { usePathname } from "next/navigation";
+import Header from "@/components/Header";
+import Footer from "@/components/Footer";
+import { AuthProvider } from "@/context/AuthContext";
+import { ConsentProvider, ConsentSurface } from "@/components/consent";
+
+export default function SiteFrame({ children }: { children: React.ReactNode }) {
+  const pathname = usePathname();
+  const isStandaloneInvoice = pathname === "/invoice/HM3W";
+
+  if (isStandaloneInvoice) {
+    return (
+      <main id="main-content" className="min-h-screen">
+        {children}
+      </main>
+    );
+  }
+
+  return (
+    <AuthProvider>
+      <ConsentProvider>
+        <a className="skip-to-content" href="#main-content">
+          Skip to main content
+        </a>
+        <ConsentSurface />
+        <Header />
+        <main
+          className="site-content max-w-6xl mx-auto px-4 sm:px-6 py-8"
+          id="main-content"
+        >
+          {children}
+        </main>
+        <Footer />
+      </ConsentProvider>
+    </AuthProvider>
+  );
+}


### PR DESCRIPTION
### Motivation

- Provide a private, single-page invoice portal for reservation reference `#HM3W` that is isolated from the main site chrome and not indexed by search engines.
- Offer a direct, user-friendly way to download the original PDF invoice for the guest.

### Description

- Add a new invoice route and view at `src/app/invoice/HM3W/page.tsx` presenting header, recipient (David Harant), reference `#HM3W`, reservation metadata, an itemised charges table, totals and payment status, and a prominent download action.
- Add responsive, accessible, and print-focused styles in `src/app/invoice/HM3W/invoice.module.css` to ensure the page is minimal and readable on mobile and desktop.
- Introduce `src/components/layout/SiteFrame.tsx` which conditionally omits the site header, footer, consent chrome, and auth wrappers when the pathname is `/invoice/HM3W` and update `src/app/layout.tsx` to use `SiteFrame`.
- Ensure the download action links directly to `/docs/survey/accommodation_invoice_david_harant.pdf` with the `download=

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a8dffbdcd0c83248e7362659511495c)