### PR TITLE
Update HM3W invoice page: add stay dates, style, and final PDF download

### DIFF
--- a/src/app/invoice/HM3W/invoice.module.css
+++ b/src/app/invoice/HM3W/invoice.module.css
@@ -15,7 +15,7 @@
   box-shadow: 0 18px 50px rgb(15 23 42 / 8%);
 }
 
-.header, .recipient, .summary, .actions { padding: 32px 40px; }
+.header, .recipient, .stay, .summary, .actions { padding: 32px 40px; }
 .header, .recipient, .sectionHeading, .actions { display: flex; justify-content: space-between; gap: 32px; }
 .header { align-items: flex-start; border-bottom: 1px solid #e6eaf0; }
 .header h1 { max-width: 560px; margin: 5px 0 0; font-size: clamp(1.65rem, 4vw, 2.35rem); line-height: 1.15; letter-spacing: -.035em; }
@@ -31,6 +31,19 @@
 .meta div { min-width: 0; }
 .meta dt { color: #64748b; font-size: .75rem; }
 .meta dd { margin: 4px 0 0; font-size: .9rem; font-weight: 600; overflow-wrap: anywhere; }
+
+.stay { display: flex; align-items: center; justify-content: space-between; gap: 36px; border-bottom: 1px solid #e6eaf0; background: linear-gradient(135deg, #f8fafc 0%, #f0f7f5 100%); }
+.stayIntro { flex: 0 1 280px; }
+.stayIntro h2 { margin: 5px 0 0; font-size: 1.25rem; letter-spacing: -.02em; }
+.stayIntro > p:last-child { margin: 7px 0 0; color: #64748b; font-size: .84rem; line-height: 1.5; }
+.dateCards { display: flex; flex: 1 1 450px; align-items: center; justify-content: flex-end; gap: 14px; }
+.dateCard { min-width: 150px; padding: 15px 17px; border: 1px solid #dce5e2; border-radius: 11px; background: rgb(255 255 255 / 85%); box-shadow: 0 4px 14px rgb(15 23 42 / 4%); }
+.dateCard > span { display: block; margin-bottom: 5px; color: #64748b; font-size: .7rem; font-weight: 700; letter-spacing: .08em; text-transform: uppercase; }
+.dateCard strong { display: flex; align-items: baseline; gap: 6px; font-size: .82rem; white-space: nowrap; }
+.dateCard b { color: #087647; font-size: 1.45rem; line-height: 1; }
+.nightCount { width: 72px; color: #64748b; text-align: center; }
+.nightCount span { display: block; margin-bottom: 2px; font-size: .7rem; font-weight: 700; white-space: nowrap; }
+.nightCount svg { width: 64px; stroke: #94a3b8; stroke-width: 1.5; stroke-linecap: round; stroke-linejoin: round; }
 
 .summary { padding-top: 36px; }
 .sectionHeading { align-items: center; }
@@ -50,18 +63,22 @@
 
 .actions { align-items: center; border-top: 1px solid #e6eaf0; background: #f8fafc; }
 .actions p { margin: 4px 0 0; font-size: .85rem; }
-.download { display: inline-flex; flex: 0 0 auto; align-items: center; justify-content: center; gap: 9px; min-height: 46px; border-radius: 9px; padding: 12px 18px; background: #172033; color: #fff; font-size: .875rem; font-weight: 700; text-decoration: none; transition: background .15s ease, transform .15s ease; }
-.download:hover { background: #2c3b55; transform: translateY(-1px); }
+.download { display: inline-flex; flex: 0 0 auto; align-items: center; justify-content: center; gap: 9px; min-height: 48px; border-radius: 9px; padding: 12px 20px; background: #087647; color: #fff; font-size: .875rem; font-weight: 700; text-decoration: none; box-shadow: 0 7px 18px rgb(8 118 71 / 18%); transition: background .15s ease, box-shadow .15s ease, transform .15s ease; }
+.download:hover { background: #06613b; box-shadow: 0 9px 22px rgb(8 118 71 / 25%); transform: translateY(-1px); }
 .download:focus-visible { outline: 3px solid #93c5fd; outline-offset: 3px; }
 .download svg { width: 18px; height: 18px; stroke: currentcolor; stroke-width: 1.8; stroke-linecap: round; stroke-linejoin: round; }
 
 @media (max-width: 680px) {
   .portal { padding: 18px 12px; }
   .invoice { border-radius: 13px; }
-  .header, .recipient, .summary, .actions { padding: 24px 20px; }
-  .header, .recipient, .actions { flex-direction: column; gap: 22px; }
+  .header, .recipient, .stay, .summary, .actions { padding: 24px 20px; }
+  .header, .recipient, .stay, .actions { flex-direction: column; gap: 22px; }
   .reference { width: 100%; text-align: left; }
   .meta { width: 100%; }
+  .stay { align-items: stretch; }
+  .stayIntro { flex-basis: auto; }
+  .dateCards { flex-basis: auto; justify-content: stretch; }
+  .dateCard { flex: 1; min-width: 0; }
   .actions { align-items: stretch; }
   .download { width: 100%; }
   .tableWrap { border: 0; overflow: visible; }
@@ -71,6 +88,11 @@
   .tableWrap td { padding: 3px 0; border: 0; }
   .tableWrap td:nth-child(2) { font-size: .8rem; }
   .tableWrap td:last-child { margin-top: 7px; text-align: left; }
+}
+
+@media (max-width: 430px) {
+  .dateCards { display: grid; grid-template-columns: 1fr; }
+  .nightCount { display: none; }
 }
 
 @media print {

--- a/src/app/invoice/HM3W/page.tsx
+++ b/src/app/invoice/HM3W/page.tsx
@@ -3,7 +3,7 @@ import styles from "./invoice.module.css";
 
 export const metadata: Metadata = {
   title: "Invoice #HM3W | James Square Accommodation",
-  description: "Accommodation invoice for David Harant.",
+  description: "Accommodation invoice for David Harant's two-night stay, 23–25 August 2026.",
   robots: {
     index: false,
     follow: false,
@@ -56,10 +56,34 @@ export default function InvoicePage() {
           </div>
           <dl className={styles.meta}>
             <div><dt>Invoice date</dt><dd>2 August 2026</dd></div>
-            <div><dt>Stay</dt><dd>2 nights</dd></div>
+            <div><dt>Stay duration</dt><dd>2 nights</dd></div>
             <div><dt>Booking channel</dt><dd>Airbnb</dd></div>
             <div><dt>Confirmation</dt><dd>HM3WSQKX92</dd></div>
           </dl>
+        </section>
+
+        <section className={styles.stay} aria-labelledby="stay-heading">
+          <div className={styles.stayIntro}>
+            <p className={styles.label}>Reservation dates</p>
+            <h2 id="stay-heading">23–25 August 2026</h2>
+            <p>Two-night accommodation at James Square, Edinburgh.</p>
+          </div>
+          <div className={styles.dateCards}>
+            <div className={styles.dateCard}>
+              <span>Check-in</span>
+              <strong><b>23</b> August 2026</strong>
+            </div>
+            <div className={styles.nightCount} aria-label="2 nights">
+              <span>2 nights</span>
+              <svg aria-hidden="true" viewBox="0 0 80 12" fill="none">
+                <path d="M1 6h78M74 1l5 5-5 5" />
+              </svg>
+            </div>
+            <div className={styles.dateCard}>
+              <span>Check-out</span>
+              <strong><b>25</b> August 2026</strong>
+            </div>
+          </div>
         </section>
 
         <section className={styles.summary} aria-labelledby="summary-heading">
@@ -96,18 +120,18 @@ export default function InvoicePage() {
 
         <footer className={styles.actions}>
           <div>
-            <p className={styles.label}>Payment status</p>
-            <p>Payment processed through Airbnb · Paid in full</p>
+            <p className={styles.label}>Your invoice is ready</p>
+            <p>Download and retain the final PDF invoice for your records.</p>
           </div>
           <a
             className={styles.download}
-            href="/docs/survey/accommodation_invoice_david_harant.pdf"
-            download="accommodation_invoice_david_harant.pdf"
+            href="/docs/survey/accommodation_invoice_david_harant_final.pdf"
+            download="accommodation_invoice_david_harant_final.pdf"
           >
             <svg aria-hidden="true" viewBox="0 0 24 24" fill="none">
               <path d="M12 3v12m0 0 4-4m-4 4-4-4M5 19h14" />
             </svg>
-            Download PDF Invoice
+            Download final invoice
           </a>
         </footer>
       </article>


### PR DESCRIPTION
### Motivation
- Provide a clear, professional invoice page that includes the reservation dates and duration (23–25 August 2026, 2 nights) and points visitors to the final PDF invoice.
- Replace the previous PDF link with the final file `public/docs/survey/accommodation_invoice_david_harant_final.pdf` and improve the download call-to-action for clarity and prominence.

### Description
- Update page metadata to mention the two-night stay and dates and change the recipient meta label to "Stay duration" in `src/app/invoice/HM3W/page.tsx`.
- Add a new `Reservation dates` section showing check-in (23 August 2026), check-out (25 August 2026) and a visual two-night indicator, implemented in `src/app/invoice/HM3W/page.tsx`.
- Point the download CTA to `/docs/survey/accommodation_invoice_david_harant_final.pdf` and change the button text to "Download final invoice" while improving the supporting copy in the footer.
- Add styling for the new reservation section and enhance the download button with a green style, hover and responsive adjustments in `src/app/invoice/HM3W/invoice.module.css`.

### Testing
- Ran `git diff --check` with no issues reported.
- Linted the updated file with `npx eslint src/app/invoice/HM3W/page.tsx` and it passed.
- Ran the test suite with `npm test` (Vitest) and the test run passed with 1 test file and 2 tests succeeding.
- Attempted `npm run build` but the build failed due to inability to download Geist / Geist Mono font files from Google Fonts in the environment, which blocked a full production build.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a8e0ae88604832488d4c72348c01e06)